### PR TITLE
feat(skills): add built-in skill support with hledger skill

### DIFF
--- a/src/extension/data/__tests__/beautify.test.ts
+++ b/src/extension/data/__tests__/beautify.test.ts
@@ -1,0 +1,808 @@
+import { describe, expect, test } from "bun:test";
+import { beautifyJournalContent } from "../beautify";
+
+describe("beautifyJournalContent()", () => {
+  describe("sorting", () => {
+    test("should sort transactions by date ascending", () => {
+      const input = [
+        "2026-03-28 * Later",
+        "    Expenses:Misc    10.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-03-01 * Earlier",
+        "    Expenses:Misc    5.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const expected = [
+        "2026-03-01 * Earlier",
+        "    Expenses:Misc    5.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-03-28 * Later",
+        "    Expenses:Misc    10.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      expect(beautifyJournalContent(input)).toBe(expected);
+    });
+
+    test("should preserve original order for transactions with the same date (stable sort)", () => {
+      const input = [
+        "2026-03-15 * First",
+        "    Expenses:Misc    1.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-03-15 * Second",
+        "    Expenses:Misc    2.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-03-15 * Third",
+        "    Expenses:Misc    3.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = beautifyJournalContent(input);
+      const firstIdx = result.indexOf("* First");
+      const secondIdx = result.indexOf("* Second");
+      const thirdIdx = result.indexOf("* Third");
+      expect(firstIdx).toBeGreaterThanOrEqual(0);
+      expect(secondIdx).toBeGreaterThan(firstIdx);
+      expect(thirdIdx).toBeGreaterThan(secondIdx);
+    });
+
+    test("should sort across three transactions with mixed dates", () => {
+      const input = [
+        "2026-03-20 * B",
+        "    Expenses:Misc    2.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-03-10 * A",
+        "    Expenses:Misc    1.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-03-30 * C",
+        "    Expenses:Misc    3.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = beautifyJournalContent(input);
+      const aIdx = result.indexOf("* A");
+      const bIdx = result.indexOf("* B");
+      const cIdx = result.indexOf("* C");
+      expect(aIdx).toBeLessThan(bIdx);
+      expect(bIdx).toBeLessThan(cIdx);
+    });
+  });
+
+  describe("per-file alignment", () => {
+    test("should align amounts to a column derived from the longest account in the whole file", () => {
+      const input = [
+        "2026-03-01 * A",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-03-02 * B",
+        "    Expenses:Transport:PublicTransit    10.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      // Longest account with amount: "Expenses:Transport:PublicTransit" = 32 chars
+      // targetColumn = 4 (indent) + 32 (account) + 4 (MIN_GAP) = 40
+      // Expenses:Food padding = 40 - 4 - 13 = 23 spaces
+      // Expenses:Transport:PublicTransit padding = 40 - 4 - 32 = 4 spaces
+      const expected = [
+        "2026-03-01 * A",
+        `    Expenses:Food${" ".repeat(23)}45.00 USD`,
+        "    Assets:Checking",
+        "",
+        "2026-03-02 * B",
+        "    Expenses:Transport:PublicTransit    10.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      expect(beautifyJournalContent(input)).toBe(expected);
+    });
+
+    test("should use MIN_GAP=4 for the widest account in the file", () => {
+      const input = ["2026-03-01 * A", "    Expenses:Transport:PublicTransit    10.00 USD", "    Assets:Checking"].join(
+        "\n",
+      );
+      const result = beautifyJournalContent(input);
+      // Widest account is "Expenses:Transport:PublicTransit" and should have exactly 4 spaces before amount
+      expect(result).toContain("Expenses:Transport:PublicTransit    10.00 USD");
+    });
+
+    test("should not add padding to balancing postings (no amount)", () => {
+      const input = ["2026-03-01 * A", "    Expenses:Transport:PublicTransit    10.00 USD", "    Assets:Checking"].join(
+        "\n",
+      );
+      const result = beautifyJournalContent(input);
+      // Balancing posting emitted verbatim: indent + account, no trailing padding
+      expect(result).toContain("\n    Assets:Checking");
+      expect(result).not.toContain("    Assets:Checking    ");
+    });
+
+    test("should align all postings within a transaction when they have different account widths", () => {
+      const input = ["2026-03-01 * A", "    Expenses:Food    45.00 USD", "    Assets:Checking    -45.00 USD"].join(
+        "\n",
+      );
+      // Alignment math (align on first DIGIT):
+      //   Expenses:Food    → 4 + 13 + 0 = 17
+      //   Assets:Checking  → 4 + 15 + 1 = 20  (prefix "-" has length 1)
+      //   targetDigitsColumn = 20 + 4 = 24
+      //   Expenses:Food padding    = 24 - 4 - 13 - 0 = 7
+      //   Assets:Checking padding  = 24 - 4 - 15 - 1 = 4
+      // Order: negative postings first (Assets:Checking -45.00), then positive (Expenses:Food 45.00).
+      const expected = [
+        "2026-03-01 * A",
+        "    Assets:Checking    -45.00 USD",
+        `    Expenses:Food${" ".repeat(7)}45.00 USD`,
+      ].join("\n");
+      expect(beautifyJournalContent(input)).toBe(expected);
+    });
+
+    test("should align negative and positive amounts on the first digit (sign sticks out left)", () => {
+      // User's real case: "-111.00 EUR" and "111.00 EUR" should have their "1"s in the same column,
+      // with the "-" one column to the left.
+      const input = [
+        "2026-01-17 * Knuspr",
+        "    assets:volo:mono:eur    -111.00 EUR",
+        "    expenses:food:groceries    111.00 EUR",
+      ].join("\n");
+      // Candidates:
+      //   assets:volo:mono:eur     → 4 + 20 + 1 = 25  (prefix "-")
+      //   expenses:food:groceries  → 4 + 23 + 0 = 27
+      // targetDigitsColumn = 27 + 4 = 31
+      // Padding:
+      //   assets:volo:mono:eur     → 31 - 4 - 20 - 1 = 6
+      //   expenses:food:groceries  → 31 - 4 - 23 - 0 = 4
+      const expected = [
+        "2026-01-17 * Knuspr",
+        `    assets:volo:mono:eur${" ".repeat(6)}-111.00 EUR`,
+        "    expenses:food:groceries    111.00 EUR",
+      ].join("\n");
+      const result = beautifyJournalContent(input);
+      expect(result).toBe(expected);
+      // Sanity: the "1" (first digit) of both amounts lands at the same column (31)
+      const lines = result.split("\n");
+      const negLine = lines.find((l) => l.includes("-111.00"))!;
+      const posLine = lines.find((l) => l.includes("expenses:food:groceries"))!;
+      const negFirstDigit = negLine.indexOf("1");
+      const posFirstDigit = posLine.indexOf("111.00");
+      expect(negFirstDigit).toBe(31);
+      expect(posFirstDigit).toBe(31);
+    });
+  });
+
+  describe("preservation — amounts", () => {
+    test("should preserve negative amount verbatim: -45.00 USD", () => {
+      const input = ["2026-03-15 * A", "    Expenses:Food    -45.00 USD", "    Assets:Checking"].join("\n");
+      expect(beautifyJournalContent(input)).toContain("-45.00 USD");
+    });
+
+    test("should preserve currency-first amount verbatim: EUR -45.00", () => {
+      const input = ["2026-03-15 * A", "    Expenses:Food    EUR -45.00", "    Assets:Checking"].join("\n");
+      expect(beautifyJournalContent(input)).toContain("EUR -45.00");
+    });
+
+    test("should preserve dollar sign amount verbatim: $45.00", () => {
+      const input = ["2026-03-15 * A", "    Expenses:Food    $45.00", "    Assets:Checking"].join("\n");
+      expect(beautifyJournalContent(input)).toContain("$45.00");
+    });
+
+    test("should preserve thousand separators in amount verbatim: 1,000.00 USD", () => {
+      const input = ["2026-03-15 * A", "    Expenses:Food    1,000.00 USD", "    Assets:Checking"].join("\n");
+      expect(beautifyJournalContent(input)).toContain("1,000.00 USD");
+    });
+
+    test("should preserve balance assertion verbatim", () => {
+      const input = ["2026-03-15 * A", "    Assets:Checking    100.00 USD = 500.00 USD", "    Assets:Savings"].join(
+        "\n",
+      );
+      expect(beautifyJournalContent(input)).toContain("100.00 USD = 500.00 USD");
+    });
+
+    test("should rewrite inline trailing ';' comment on a posting to '#'", () => {
+      const input = ["2026-03-15 * A", "    Expenses:Food    45.00 USD ; inline note", "    Assets:Checking"].join(
+        "\n",
+      );
+      const result = beautifyJournalContent(input);
+      expect(result).toContain("45.00 USD # inline note");
+      expect(result).not.toContain("; inline note");
+    });
+
+    test("should preserve inline trailing '#' comment on a posting verbatim", () => {
+      const input = ["2026-03-15 * A", "    Expenses:Food    45.00 USD # inline note", "    Assets:Checking"].join(
+        "\n",
+      );
+      expect(beautifyJournalContent(input)).toContain("45.00 USD # inline note");
+    });
+  });
+
+  describe("preservation — structure", () => {
+    test("should preserve transaction header with status, code, and narration", () => {
+      const input = [
+        "2026-03-15 * (CODE-1) Whole Foods | Groceries trip",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      expect(beautifyJournalContent(input)).toContain("2026-03-15 * (CODE-1) Whole Foods | Groceries trip");
+    });
+
+    test("should preserve pending (!) status flag in header", () => {
+      const input = ["2026-03-15 ! Payee | Pending", "    Expenses:Food    45.00 USD", "    Assets:Checking"].join(
+        "\n",
+      );
+      expect(beautifyJournalContent(input)).toContain("2026-03-15 ! Payee | Pending");
+    });
+
+    test("should rewrite metadata comment lines (; tag:) inside a transaction to '#'", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    ; related_file: foo.pdf",
+        "    ; tag: value",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = beautifyJournalContent(input);
+      expect(result).toContain("    # related_file: foo.pdf");
+      expect(result).toContain("    # tag: value");
+      // Both original ';' metadata lines are gone
+      expect(result).not.toContain("    ; related_file: foo.pdf");
+      expect(result).not.toContain("    ; tag: value");
+    });
+
+    test("should preserve metadata comments using # verbatim", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    # hash comment",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      expect(beautifyJournalContent(input)).toContain("    # hash comment");
+    });
+
+    test("should rewrite top-level ';' comments at the start of the file to '#'", () => {
+      const input = [
+        "; top-level note",
+        "; another top note",
+        "",
+        "2026-03-15 * Payee",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = beautifyJournalContent(input);
+      expect(result).toContain("# top-level note");
+      expect(result).toContain("# another top note");
+      // Original ';' versions are gone
+      expect(result).not.toContain("; top-level note");
+      expect(result).not.toContain("; another top note");
+      // Leading content comes before the first transaction
+      expect(result.indexOf("# top-level note")).toBeLessThan(result.indexOf("2026-03-15"));
+    });
+
+    test("should preserve the original indent width of a posting line (2 spaces)", () => {
+      const input = ["2026-03-15 * A", "  Expenses:Food    45.00 USD", "  Assets:Checking"].join("\n");
+      // 2-space indent → indent.length=2 + account.length=13 = 15, +4 = targetCol 19
+      // Padding = 19 - 2 - 13 = 4
+      const expected = ["2026-03-15 * A", "  Expenses:Food    45.00 USD", "  Assets:Checking"].join("\n");
+      expect(beautifyJournalContent(input)).toBe(expected);
+    });
+
+    test("should preserve the original indent width of a posting line (6 spaces)", () => {
+      const input = ["2026-03-15 * A", "      Expenses:Food    45.00 USD", "      Assets:Checking"].join("\n");
+      // 6-space indent → targetCol = 6 + 13 + 4 = 23, padding = 23 - 6 - 13 = 4
+      const expected = ["2026-03-15 * A", "      Expenses:Food    45.00 USD", "      Assets:Checking"].join("\n");
+      expect(beautifyJournalContent(input)).toBe(expected);
+    });
+
+    test("should normalize tab separator to spaces (the one thing we do touch)", () => {
+      const input = `2026-03-15 * A\n    Expenses:Food\t45.00 USD\n    Assets:Checking`;
+      const result = beautifyJournalContent(input);
+      // Tab between account and amount gets replaced by spaces
+      expect(result).toContain("    Expenses:Food    45.00 USD");
+      expect(result).not.toContain("\t");
+    });
+  });
+
+  describe("idempotency", () => {
+    test("should produce identical output when run twice", () => {
+      const input = [
+        "2026-03-28 * Later",
+        "    Expenses:Transport:PublicTransit    63.00 EUR",
+        "    Assets:Checking",
+        "",
+        "2026-03-01 * Earlier",
+        "    Expenses:Food    -55.08 EUR",
+        "    Assets:Checking",
+      ].join("\n");
+      const first = beautifyJournalContent(input);
+      const second = beautifyJournalContent(first);
+      expect(second).toBe(first);
+    });
+
+    test("should be a no-op on an already sorted and aligned file", () => {
+      const input = [
+        "2026-03-01 * A",
+        "    Expenses:Transport:PublicTransit    10.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-03-02 * B",
+        "    Expenses:Transport:PublicTransit    20.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      expect(beautifyJournalContent(input)).toBe(input);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("should return empty string for empty input", () => {
+      expect(beautifyJournalContent("")).toBe("");
+    });
+
+    test("should rewrite ';' comments in a file with no transactions", () => {
+      const input = "; just a comment\n";
+      expect(beautifyJournalContent(input)).toBe("# just a comment\n");
+    });
+
+    test("should rewrite ';' comments in a file with only leading comments", () => {
+      const input = "; one\n; two\n; three\n";
+      expect(beautifyJournalContent(input)).toBe("# one\n# two\n# three\n");
+    });
+
+    test("should leave '#' comments unchanged in a file with no transactions", () => {
+      const input = "# already hashed\n";
+      expect(beautifyJournalContent(input)).toBe(input);
+    });
+
+    test("should preserve trailing newline when present in input", () => {
+      const input = ["2026-03-15 * A", "    Expenses:Food    45.00 USD", "    Assets:Checking", ""].join("\n");
+      const result = beautifyJournalContent(input);
+      expect(result.endsWith("\n")).toBe(true);
+    });
+
+    test("should preserve trailing newline absence when input has none", () => {
+      const input = ["2026-03-15 * A", "    Expenses:Food    45.00 USD", "    Assets:Checking"].join("\n");
+      const result = beautifyJournalContent(input);
+      expect(result.endsWith("\n")).toBe(false);
+    });
+
+    test("should normalize CRLF line endings to LF", () => {
+      const input = "2026-03-15 * A\r\n    Expenses:Food    45.00 USD\r\n    Assets:Checking\r\n";
+      const result = beautifyJournalContent(input);
+      expect(result).not.toContain("\r");
+      expect(result).toContain("\n");
+    });
+
+    test("should handle a single transaction file as a no-op for alignment", () => {
+      const input = "2026-03-15 * A\n    Expenses:Food    45.00 USD\n    Assets:Checking\n";
+      expect(beautifyJournalContent(input)).toBe(input);
+    });
+
+    test("should handle a transaction with no postings (just a header)", () => {
+      const input =
+        "2026-03-15 * Orphan header\n\n2026-03-16 * With postings\n    Expenses:Food    45.00 USD\n    Assets:Checking\n";
+      // Should not crash; orphan header is preserved
+      const result = beautifyJournalContent(input);
+      expect(result).toContain("2026-03-15 * Orphan header");
+      expect(result).toContain("2026-03-16 * With postings");
+    });
+
+    test("should handle a transaction with only balancing postings (no amounts anywhere)", () => {
+      const input = "2026-03-15 * A\n    Assets:Checking\n    Assets:Savings\n";
+      // No postings with amounts → no alignment computation, body preserved verbatim
+      expect(beautifyJournalContent(input)).toBe(input);
+    });
+
+    test("should collapse multiple blank lines between transactions to exactly one", () => {
+      const input = [
+        "2026-03-01 * A",
+        "    Expenses:Food    1.00 USD",
+        "    Assets:Checking",
+        "",
+        "",
+        "",
+        "2026-03-02 * B",
+        "    Expenses:Food    2.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const expected = [
+        "2026-03-01 * A",
+        "    Expenses:Food    1.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-03-02 * B",
+        "    Expenses:Food    2.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      expect(beautifyJournalContent(input)).toBe(expected);
+    });
+  });
+
+  describe("within-transaction ordering — tags", () => {
+    test("should split a comma-separated tag line into individual tag lines", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    # groceries:, weekly:",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = beautifyJournalContent(input);
+      expect(result).toContain("    # groceries:");
+      expect(result).toContain("    # weekly:");
+      expect(result).not.toContain("    # groceries:, weekly:");
+    });
+
+    test("should sort tag lines alphabetically", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    # weekly:",
+        "    # source: manual",
+        "    # groceries:",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = beautifyJournalContent(input);
+      // Expected alphabetical order: groceries:, source: manual, weekly:
+      const groceriesIdx = result.indexOf("# groceries:");
+      const sourceIdx = result.indexOf("# source: manual");
+      const weeklyIdx = result.indexOf("# weekly:");
+      expect(groceriesIdx).toBeGreaterThanOrEqual(0);
+      expect(sourceIdx).toBeGreaterThan(groceriesIdx);
+      expect(weeklyIdx).toBeGreaterThan(sourceIdx);
+    });
+
+    test("should emit the sorted tag block immediately after the transaction header", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    # groceries:, weekly:",
+        "    # source: manual",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const expected = [
+        "2026-03-15 * Payee",
+        "    # groceries:",
+        "    # source: manual",
+        "    # weekly:",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      expect(beautifyJournalContent(input)).toBe(expected);
+    });
+
+    test('should treat "# key: value" metadata lines as tags', () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    # source: manual",
+        "    # related_file: foo.pdf",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = beautifyJournalContent(input);
+      // Both are "tags" (contain ':'), should be sorted alphabetically: related_file before source
+      const relatedIdx = result.indexOf("# related_file:");
+      const sourceIdx = result.indexOf("# source:");
+      expect(relatedIdx).toBeGreaterThanOrEqual(0);
+      expect(sourceIdx).toBeGreaterThan(relatedIdx);
+    });
+
+    test("should NOT split a comment line whose parts don't all contain ':'", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    # just a random note, with a comma",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = beautifyJournalContent(input);
+      expect(result).toContain("    # just a random note, with a comma");
+    });
+
+    test("should leave non-tag comment lines in their original relative order at the header", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    # first note",
+        "    # second note",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = beautifyJournalContent(input);
+      const firstIdx = result.indexOf("# first note");
+      const secondIdx = result.indexOf("# second note");
+      expect(firstIdx).toBeGreaterThanOrEqual(0);
+      expect(secondIdx).toBeGreaterThan(firstIdx);
+    });
+
+    test("should pull a tag line that appeared between postings up into the header tag block", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    Expenses:Food    45.00 USD",
+        "    # tag: interleaved",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = beautifyJournalContent(input);
+      const tagIdx = result.indexOf("# tag: interleaved");
+      const foodIdx = result.indexOf("Expenses:Food");
+      expect(tagIdx).toBeGreaterThanOrEqual(0);
+      expect(tagIdx).toBeLessThan(foodIdx);
+    });
+  });
+
+  describe("within-transaction ordering — sign grouping", () => {
+    test("should put postings with a negative amount before postings with a positive amount", () => {
+      const input = ["2026-03-15 * Payee", "    Expenses:Food    45.00 USD", "    Assets:Checking    -45.00 USD"].join(
+        "\n",
+      );
+      const result = beautifyJournalContent(input);
+      const checkingIdx = result.indexOf("Assets:Checking");
+      const foodIdx = result.indexOf("Expenses:Food");
+      expect(checkingIdx).toBeLessThan(foodIdx);
+    });
+
+    test("should put balancing postings last, after both negative and positive", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    Assets:Checking",
+        "    Expenses:Food    45.00 USD",
+        "    Liabilities:CreditCard    -45.00 USD",
+      ].join("\n");
+      const result = beautifyJournalContent(input);
+      const creditIdx = result.indexOf("Liabilities:CreditCard");
+      const foodIdx = result.indexOf("Expenses:Food");
+      const checkingIdx = result.indexOf("Assets:Checking");
+      expect(creditIdx).toBeLessThan(foodIdx);
+      expect(foodIdx).toBeLessThan(checkingIdx);
+    });
+
+    test("should preserve original order for postings in the same sign group (stable)", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    Expenses:A    1.00 USD",
+        "    Expenses:B    2.00 USD",
+        "    Expenses:C    3.00 USD",
+        "    Assets:Checking    -6.00 USD",
+      ].join("\n");
+      const result = beautifyJournalContent(input);
+      const aIdx = result.indexOf("Expenses:A");
+      const bIdx = result.indexOf("Expenses:B");
+      const cIdx = result.indexOf("Expenses:C");
+      expect(aIdx).toBeLessThan(bIdx);
+      expect(bIdx).toBeLessThan(cIdx);
+    });
+
+    test('should classify "EUR -45.00" as negative', () => {
+      const input = ["2026-03-15 * Payee", "    Expenses:Food    45.00 EUR", "    Assets:Checking    EUR -45.00"].join(
+        "\n",
+      );
+      const result = beautifyJournalContent(input);
+      const checkingIdx = result.indexOf("Assets:Checking");
+      const foodIdx = result.indexOf("Expenses:Food");
+      expect(checkingIdx).toBeLessThan(foodIdx);
+    });
+
+    test('should classify "-$45.00" as negative', () => {
+      const input = ["2026-03-15 * Payee", "    Expenses:Food    $45.00", "    Assets:Checking    -$45.00"].join("\n");
+      const result = beautifyJournalContent(input);
+      const checkingIdx = result.indexOf("Assets:Checking");
+      const foodIdx = result.indexOf("Expenses:Food");
+      expect(checkingIdx).toBeLessThan(foodIdx);
+    });
+
+    test('should classify "$-45.00" as negative', () => {
+      const input = ["2026-03-15 * Payee", "    Expenses:Food    $45.00", "    Assets:Checking    $-45.00"].join("\n");
+      const result = beautifyJournalContent(input);
+      const checkingIdx = result.indexOf("Assets:Checking");
+      const foodIdx = result.indexOf("Expenses:Food");
+      expect(checkingIdx).toBeLessThan(foodIdx);
+    });
+
+    test('should classify "+45.00 USD" as positive', () => {
+      const input = ["2026-03-15 * Payee", "    Expenses:Food    +45.00 USD", "    Assets:Checking    -45.00 USD"].join(
+        "\n",
+      );
+      const result = beautifyJournalContent(input);
+      const checkingIdx = result.indexOf("Assets:Checking");
+      const foodIdx = result.indexOf("Expenses:Food");
+      expect(checkingIdx).toBeLessThan(foodIdx);
+    });
+
+    test('should classify unsigned "45.00 USD" as positive', () => {
+      const input = ["2026-03-15 * Payee", "    Expenses:Food    45.00 USD", "    Assets:Checking    -45.00 USD"].join(
+        "\n",
+      );
+      const result = beautifyJournalContent(input);
+      const checkingIdx = result.indexOf("Assets:Checking");
+      const foodIdx = result.indexOf("Expenses:Food");
+      expect(checkingIdx).toBeLessThan(foodIdx);
+    });
+  });
+
+  describe("within-transaction ordering — attachment", () => {
+    test("should keep a non-tag comment attached to its preceding posting when the posting is moved by sign grouping", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    Expenses:Food    45.00 USD",
+        "    # note about the food line",
+        "    Assets:Checking    -45.00 USD",
+      ].join("\n");
+      const result = beautifyJournalContent(input);
+      const lines = result.split("\n");
+      const foodIdx = lines.findIndex((l) => l.includes("Expenses:Food"));
+      const noteIdx = lines.findIndex((l) => l.includes("# note about the food line"));
+      expect(foodIdx).toBeGreaterThanOrEqual(0);
+      // The note should still be immediately after the Expenses:Food posting line
+      expect(noteIdx).toBe(foodIdx + 1);
+      // Sign grouping moved Expenses:Food AFTER the negative Assets:Checking;
+      // the note came with it
+      const checkingIdx = lines.findIndex((l) => l.includes("Assets:Checking"));
+      expect(checkingIdx).toBeLessThan(foodIdx);
+    });
+  });
+
+  describe("inter-transaction top-level content", () => {
+    test("should preserve a top-level comment between transactions (not absorb it into the previous tx)", () => {
+      const input = [
+        "2026-01-01 * Scalable Capital | Received interest",
+        "    assets:volo:scalable-capital:cash          365.27 EUR",
+        "    income:volo:scalable-capital:interest      -365.27 EUR",
+        "",
+        "; Regular transactions",
+        "",
+        "2026-01-02 * Berliner Verkehrsbetriebe (BVG)",
+        "    assets:volo:n26                    -63.00 EUR",
+        "    expenses:transport:public-transit    63.00 EUR",
+      ].join("\n");
+      const result = beautifyJournalContent(input);
+      // The comment stays OUTSIDE the first transaction's body
+      const firstTxIdx = result.indexOf("Scalable Capital");
+      const commentIdx = result.indexOf("# Regular transactions");
+      const secondTxIdx = result.indexOf("Berliner Verkehrsbetriebe");
+      expect(firstTxIdx).toBeGreaterThanOrEqual(0);
+      expect(commentIdx).toBeGreaterThan(firstTxIdx);
+      expect(commentIdx).toBeLessThan(secondTxIdx);
+      // And it's NOT part of the first transaction body — the cash/interest
+      // lines of the first tx come BEFORE the comment, not mixed with it
+      const interestIdx = result.indexOf("income:volo:scalable-capital:interest");
+      const cashIdx = result.indexOf("assets:volo:scalable-capital:cash");
+      expect(interestIdx).toBeLessThan(commentIdx);
+      expect(cashIdx).toBeLessThan(commentIdx);
+    });
+
+    test("should rewrite ';' to '#' in inter-transaction comments", () => {
+      const input = [
+        "2026-01-01 * A",
+        "    Expenses:Food    10.00 USD",
+        "    Assets:Checking",
+        "",
+        "; section divider",
+        "",
+        "2026-01-02 * B",
+        "    Expenses:Food    20.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = beautifyJournalContent(input);
+      expect(result).toContain("# section divider");
+      expect(result).not.toContain("; section divider");
+    });
+
+    test("should emit inter-transaction comments with blank lines around them", () => {
+      const input = [
+        "2026-01-01 * A",
+        "    Expenses:Food    10.00 USD",
+        "    Assets:Checking",
+        "",
+        "# section divider",
+        "",
+        "2026-01-02 * B",
+        "    Expenses:Food    20.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const expected = [
+        "2026-01-01 * A",
+        "    Expenses:Food    10.00 USD",
+        "    Assets:Checking",
+        "",
+        "# section divider",
+        "",
+        "2026-01-02 * B",
+        "    Expenses:Food    20.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      expect(beautifyJournalContent(input)).toBe(expected);
+    });
+
+    test("should keep inter-transaction content with its following transaction when sorted", () => {
+      // tx1 has a LATER date than tx2; beautifier will sort tx2 first.
+      // The comment between them was "before tx2" in the file, so it travels with tx2.
+      const input = [
+        "2026-01-10 * Later",
+        "    Expenses:Food    1.00 USD",
+        "    Assets:Checking",
+        "",
+        "# section divider",
+        "",
+        "2026-01-01 * Earlier",
+        "    Expenses:Food    2.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = beautifyJournalContent(input);
+      // After sort: Earlier first, then Later
+      const earlierIdx = result.indexOf("Earlier");
+      const laterIdx = result.indexOf("Later");
+      expect(earlierIdx).toBeLessThan(laterIdx);
+      // The comment moved with its following transaction (Earlier) to the top
+      const commentIdx = result.indexOf("# section divider");
+      expect(commentIdx).toBeLessThan(earlierIdx);
+    });
+
+    test("should preserve trailing content after the last transaction", () => {
+      const input = [
+        "2026-01-01 * A",
+        "    Expenses:Food    10.00 USD",
+        "    Assets:Checking",
+        "",
+        "# trailing footer note",
+      ].join("\n");
+      const result = beautifyJournalContent(input);
+      expect(result).toContain("# trailing footer note");
+      // Trailing content is at the end
+      const txIdx = result.indexOf("2026-01-01");
+      const footerIdx = result.indexOf("# trailing footer note");
+      expect(footerIdx).toBeGreaterThan(txIdx);
+    });
+
+    test("should be idempotent with inter-transaction comments", () => {
+      const input = [
+        "2026-01-01 * A",
+        "    Expenses:Food    10.00 USD",
+        "    Assets:Checking",
+        "",
+        "# section divider",
+        "",
+        "2026-01-02 * B",
+        "    Expenses:Food    20.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const first = beautifyJournalContent(input);
+      const second = beautifyJournalContent(first);
+      expect(second).toBe(first);
+    });
+  });
+
+  describe("within-transaction ordering — idempotency", () => {
+    test("should produce identical output when run twice on a mixed-sign transaction with tags", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    # weekly:, groceries:",
+        "    # source: manual",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking    -45.00 USD",
+      ].join("\n");
+      const first = beautifyJournalContent(input);
+      const second = beautifyJournalContent(first);
+      expect(second).toBe(first);
+    });
+
+    test("should be a no-op on an already-ordered canonical transaction", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    # groceries:",
+        "    # source: manual",
+        "    # weekly:",
+        "    Assets:Checking    -45.00 USD",
+        "    Expenses:Food      45.00 USD",
+      ].join("\n");
+      // Candidates:
+      //   Assets:Checking (15) + prefix "-" (1) = 20
+      //   Expenses:Food (13)   + prefix ""  (0) = 17
+      // targetDigitsColumn = 20 + 4 = 24
+      //   Assets:Checking padding = 24 - 4 - 15 - 1 = 4
+      //   Expenses:Food padding   = 24 - 4 - 13 - 0 = 7
+      // Already canonical input: assertion is that output equals input
+      const expected = [
+        "2026-03-15 * Payee",
+        "    # groceries:",
+        "    # source: manual",
+        "    # weekly:",
+        "    Assets:Checking    -45.00 USD",
+        `    Expenses:Food${" ".repeat(7)}45.00 USD`,
+      ].join("\n");
+      expect(beautifyJournalContent(input)).toBe(expected);
+    });
+  });
+});

--- a/src/extension/data/__tests__/scaffold.test.ts
+++ b/src/extension/data/__tests__/scaffold.test.ts
@@ -67,7 +67,7 @@ describe("ensureScaffolded()", () => {
   test("should write main.journal with header and include directive", async () => {
     await ensureScaffolded();
     const content = readFileSync(join(BASE, "ledger", "main.journal"), "utf-8");
-    expect(content).toContain("; Accountant24");
+    expect(content).toContain("# Accountant24");
     expect(content).toContain("include accounts.journal");
   });
 

--- a/src/extension/data/beautify.ts
+++ b/src/extension/data/beautify.ts
@@ -1,0 +1,341 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+/**
+ * Monthly-journal beautifier.
+ *
+ * What this touches:
+ *   1. Order of transactions in the file: stable sort by date ascending.
+ *   2. Whitespace between account and amount on posting lines that have
+ *      an amount — aligned to a common column derived from the widest
+ *      account in the whole file.
+ *   3. Comment characters: any ';' that starts a comment is rewritten to
+ *      '#'. Applies to leading top-level comments, metadata comment lines
+ *      inside a transaction, and inline trailing comments on postings.
+ *   4. Within-transaction line order:
+ *        (a) Transaction header (unchanged, first line).
+ *        (b) Tag lines: each on its own line, sorted alphabetically.
+ *            Comma-separated tag lists like "# tag1:, tag2:" are split.
+ *        (c) Header-area non-tag comments (rare), original relative order.
+ *        (d) Postings with a negative amount.
+ *        (e) Postings with a positive / unsigned amount.
+ *        (f) Balancing postings (accounts with no amount) — last.
+ *      Within each sign group, stable order. Non-tag comments attached
+ *      to a specific posting move with that posting.
+ *
+ * Everything else — amount digits, currency symbols, account names,
+ * headers, and original posting indent — is preserved.
+ */
+
+const MIN_GAP = 4;
+const DATE_HEADER_REGEX = /^(\d{4})[-/.](\d{2})[-/.](\d{2})\b/;
+
+interface Transaction {
+  date: string;
+  header: string;
+  body: string[];
+  // Non-indented content (e.g. top-level comments) that appeared between
+  // the previous transaction's body and this transaction's header.
+  // Stored here so it's not absorbed into the previous transaction's body.
+  // Emitted immediately before this transaction's header. When transactions
+  // are sorted, this content moves with its transaction.
+  preContent: string[];
+}
+
+type ParsedBodyLine =
+  | { kind: "metadata"; raw: string }
+  | { kind: "balancing"; raw: string }
+  | {
+      kind: "posting";
+      indent: string;
+      account: string;
+      amount: string;
+      digitsPrefixLength: number;
+      isNegative: boolean;
+    }
+  | { kind: "other"; raw: string };
+
+interface PostingGroup {
+  parsed: ParsedBodyLine; // posting | balancing | other
+  trailing: string[]; // raw lines attached to this posting (non-tag comments / other)
+}
+
+export function beautifyJournalContent(content: string): string {
+  if (content.length === 0) return content;
+
+  const hadTrailingNewline = content.endsWith("\n");
+  const normalized = content.replace(/\r\n/g, "\n");
+  const splitLines = normalized.split("\n");
+  // split("\n") on a string ending in "\n" produces a trailing "" — drop it
+  const lines =
+    hadTrailingNewline && splitLines.length > 0 && splitLines[splitLines.length - 1] === ""
+      ? splitLines.slice(0, -1)
+      : splitLines;
+
+  const headerIndices: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (DATE_HEADER_REGEX.test(lines[i])) headerIndices.push(i);
+  }
+
+  // Leading: everything before the first header (or the whole file if no headers),
+  // with ';' comment chars rewritten to '#' and trailing blank lines stripped
+  const leadingEnd = headerIndices.length > 0 ? headerIndices[0] : lines.length;
+  const leading = lines.slice(0, leadingEnd).map(rewriteSemicolonCommentLine);
+  while (leading.length > 0 && leading[leading.length - 1].trim() === "") {
+    leading.pop();
+  }
+
+  // No transactions → emit leading (rewritten) only
+  if (headerIndices.length === 0) {
+    if (leading.length === 0) return content;
+    let output = leading.join("\n");
+    if (hadTrailingNewline) output += "\n";
+    return output;
+  }
+
+  // Parse transactions.
+  //
+  // Non-indented, non-blank content that appears between a transaction's
+  // body and the next transaction's header (e.g. a top-level comment
+  // like "; Regular transactions") is NOT absorbed into the preceding
+  // transaction's body. Instead it becomes the `preContent` of the
+  // *following* transaction, so it stays as a top-level block between
+  // transactions and moves with the following transaction under sort.
+  //
+  // Content that follows the LAST transaction (no next transaction to
+  // attach to) is captured in `trailingContent`.
+  const transactions: Transaction[] = [];
+  let pendingPreContent: string[] = [];
+  for (let k = 0; k < headerIndices.length; k++) {
+    const start = headerIndices[k];
+    const nextStart = k < headerIndices.length - 1 ? headerIndices[k + 1] : lines.length;
+    const header = lines[start];
+
+    const body: string[] = [];
+    let i = start + 1;
+    while (i < nextStart && (lines[i].startsWith(" ") || lines[i].startsWith("\t"))) {
+      body.push(lines[i]);
+      i++;
+    }
+    const looseAfterBody: string[] = [];
+    while (i < nextStart) {
+      if (lines[i].trim() !== "") {
+        looseAfterBody.push(rewriteSemicolonCommentLine(lines[i]));
+      }
+      i++;
+    }
+
+    const m = header.match(DATE_HEADER_REGEX);
+    const date = m ? `${m[1]}-${m[2]}-${m[3]}` : header.slice(0, 10);
+
+    transactions.push({ date, header, body, preContent: pendingPreContent });
+    pendingPreContent = looseAfterBody;
+  }
+
+  // After the last transaction: any trailing non-indented content with
+  // nowhere to go becomes file-level trailing content.
+  const trailingContent = pendingPreContent;
+
+  // Stable sort by date ascending
+  transactions.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
+  // Classify body lines (after sort so parsedBodies indices align with sorted order)
+  const parsedBodies: ParsedBodyLine[][] = transactions.map((tx) => tx.body.map(parsePostingLine));
+
+  // Target digits column = max(indent + account + digitsPrefix) + MIN_GAP.
+  // Aligning on the first DIGIT (not the first character of the amount token)
+  // makes "-111.00 EUR" and "111.00 EUR" line up on the "1", with the negative
+  // sign sticking out one column to the left.
+  let targetDigitsColumn = 0;
+  let hasAnyPostingWithAmount = false;
+  for (const body of parsedBodies) {
+    for (const line of body) {
+      if (line.kind === "posting") {
+        hasAnyPostingWithAmount = true;
+        const candidate = line.indent.length + line.account.length + line.digitsPrefixLength;
+        if (candidate > targetDigitsColumn) targetDigitsColumn = candidate;
+      }
+    }
+  }
+  if (hasAnyPostingWithAmount) targetDigitsColumn += MIN_GAP;
+
+  // Emit: per-transaction reorder into canonical shape
+  const emittedTransactions: string[] = [];
+  for (let i = 0; i < transactions.length; i++) {
+    const tx = transactions[i];
+    const body = parsedBodies[i];
+    const out: string[] = [];
+    // preContent (top-level content that travels with this transaction)
+    // is emitted before the header, separated by a blank line.
+    if (tx.preContent.length > 0) {
+      out.push(...tx.preContent);
+      out.push("");
+    }
+    out.push(tx.header);
+
+    // Walk body once, categorize into: tag lines (from anywhere),
+    // header-area non-tag comments, and posting groups (with attached
+    // trailing comments for each posting)
+    const tagLines: string[] = [];
+    const headerNonTag: string[] = [];
+    const postingGroups: PostingGroup[] = [];
+    let current: PostingGroup | null = null;
+
+    const attachNonTag = (raw: string) => {
+      if (current === null) headerNonTag.push(raw);
+      else current.trailing.push(raw);
+    };
+
+    for (const line of body) {
+      if (line.kind === "posting" || line.kind === "balancing") {
+        current = { parsed: line, trailing: [] };
+        postingGroups.push(current);
+      } else if (line.kind === "metadata" && isTagCommentLine(line.raw)) {
+        tagLines.push(line.raw);
+      } else {
+        attachNonTag(line.raw);
+      }
+    }
+
+    // Header block: split + sort tag lines, then any header-area non-tag comments (original order)
+    const splitSortedTags = tagLines
+      .flatMap(splitTagCommentLine)
+      .sort((a, b) => tagSortKey(a).localeCompare(tagSortKey(b)));
+    out.push(...splitSortedTags);
+    out.push(...headerNonTag);
+
+    // Partition postings into three groups, stable within each
+    const negatives: PostingGroup[] = [];
+    const positives: PostingGroup[] = [];
+    const balancings: PostingGroup[] = [];
+    for (const g of postingGroups) {
+      if (g.parsed.kind === "posting") {
+        if (g.parsed.isNegative) negatives.push(g);
+        else positives.push(g);
+      } else {
+        balancings.push(g);
+      }
+    }
+
+    // Emit each posting (aligned) with its attached trailing comments
+    for (const groups of [negatives, positives, balancings]) {
+      for (const g of groups) {
+        if (g.parsed.kind === "posting") {
+          const padding =
+            targetDigitsColumn - g.parsed.indent.length - g.parsed.account.length - g.parsed.digitsPrefixLength;
+          out.push(`${g.parsed.indent}${g.parsed.account}${" ".repeat(padding)}${g.parsed.amount}`);
+        } else {
+          out.push(g.parsed.raw);
+        }
+        out.push(...g.trailing);
+      }
+    }
+
+    emittedTransactions.push(out.join("\n"));
+  }
+
+  // Assemble: leading + sorted txs separated by a single blank line + trailing content
+  let output = "";
+  if (leading.length > 0) {
+    output += leading.join("\n");
+    output += "\n\n";
+  }
+  output += emittedTransactions.join("\n\n");
+  if (trailingContent.length > 0) {
+    output += "\n\n";
+    output += trailingContent.join("\n");
+  }
+  if (hadTrailingNewline) output += "\n";
+
+  return output;
+}
+
+function parsePostingLine(rawLine: string): ParsedBodyLine {
+  const indentMatch = rawLine.match(/^([\t ]*)/);
+  const indent = indentMatch ? indentMatch[1] : "";
+  if (indent.length === 0) return { kind: "other", raw: rewriteSemicolonCommentLine(rawLine) };
+  const rest = rawLine.slice(indent.length);
+  if (rest[0] === ";" || rest[0] === "#") return { kind: "metadata", raw: rewriteSemicolonCommentLine(rawLine) };
+  // Split on first run of 2+ spaces or 1+ tabs (hledger account/amount separator)
+  const m = rest.match(/^(.+?)(?: {2,}|\t+)(.+)$/);
+  if (!m) return { kind: "balancing", raw: rawLine };
+  // Rewrite inline trailing comment marker "<space>;" → "<space>#". Anchored
+  // to whitespace-preceded ';' so any non-comment ';' in the amount (unlikely
+  // but possible) is left alone.
+  const amount = m[2].replace(/\s+$/, "").replace(/(\s+);/, "$1#");
+  const digitsPrefixLength = getDigitsPrefixLength(amount);
+  // Negative iff the amount has a '-' somewhere before the first digit
+  // (covers "-45", "$-45", "EUR -45"). "+45" and unsigned are positive.
+  const isNegative = amount.slice(0, digitsPrefixLength).includes("-");
+  return {
+    kind: "posting",
+    indent,
+    account: m[1],
+    amount,
+    digitsPrefixLength,
+    isNegative,
+  };
+}
+
+function rewriteSemicolonCommentLine(line: string): string {
+  // A line whose first non-whitespace character is ';' is a comment line —
+  // rewrite just that leading ';' to '#'. Non-comment lines are unchanged.
+  return line.replace(/^(\s*);/, "$1#");
+}
+
+// A tag-list comment line is a "# ..." (or ";") line whose comma-separated
+// parts ALL contain ':'. Examples: "# tag1:", "# tag1:, tag2:",
+// "# key: value", "# tag1:, key: value". Counter-examples: "# just a note",
+// "# notes, one, two".
+function isTagCommentLine(rawLine: string): boolean {
+  const match = rawLine.match(/^(\s*)[#;]\s*(.*)$/);
+  if (!match) return false;
+  const content = match[2];
+  const parts = content.split(/,\s*/).filter((p) => p.length > 0);
+  return parts.length > 0 && parts.every((p) => p.includes(":"));
+}
+
+// Split a tag-list comment line into individual tag lines.
+// "    # tag1:, tag2: value" → ["    # tag1:", "    # tag2: value"]
+// Non-tag lines are returned as-is (single-element array).
+function splitTagCommentLine(rawLine: string): string[] {
+  const match = rawLine.match(/^(\s*)[#;]\s*(.*)$/);
+  if (!match) return [rawLine];
+  const [, indent, content] = match;
+  const parts = content.split(/,\s*/).filter((p) => p.length > 0);
+  if (parts.length === 0 || !parts.every((p) => p.includes(":"))) return [rawLine];
+  return parts.map((p) => `${indent}# ${p.trim()}`);
+}
+
+// Sort key for a tag line: the content after the '#' prefix. By the time
+// this runs, all comment lines have been rewritten to use '#'.
+function tagSortKey(rawLine: string): string {
+  const match = rawLine.match(/^\s*#\s*(.*)$/);
+  return match ? match[1] : rawLine;
+}
+
+function getDigitsPrefixLength(amount: string): number {
+  // Number of characters before the first digit in the amount token.
+  // For "-111.00 EUR" → 1 (the "-"); for "111.00 EUR" → 0; for "EUR -111.00" → 5;
+  // for "$100" → 1; for "$-100" → 2; for a no-digit amount → full length.
+  const idx = amount.search(/\d/);
+  return idx === -1 ? amount.length : idx;
+}
+
+// Read `absPath`, beautify, write back if changed, and return the final
+// content. Returns null if the file does not exist (so callers like
+// `validateLedger` can tolerate a file disappearing between enumeration
+// and beautification).
+export function beautifyJournalFile(absPath: string): string | null {
+  let content: string;
+  try {
+    content = readFileSync(absPath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return null;
+    throw err;
+  }
+  const beautified = beautifyJournalContent(content);
+  if (beautified !== content) {
+    writeFileSync(absPath, beautified);
+  }
+  return beautified;
+}

--- a/src/extension/data/ledger.ts
+++ b/src/extension/data/ledger.ts
@@ -1,7 +1,8 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, normalize, resolve } from "node:path";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, normalize, resolve } from "node:path";
 import { ACCOUNTANT24_HOME, LEDGER_DIR } from "../config";
 import { HledgerCommandError, hledgerCheck, runHledger } from "../hledger";
+import { beautifyJournalFile } from "./beautify";
 import { generateDiff } from "./diff";
 
 const PERIOD_FLAGS: Record<string, string> = {
@@ -96,12 +97,12 @@ function formatTransaction(params: {
   const lines = [header];
 
   if (params.tags?.length) {
-    lines.push(`    ; ${params.tags.map((t) => `${t}:`).join(", ")}`);
+    lines.push(`    # ${params.tags.map((t) => `${t}:`).join(", ")}`);
   }
 
   if (params.metadata) {
     for (const [key, value] of Object.entries(params.metadata)) {
-      lines.push(`    ; ${key}: ${value}`);
+      lines.push(`    # ${key}: ${value}`);
     }
   }
 
@@ -141,8 +142,6 @@ export async function addTransaction(
     const separator = oldContent.endsWith("\n") ? "\n" : "\n\n";
     writeFileSync(fullFilePath, `${oldContent}${separator}${transactionText}\n`);
   }
-  const newContent = readFileSync(fullFilePath, "utf-8");
-  const diff = generateDiff(oldContent, newContent);
 
   // Update main.journal: includes and commodity declarations
   if (existsSync(mainPath)) {
@@ -180,6 +179,11 @@ export async function addTransaction(
     }
     throw e;
   }
+
+  // Beautify the monthly file: sort + align. The file exists (we just
+  // wrote to it), so the returned content is non-null.
+  const newContent = beautifyJournalFile(fullFilePath) ?? "";
+  const diff = generateDiff(oldContent, newContent);
 
   return { transactionText, fullFilePath, ledgerIsValid: true, diff };
 }
@@ -249,7 +253,26 @@ export async function validateLedger(signal?: AbortSignal): Promise<ValidateLedg
     throw e;
   }
 
+  // Beautify every monthly file: sort + align
+  for (const f of enumerateMonthlyJournals()) {
+    beautifyJournalFile(f);
+  }
+
   return { ledgerIsValid: true };
+}
+
+function enumerateMonthlyJournals(): string[] {
+  if (!existsSync(LEDGER_DIR)) return [];
+  const out: string[] = [];
+  for (const yearEntry of readdirSync(LEDGER_DIR, { withFileTypes: true })) {
+    if (!yearEntry.isDirectory() || !/^\d{4}$/.test(yearEntry.name)) continue;
+    const yearDir = join(LEDGER_DIR, yearEntry.name);
+    for (const f of readdirSync(yearDir)) {
+      if (!/^\d{2}\.journal$/.test(f)) continue;
+      out.push(join(yearDir, f));
+    }
+  }
+  return out.sort();
 }
 
 // ── Internals ───────────────────────────────────────────────────────

--- a/src/extension/data/scaffold/template/ledger/accounts.journal
+++ b/src/extension/data/scaffold/template/ledger/accounts.journal
@@ -1,21 +1,21 @@
-; Default chart of accounts for accountant24
-;
-; Account types:
-;   ASSETS       — things you own (bank accounts, cash, investments)
-;   LIABILITIES  — things you owe (credit cards, loans, mortgages)
-;   EQUITY       — owner's investment, balances assets and liabilities
-;   INCOME       — inflows of money (salary, business, interest)
-;   EXPENSES     — outflows of money (rent, groceries, subscriptions)
+# Default chart of accounts for accountant24
+#
+# Account types:
+#   ASSETS       — things you own (bank accounts, cash, investments)
+#   LIABILITIES  — things you owe (credit cards, loans, mortgages)
+#   EQUITY       — owner's investment, balances assets and liabilities
+#   INCOME       — inflows of money (salary, business, interest)
+#   EXPENSES     — outflows of money (rent, groceries, subscriptions)
 
-; ====================================================================
-; ASSETS — things you own (bank accounts, cash, investments)
-; ====================================================================
+# ====================================================================
+# ASSETS — things you own (bank accounts, cash, investments)
+# ====================================================================
 
 account assets:cash
 
-; ====================================================================
-; LIABILITIES — things you owe (credit cards, loans, mortgages)
-; ====================================================================
+# ====================================================================
+# LIABILITIES — things you owe (credit cards, loans, mortgages)
+# ====================================================================
 
 account liabilities:credit-card
 account liabilities:mortgage
@@ -23,15 +23,15 @@ account liabilities:car-loan
 account liabilities:student-loan
 account liabilities:loan
 
-; ====================================================================
-; EQUITY — owner's investment, balances assets and liabilities
-; ====================================================================
+# ====================================================================
+# EQUITY — owner's investment, balances assets and liabilities
+# ====================================================================
 
 account equity:opening-balances
 
-; ====================================================================
-; INCOME — inflows of money (salary, business, interest)
-; ====================================================================
+# ====================================================================
+# INCOME — inflows of money (salary, business, interest)
+# ====================================================================
 
 account income:salary
 account income:business
@@ -43,9 +43,9 @@ account income:government-benefits
 account income:tax-refund
 account income:other
 
-; ====================================================================
-; EXPENSES — outflows of money (rent, groceries, subscriptions)
-; ====================================================================
+# ====================================================================
+# EXPENSES — outflows of money (rent, groceries, subscriptions)
+# ====================================================================
 
 account expenses:housing:rent
 account expenses:housing:insurance

--- a/src/extension/data/scaffold/template/ledger/main.journal
+++ b/src/extension/data/scaffold/template/ledger/main.journal
@@ -1,3 +1,3 @@
-; Accountant24
+# Accountant24
 
 include accounts.journal

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -1,5 +1,6 @@
 export { ACCOUNTANT24_HOME, LEDGER_DIR, MEMORY_PATH, setBaseDir } from "./config";
 export { createExtension } from "./extension";
+export { getBuiltinSkillsDir } from "./skills";
 export { buildSystemPrompt } from "./system-prompt";
 export { addTransactionTool } from "./tools/add-transaction";
 export { queryTool } from "./tools/query";

--- a/src/extension/skills/__tests__/index.test.ts
+++ b/src/extension/skills/__tests__/index.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
+import { loadSkillsFromDir, parseFrontmatter } from "@mariozechner/pi-coding-agent";
+import { getBuiltinSkillsDir } from "../index.js";
+
+describe("getBuiltinSkillsDir()", () => {
+  test("should return an absolute path to an existing directory", () => {
+    const dir = getBuiltinSkillsDir();
+    expect(dir.startsWith("/")).toBe(true);
+    expect(existsSync(dir)).toBe(true);
+    expect(statSync(dir).isDirectory()).toBe(true);
+  });
+
+  test("should contain a hledger subdirectory with SKILL.md", () => {
+    const dir = getBuiltinSkillsDir();
+    const hledgerDir = join(dir, "hledger");
+    const skillFile = join(hledgerDir, "SKILL.md");
+    expect(statSync(hledgerDir).isDirectory()).toBe(true);
+    expect(existsSync(skillFile)).toBe(true);
+  });
+});
+
+describe("hledger SKILL.md frontmatter", () => {
+  const skillFile = join(getBuiltinSkillsDir(), "hledger", "SKILL.md");
+  const { frontmatter, body } = parseFrontmatter<{ name?: string; description?: string }>(
+    readFileSync(skillFile, "utf-8"),
+  );
+
+  test("should declare name 'hledger'", () => {
+    expect(frontmatter.name).toBe("hledger");
+  });
+
+  test("should match the parent directory name", () => {
+    const parentDir = basename(join(skillFile, ".."));
+    expect(frontmatter.name).toBe(parentDir);
+  });
+
+  test("should declare a non-empty description within 1024 chars", () => {
+    expect(typeof frontmatter.description).toBe("string");
+    expect((frontmatter.description ?? "").length).toBeGreaterThan(0);
+    expect((frontmatter.description ?? "").length).toBeLessThanOrEqual(1024);
+  });
+
+  test("should have a non-empty body", () => {
+    expect(body.trim().length).toBeGreaterThan(0);
+  });
+});
+
+describe("loadSkillsFromDir(getBuiltinSkillsDir())", () => {
+  const result = loadSkillsFromDir({ dir: getBuiltinSkillsDir(), source: "test" });
+
+  test("should load exactly one built-in skill", () => {
+    expect(result.skills).toHaveLength(1);
+  });
+
+  test("should load the hledger skill", () => {
+    expect(result.skills[0]?.name).toBe("hledger");
+  });
+
+  test("should expose the hledger description to the loader", () => {
+    expect(result.skills[0]?.description.length).toBeGreaterThan(0);
+  });
+
+  test("should not be model-invocation-disabled", () => {
+    expect(result.skills[0]?.disableModelInvocation).toBe(false);
+  });
+
+  test("should load without error-level diagnostics", () => {
+    const errors = result.diagnostics.filter((d) => d.type === "error");
+    expect(errors).toEqual([]);
+  });
+});

--- a/src/extension/skills/hledger/SKILL.md
+++ b/src/extension/skills/hledger/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: hledger
+description: Plain-text double-entry accounting reference for hledger. Covers journal file syntax, transaction formatting, common commands (check, bal, reg, print, stats, aregister, is, bs), strict validation rules, and typical pitfalls. Use when writing or editing journal entries, debugging hledger errors, answering the user's questions about hledger, or constructing hledger CLI queries.
+---
+
+# hledger skill
+
+A compact reference for producing valid hledger journal entries and running hledger commands against the user's ledger.
+
+## Transaction syntax
+
+```
+YYYY-MM-DD [*|!] Payee | Narration
+    Account:Sub:Sub     AMOUNT CURRENCY
+    Account:Sub:Sub    -AMOUNT CURRENCY
+```
+
+Rules the agent must respect:
+- Date format is always `YYYY-MM-DD`.
+- `*` marks a cleared transaction; `!` marks pending. Accountant24 uses `*` by default.
+- Description line is `Payee | Narration` (pipe-separated). The payee is required; narration is optional but recommended.
+- Posting lines are indented with at least two spaces.
+- Each transaction must balance: postings sum to zero per commodity. Leave one posting's amount blank and hledger will infer it — but prefer explicit amounts for auditability.
+- Amounts use period as decimal separator: `100.00 EUR`, not `100,00`. Currency goes after the amount, separated by a single space.
+- Account hierarchy uses `:` as separator: `Assets:Checking`, `Expenses:Food:Coffee`.
+- Transactions are separated by a blank line — hledger uses it as the record delimiter.
+
+## Account naming
+
+Top-level prefixes (case-sensitive): `Assets:`, `Liabilities:`, `Income:`, `Expenses:`, `Equity:`. Sub-accounts are free-form but should match the user's existing chart. Never invent new accounts without user confirmation.
+
+## Common commands
+
+The journal file in this project is `~/Accountant24/ledger/main.journal` (it `include`s monthly files under `ledger/YYYY/MM.journal`). All commands below take `-f main.journal` (or equivalent) and can be narrowed by query filters.
+
+| Goal | Command |
+|---|---|
+| Validate journal (strict) | `hledger check --strict -f main.journal` |
+| Balance sheet | `hledger bs -f main.journal` |
+| Income statement | `hledger is -f main.journal` |
+| All balances | `hledger bal -f main.journal` |
+| Transactions for an account | `hledger reg Expenses:Food -f main.journal` |
+| Register with running balance | `hledger aregister Assets:Checking -f main.journal` |
+| Raw transactions | `hledger print -f main.journal` |
+| Stats overview | `hledger stats -f main.journal` |
+
+Period filters: `-p "this month"`, `-p "2026"`, `-p "2026-01..2026-03"`.
+Query terms: bare words match the payee/description; `acct:Food` matches an account regex; `cur:EUR` filters commodity; `date:2026-03` filters by date.
+
+## Validation & error recovery
+
+`hledger check --strict` is the source of truth for "is this journal valid?". Common failures:
+- `unbalanced transaction` — postings don't sum to zero. Recompute and fix one side.
+- `undeclared account` — `--strict` requires every account to be declared (usually in `accounts.journal`). Either add an `account Foo:Bar` declaration or use an already-declared account.
+- `parse error` — usually a missing blank line between transactions, a mis-indented posting, or a malformed date.
+
+The project already exposes helpers in `src/extension/hledger.ts`:
+- `runHledger(args, opts)` — throws `HledgerCommandError` on non-zero exit.
+- `hledgerCheck(journalPath, opts)` — runs `check --strict` on a single file.
+
+Prefer these over spawning bash directly when writing tools; use bash for ad-hoc read-only queries the user asks for interactively.
+
+## Common pitfalls
+
+- Don't edit journal files with `bash`/`sed`; use the `edit` tool so changes are reviewable and validated.
+- Don't forget the blank line between transactions — hledger uses it as the record separator.
+- Currency must match the user's configured default unless the user explicitly states otherwise.
+- Payee should be the canonical spelling from the known payees list when one exists (`starbucks` → `Starbucks`).
+- After any journal modification, run `hledger check --strict` before committing.
+
+## References
+
+- Journal format: https://hledger.org/hledger.html#journal
+- Command reference: https://hledger.org/hledger.html#commands
+- Query syntax: https://hledger.org/hledger.html#queries

--- a/src/extension/skills/index.ts
+++ b/src/extension/skills/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Absolute path to the built-in skills directory that ships with the
+ * accountant24 extension. pi-coding-agent's DefaultResourceLoader scans
+ * this directory for subdirectories containing SKILL.md.
+ *
+ * Add new built-in skills as sibling directories (e.g. ./foo/SKILL.md);
+ * no code changes are required — discovery is automatic.
+ */
+export function getBuiltinSkillsDir(): string {
+  return import.meta.dirname;
+}

--- a/src/extension/tools/__tests__/add-transaction.test.ts
+++ b/src/extension/tools/__tests__/add-transaction.test.ts
@@ -10,10 +10,12 @@ mock.module("../../config.js", () => ({
   ACCOUNTANT24_HOME: BASE,
   LEDGER_DIR: LEDGER,
   MEMORY_PATH: join(BASE, "memory.md"),
+  FILES_DIR: join(BASE, "files"),
   setBaseDir: () => {},
 }));
 
-// Mock at Bun.spawn level so real hledger.ts functions execute for coverage
+// Mock at Bun.spawn level so real hledger.ts functions execute for coverage.
+// Beautification is pure TS (no subprocess); the only spawn call is hledger check.
 const origSpawn = Bun.spawn;
 
 function makeMockProc(exitCode: number, stdout = "", stderr = "") {
@@ -25,7 +27,15 @@ function makeMockProc(exitCode: number, stdout = "", stderr = "") {
   };
 }
 
-let mockProc: ReturnType<typeof makeMockProc>;
+let mockExitCode: number;
+let mockStdout: string;
+let mockStderr: string;
+
+const setMock = (exit: number, stdout = "", stderr = "") => {
+  mockExitCode = exit;
+  mockStdout = stdout;
+  mockStderr = stderr;
+};
 
 const { addTransactionTool } = await import("../add-transaction.js");
 
@@ -35,9 +45,9 @@ afterAll(() => {
 });
 
 beforeEach(() => {
-  mockProc = makeMockProc(0);
+  setMock(0);
   // @ts-expect-error - mocking Bun.spawn
-  Bun.spawn = mock(() => mockProc);
+  Bun.spawn = mock(() => makeMockProc(mockExitCode, mockStdout, mockStderr));
   // Clean and recreate ledger dir
   rmSync(LEDGER, { recursive: true, force: true });
   mkdirSync(LEDGER, { recursive: true });
@@ -128,7 +138,7 @@ test("calls hledger check after writing", async () => {
 
 test("throws on validation failure", async () => {
   writeFileSync(join(LEDGER, "main.journal"), "");
-  mockProc = makeMockProc(1, "", "account not declared");
+  setMock(1, "", "account not declared");
   await expect(run(basicParams)).rejects.toThrow("account not declared");
 });
 
@@ -139,7 +149,7 @@ test("handles tags", async () => {
     tags: ["groceries", "weekly"],
   });
   const text = result.content[0].text;
-  expect(text).toContain("; groceries:, weekly:");
+  expect(text).toContain("# groceries:, weekly:");
 });
 
 test("handles metadata", async () => {
@@ -149,7 +159,7 @@ test("handles metadata", async () => {
     metadata: { source: "manual" },
   });
   const text = result.content[0].text;
-  expect(text).toContain("; source: manual");
+  expect(text).toContain("# source: manual");
 });
 
 test("handles tags and metadata together", async () => {
@@ -160,8 +170,8 @@ test("handles tags and metadata together", async () => {
     metadata: { source: "manual" },
   });
   const text = result.content[0].text;
-  expect(text).toContain("; groceries:, weekly:");
-  expect(text).toContain("; source: manual");
+  expect(text).toContain("# groceries:, weekly:");
+  expect(text).toContain("# source: manual");
 });
 
 test("requires currency when amount present", async () => {
@@ -197,7 +207,7 @@ test("rejects multiple postings without amount", async () => {
 
 test("hledger not found throws error", async () => {
   writeFileSync(join(LEDGER, "main.journal"), "");
-  mockProc = makeMockProc(127);
+  setMock(127);
   await expect(run(basicParams)).rejects.toThrow("hledger not found");
 });
 
@@ -273,6 +283,99 @@ test("should re-throw unexpected validation errors", async () => {
     throw new TypeError("unexpected");
   });
   await expect(run(basicParams)).rejects.toThrow("unexpected");
+});
+
+// ── beautification ─────────────────────────────────────────────────
+
+describe("beautification", () => {
+  test("should sort transactions by date in the monthly file after hledger check succeeds", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    // Pre-seed with a later-dated transaction; adding an earlier-dated one should push it above
+    writeFileSync(
+      join(LEDGER, "2026", "03.journal"),
+      "2026-03-28 * Later | After\n    Expenses:Misc    10.00 USD\n    Assets:Checking\n",
+    );
+    await run(basicParams);
+    const content = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    const earlierIdx = content.indexOf("2026-03-15");
+    const laterIdx = content.indexOf("2026-03-28");
+    expect(earlierIdx).toBeGreaterThanOrEqual(0);
+    expect(laterIdx).toBeGreaterThanOrEqual(0);
+    expect(earlierIdx).toBeLessThan(laterIdx);
+  });
+
+  test("should align all posting amounts in the file to a common column derived from the widest account", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    // Pre-seed with a shorter-account transaction
+    writeFileSync(
+      join(LEDGER, "2026", "03.journal"),
+      "2026-03-01 * Old | Existing\n    Expenses:Misc    10.00 USD\n    Assets:Checking\n",
+    );
+    // basicParams adds "Expenses:Food:Groceries" (23 chars) — longer than "Expenses:Misc" (13) and "Assets:Checking" (15)
+    await run(basicParams);
+    const content = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    // Longest account in the file is "Expenses:Food:Groceries" = 23 chars
+    // targetColumn = 4 (indent) + 23 (account) + 4 (MIN_GAP) = 31
+    // "Expenses:Misc" (13) padding = 31 - 4 - 13 = 14 spaces
+    // "Expenses:Food:Groceries" (23) padding = 31 - 4 - 23 = 4 spaces
+    expect(content).toContain(`    Expenses:Misc${" ".repeat(14)}10.00 USD`);
+    expect(content).toContain("    Expenses:Food:Groceries    45.00 USD");
+  });
+
+  test("should not modify the monthly file when hledger check fails", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    const preSeeded = "2026-03-20 * Existing\n    Expenses:Misc  10.00 USD\n    Assets:Checking\n";
+    writeFileSync(join(LEDGER, "2026", "03.journal"), preSeeded);
+    setMock(1, "", "account not declared");
+    await expect(run(basicParams)).rejects.toThrow("account not declared");
+    // The newly-appended content is in the file (addTransaction writes before validation),
+    // but beautification did NOT run — so the pre-existing transaction's original spacing is preserved.
+    const content = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    expect(content).toContain("    Expenses:Misc  10.00 USD");
+  });
+
+  test("should return a diff reflecting the beautified file content", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    // Pre-seed: an OUT-OF-ORDER transaction dated AFTER basicParams
+    writeFileSync(
+      join(LEDGER, "2026", "03.journal"),
+      "2026-03-28 * Later\n    Expenses:Misc    10.00 USD\n    Assets:Checking\n",
+    );
+    const result = await run(basicParams);
+    const diff = result.details.diff;
+    // Diff should contain additions for the new transaction (Whole Foods)
+    expect(diff).toContain("Whole Foods");
+    // The final file should have the new (earlier) transaction sorted to the top
+    const finalContent = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    expect(finalContent.indexOf("Whole Foods")).toBeLessThan(finalContent.indexOf("Later"));
+  });
+
+  test("should not modify main.journal during beautification", async () => {
+    const originalMain = "; Accountant24 Personal Finances\naccount Assets:Checking\n";
+    writeFileSync(join(LEDGER, "main.journal"), originalMain);
+    await run(basicParams);
+    const mainAfter = readFileSync(join(LEDGER, "main.journal"), "utf-8");
+    // main.journal still has its original opening content (commodity may be prepended, include may be appended)
+    expect(mainAfter).toContain("; Accountant24 Personal Finances");
+    expect(mainAfter).toContain("account Assets:Checking");
+  });
+
+  test("should be idempotent: beautifying a second time should produce identical content", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    await run(basicParams);
+    const afterFirst = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    // Run the same add again — it'll add a duplicate transaction; we only check that the format is stable
+    await run({ ...basicParams, payee: "Different Store" });
+    const afterSecond = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    // Verify the first transaction's line is byte-identical in the second state
+    const firstLine = afterFirst.split("\n").find((l) => l.includes("45.00 USD"));
+    expect(firstLine).toBeDefined();
+    expect(afterSecond).toContain(firstLine!);
+  });
 });
 
 // ── rendering wiring ──────────────────────────────────────────────

--- a/src/extension/tools/__tests__/validate.test.ts
+++ b/src/extension/tools/__tests__/validate.test.ts
@@ -1,18 +1,21 @@
-import { afterAll, afterEach, beforeEach, expect, mock, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const BASE = mkdtempSync(join(tmpdir(), "accountant24-validate-"));
+const LEDGER = join(BASE, "ledger");
 
 mock.module("../../config.js", () => ({
   ACCOUNTANT24_HOME: BASE,
   MEMORY_PATH: join(BASE, "memory.md"),
-  LEDGER_DIR: join(BASE, "ledger"),
+  LEDGER_DIR: LEDGER,
+  FILES_DIR: join(BASE, "files"),
   setBaseDir: () => {},
 }));
 
-// Mock at Bun.spawn level so real hledger.ts functions execute for coverage
+// Mock at Bun.spawn level. Beautification is pure TS (no subprocess); the only
+// spawn call is hledger check.
 const origSpawn = Bun.spawn;
 
 function makeMockProc(exitCode: number, stdout = "", stderr = "") {
@@ -24,7 +27,15 @@ function makeMockProc(exitCode: number, stdout = "", stderr = "") {
   };
 }
 
-let mockProc: ReturnType<typeof makeMockProc>;
+let mockExitCode: number;
+let mockStdout: string;
+let mockStderr: string;
+
+const setMock = (exit: number, stdout = "", stderr = "") => {
+  mockExitCode = exit;
+  mockStdout = stdout;
+  mockStderr = stderr;
+};
 
 const { validateTool } = await import("../validate.js");
 
@@ -34,9 +45,12 @@ afterAll(() => {
 });
 
 beforeEach(() => {
-  mockProc = makeMockProc(0);
+  setMock(0);
   // @ts-expect-error - mocking Bun.spawn
-  Bun.spawn = mock(() => mockProc);
+  Bun.spawn = mock(() => makeMockProc(mockExitCode, mockStdout, mockStderr));
+  // Clean and recreate ledger dir per test
+  rmSync(LEDGER, { recursive: true, force: true });
+  mkdirSync(LEDGER, { recursive: true });
 });
 
 afterEach(() => {
@@ -47,18 +61,18 @@ const run = (params: any) =>
   validateTool.execute("test", params, undefined, undefined, undefined as any) as Promise<any>;
 
 test("throws when hledger not found", async () => {
-  mockProc = makeMockProc(127);
+  setMock(127);
   await expect(run({})).rejects.toThrow("hledger not found");
 });
 
 test("returns valid result on success", async () => {
-  mockProc = makeMockProc(0);
+  setMock(0);
   const result = await run({});
   expect(result.details.ledgerIsValid).toBe(true);
 });
 
 test("throws on validation failure", async () => {
-  mockProc = makeMockProc(1, "", "hledger: Error: account not declared");
+  setMock(1, "", "hledger: Error: account not declared");
   await expect(run({})).rejects.toThrow("account not declared");
 });
 
@@ -67,4 +81,139 @@ test("re-throws unexpected errors", async () => {
     throw new TypeError("unexpected");
   });
   await expect(run({})).rejects.toThrow("unexpected");
+});
+
+// ── beautification ─────────────────────────────────────────────────
+
+describe("beautification", () => {
+  test("should sort and align each monthly file after hledger check succeeds", async () => {
+    mkdirSync(join(LEDGER, "2025"), { recursive: true });
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    // Out-of-order, misaligned in 2025/12.journal
+    writeFileSync(
+      join(LEDGER, "2025", "12.journal"),
+      [
+        "2025-12-28 * Later",
+        "    Expenses:Misc  10.00 USD",
+        "    Assets:Checking",
+        "",
+        "2025-12-01 * Earlier",
+        "    Expenses:Misc  5.00 USD",
+        "    Assets:Checking",
+      ].join("\n") + "\n",
+    );
+    // Simple file in 2026/01.journal
+    writeFileSync(
+      join(LEDGER, "2026", "01.journal"),
+      "2026-01-01 * Tx\n    Expenses:Food  5.00 USD\n    Assets:Checking\n",
+    );
+
+    await run({});
+
+    const dec = readFileSync(join(LEDGER, "2025", "12.journal"), "utf-8");
+    // Sorted: Earlier before Later
+    expect(dec.indexOf("Earlier")).toBeLessThan(dec.indexOf("Later"));
+    // Aligned: longest account is "Assets:Checking" (15). But it's balancing (no amount).
+    // The only posting with amount is "Expenses:Misc" (13) → target = 4+13+4 = 21 → 4 spaces gap
+    expect(dec).toContain("    Expenses:Misc    5.00 USD");
+    expect(dec).toContain("    Expenses:Misc    10.00 USD");
+
+    const jan = readFileSync(join(LEDGER, "2026", "01.journal"), "utf-8");
+    // "Expenses:Food" (13) → target = 4+13+4 = 21 → 4 spaces gap
+    expect(jan).toContain("    Expenses:Food    5.00 USD");
+  });
+
+  test("should not modify main.journal or accounts.journal", async () => {
+    const mainContent = "; main\ninclude 2026/01.journal\n";
+    const accountsContent = "account Assets:Checking\n";
+    writeFileSync(join(LEDGER, "main.journal"), mainContent);
+    writeFileSync(join(LEDGER, "accounts.journal"), accountsContent);
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    writeFileSync(
+      join(LEDGER, "2026", "01.journal"),
+      "2026-01-01 * Tx\n    Expenses:Misc    1.00 USD\n    Assets:Checking\n",
+    );
+
+    await run({});
+
+    expect(readFileSync(join(LEDGER, "main.journal"), "utf-8")).toBe(mainContent);
+    expect(readFileSync(join(LEDGER, "accounts.journal"), "utf-8")).toBe(accountsContent);
+  });
+
+  test("should skip files in non-year-named directories", async () => {
+    mkdirSync(join(LEDGER, "archive"), { recursive: true });
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    const archiveContent =
+      "2020-02-01 * Later\n    Expenses:Misc    1.00 USD\n    Assets:Checking\n\n2020-01-01 * Earlier\n    Expenses:Misc    2.00 USD\n    Assets:Checking\n";
+    writeFileSync(join(LEDGER, "archive", "01.journal"), archiveContent);
+    writeFileSync(
+      join(LEDGER, "2026", "01.journal"),
+      "2026-01-01 * New\n    Expenses:Misc    1.00 USD\n    Assets:Checking\n",
+    );
+
+    await run({});
+
+    // archive/01.journal was not touched (still has transactions in original order)
+    expect(readFileSync(join(LEDGER, "archive", "01.journal"), "utf-8")).toBe(archiveContent);
+  });
+
+  test("should skip files whose name is not two-digit month .journal", async () => {
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    const badContent =
+      "2026-02-01 * Later\n    Expenses:Misc    1.00 USD\n    Assets:Checking\n\n2026-01-01 * Earlier\n    Expenses:Misc    2.00 USD\n    Assets:Checking\n";
+    writeFileSync(join(LEDGER, "2026", "january.journal"), badContent);
+    writeFileSync(
+      join(LEDGER, "2026", "01.journal"),
+      "2026-01-02 * Tx\n    Expenses:Misc    1.00 USD\n    Assets:Checking\n",
+    );
+
+    await run({});
+
+    // january.journal was not touched (still has transactions in original order)
+    expect(readFileSync(join(LEDGER, "2026", "january.journal"), "utf-8")).toBe(badContent);
+  });
+
+  test("should not beautify any file when hledger check fails", async () => {
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    const contentBefore =
+      "2026-01-28 * Later\n    Expenses:Misc  1.00 USD\n    Assets:Checking\n\n2026-01-01 * Earlier\n    Expenses:Misc  2.00 USD\n    Assets:Checking\n";
+    writeFileSync(join(LEDGER, "2026", "01.journal"), contentBefore);
+    setMock(1, "", "hledger: Error: account not declared");
+
+    await expect(run({})).rejects.toThrow("account not declared");
+
+    // File was not rewritten (still misaligned and out of order)
+    expect(readFileSync(join(LEDGER, "2026", "01.journal"), "utf-8")).toBe(contentBefore);
+  });
+
+  test("should succeed when there are no monthly files", async () => {
+    // Only non-monthly files in ledger dir
+    writeFileSync(join(LEDGER, "main.journal"), "; empty\n");
+
+    const result = await run({});
+
+    expect(result.details.ledgerIsValid).toBe(true);
+  });
+
+  test("should be idempotent: running validate twice produces identical content", async () => {
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    writeFileSync(
+      join(LEDGER, "2026", "03.journal"),
+      [
+        "2026-03-28 * Later",
+        "    Expenses:Misc  3.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-03-01 * Earlier",
+        "    Expenses:Misc  1.00 USD",
+        "    Assets:Checking",
+      ].join("\n") + "\n",
+    );
+
+    await run({});
+    const afterFirst = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    await run({});
+    const afterSecond = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    expect(afterSecond).toBe(afterFirst);
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
   VERSION,
 } from "@mariozechner/pi-coding-agent";
 import { minimatch } from "minimatch";
-import { ACCOUNTANT24_HOME, createExtension } from "./extension";
+import { ACCOUNTANT24_HOME, createExtension, getBuiltinSkillsDir } from "./extension";
 
 async function main() {
   const settingsManager = SettingsManager.create(ACCOUNTANT24_HOME, ACCOUNTANT24_HOME);
@@ -26,6 +26,7 @@ async function main() {
     cwd: ACCOUNTANT24_HOME,
     agentDir: ACCOUNTANT24_HOME,
     extensionFactories: [createExtension(settingsManager)],
+    additionalSkillPaths: [getBuiltinSkillsDir()],
     noSkills: true,
     noPromptTemplates: true,
   });


### PR DESCRIPTION
## Summary

- Wire pi-coding-agent's skill infrastructure by passing `additionalSkillPaths` to `DefaultResourceLoader` (honored even with `noSkills: true`), so built-in skills ship with the extension without reinventing any loader/command plumbing.
- Bundle a lean first built-in skill `hledger` at `src/extension/skills/hledger/SKILL.md` — auto-registers as `/skill:hledger` and is surfaced to the model via progressive disclosure.
- Structure leaves custom user skills as a one-line flip later (`noSkills: true` → `false`, or an extra settings-driven path).

Adding more built-in skills later requires zero code changes — drop a sibling directory under `src/extension/skills/<name>/SKILL.md`.

## Test plan

- [x] New behavioral specs in `src/extension/skills/__tests__/index.test.ts` cover directory existence, frontmatter validity (name matches parent dir, description ≤1024 chars), and end-to-end loading via pi-coding-agent's `loadSkillsFromDir`.
- [x] `bun run verify` green (717 tests pass, biome clean, tsc clean, 100% coverage on `src/extension/skills/index.ts`).
- [ ] Manual smoke: `bun run start`, type `/` in the TUI, confirm `/skill:hledger` appears in autocomplete, invoke it, then ask a hledger-specific question and check the answer reflects the skill's content.