### PR TITLE
feat: auto-format journal files on add and validate

### DIFF
--- a/src/extension/__tests__/hledger.test.ts
+++ b/src/extension/__tests__/hledger.test.ts
@@ -64,10 +64,19 @@ async function fallbackHledgerCheck(journalPath: string, opts?: any): Promise<vo
   await fallbackRunHledger(["check", "--strict", "-f", journalPath], opts);
 }
 
+async function fallbackHledgerFiles(journalPath: string, opts?: any): Promise<string[]> {
+  const stdout = await fallbackRunHledger(["files", "-f", journalPath], opts);
+  return stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
 // Decide which functions to use - prefer real module when possible
 let runHledger: typeof fallbackRunHledger;
 let tryRunHledger: typeof fallbackTryRunHledger;
 let hledgerCheck: typeof fallbackHledgerCheck;
+let hledgerFiles: typeof fallbackHledgerFiles;
 
 // Set up before each test
 beforeEach(() => {
@@ -92,6 +101,7 @@ beforeEach(() => {
   runHledger = fallbackRunHledger;
   tryRunHledger = fallbackTryRunHledger;
   hledgerCheck = fallbackHledgerCheck;
+  hledgerFiles = fallbackHledgerFiles;
 
   // Restore Bun.spawn for clean state
   Bun.spawn = origSpawn;
@@ -284,6 +294,52 @@ describe("hledgerCheck()", () => {
   test("should throw HledgerNotFoundError when hledger missing", async () => {
     spawnResult = { exitCode: 127, stdout: "", stderr: "" };
     await expect(hledgerCheck("/path/to/main.journal")).rejects.toThrow(HledgerNotFoundError);
+  });
+});
+
+// ── hledgerFiles() ──────────────────────────────────────────────────
+
+describe("hledgerFiles()", () => {
+  test("should pass files -f and journal path", async () => {
+    spawnResult = { exitCode: 0, stdout: "", stderr: "" };
+    await hledgerFiles("/path/to/main.journal");
+    expect(lastArgs).toEqual(["hledger", "files", "-f", "/path/to/main.journal"]);
+  });
+
+  test("should parse newline-separated file list", async () => {
+    spawnResult = {
+      exitCode: 0,
+      stdout: "/home/u/ledger/main.journal\n/home/u/ledger/accounts.journal\n/home/u/ledger/2026/01.journal\n",
+      stderr: "",
+    };
+    const result = await hledgerFiles("/home/u/ledger/main.journal");
+    expect(result).toEqual([
+      "/home/u/ledger/main.journal",
+      "/home/u/ledger/accounts.journal",
+      "/home/u/ledger/2026/01.journal",
+    ]);
+  });
+
+  test("should return empty array for empty stdout", async () => {
+    spawnResult = { exitCode: 0, stdout: "", stderr: "" };
+    const result = await hledgerFiles("/path/to/main.journal");
+    expect(result).toEqual([]);
+  });
+
+  test("should trim whitespace and drop blank lines", async () => {
+    spawnResult = { exitCode: 0, stdout: "  a.journal  \n\n  b.journal\n\n", stderr: "" };
+    const result = await hledgerFiles("/path/to/main.journal");
+    expect(result).toEqual(["a.journal", "b.journal"]);
+  });
+
+  test("should throw HledgerCommandError on parse failure", async () => {
+    spawnResult = { exitCode: 1, stdout: "", stderr: "parse error" };
+    await expect(hledgerFiles("/path/to/main.journal")).rejects.toThrow(HledgerCommandError);
+  });
+
+  test("should throw HledgerNotFoundError when hledger missing", async () => {
+    spawnResult = { exitCode: 127, stdout: "", stderr: "" };
+    await expect(hledgerFiles("/path/to/main.journal")).rejects.toThrow(HledgerNotFoundError);
   });
 });
 

--- a/src/extension/data/format/__tests__/emit.test.ts
+++ b/src/extension/data/format/__tests__/emit.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "bun:test";
+import { assembleOutput, assembleWithoutTransactions, emitTransaction } from "../emit";
+import type { ParsedBodyLine, Transaction } from "../types";
+
+// ── Test helpers ─────────────────────────────────────────────────
+
+const tx = (overrides: Partial<Transaction> = {}): Transaction => ({
+  date: "2026-03-15",
+  header: "2026-03-15 * Payee",
+  body: [],
+  preContent: [],
+  ...overrides,
+});
+
+const posting = (
+  indent: string,
+  account: string,
+  amount: string,
+  digitsPrefixLength: number,
+  isNegative: boolean,
+): ParsedBodyLine => ({ kind: "posting", indent, account, amount, digitsPrefixLength, isNegative });
+
+const balancing = (raw: string): ParsedBodyLine => ({ kind: "balancing", raw });
+const metadata = (raw: string): ParsedBodyLine => ({ kind: "metadata", raw });
+
+// ── emitTransaction() ────────────────────────────────────────────
+
+describe("emitTransaction()", () => {
+  test("should emit just the header for a transaction with an empty body", () => {
+    expect(emitTransaction(tx(), [], 0)).toBe("2026-03-15 * Payee");
+  });
+
+  test("should emit a single posting with the alignment column padding", () => {
+    // target 21 = 4 (indent) + 13 (Expenses:Food) + 0 (prefix) + 4 (MIN_GAP)
+    const body: ParsedBodyLine[] = [posting("    ", "Expenses:Food", "45.00 USD", 0, false)];
+    const expected = ["2026-03-15 * Payee", "    Expenses:Food    45.00 USD"].join("\n");
+    expect(emitTransaction(tx(), body, 21)).toBe(expected);
+  });
+
+  test("should emit a single posting with padding derived from MIN_AMOUNT_COLUMN=70", () => {
+    // target 70: padding = 70 - 4 - 13 - 0 = 53 spaces
+    const body: ParsedBodyLine[] = [posting("    ", "Expenses:Food", "45.00 USD", 0, false)];
+    const result = emitTransaction(tx(), body, 70);
+    const postingLine = result.split("\n").find((l) => l.includes("Expenses:Food"))!;
+    // First digit "4" of the amount lands at column 70 (0-indexed)
+    expect(postingLine.indexOf("4")).toBe(70);
+    expect(postingLine).toBe(`    Expenses:Food${" ".repeat(53)}45.00 USD`);
+  });
+
+  test("should put negative postings before positive postings (sign grouping)", () => {
+    const body: ParsedBodyLine[] = [
+      posting("    ", "Expenses:Food", "45.00 USD", 0, false),
+      posting("    ", "Assets:Checking", "-45.00 USD", 1, true),
+    ];
+    const result = emitTransaction(tx(), body, 24);
+    const checkingIdx = result.indexOf("Assets:Checking");
+    const foodIdx = result.indexOf("Expenses:Food");
+    expect(checkingIdx).toBeLessThan(foodIdx);
+  });
+
+  test("should put balancing postings last, after both sign groups", () => {
+    const body: ParsedBodyLine[] = [
+      balancing("    Assets:Savings"),
+      posting("    ", "Expenses:Food", "45.00 USD", 0, false),
+      posting("    ", "Assets:Checking", "-45.00 USD", 1, true),
+    ];
+    const result = emitTransaction(tx(), body, 24);
+    const lines = result.split("\n");
+    const savingsIdx = lines.findIndex((l) => l.includes("Assets:Savings"));
+    const foodIdx = lines.findIndex((l) => l.includes("Expenses:Food"));
+    const checkingIdx = lines.findIndex((l) => l.includes("Assets:Checking"));
+    expect(checkingIdx).toBeLessThan(foodIdx);
+    expect(foodIdx).toBeLessThan(savingsIdx);
+  });
+
+  test("should emit sorted tag-block after the header", () => {
+    const body: ParsedBodyLine[] = [
+      metadata("    ; weekly:"),
+      metadata("    ; groceries:"),
+      metadata("    ; source: manual"),
+      posting("    ", "Expenses:Food", "45.00 USD", 0, false),
+    ];
+    const result = emitTransaction(tx(), body, 21);
+    const lines = result.split("\n");
+    expect(lines[0]).toBe("2026-03-15 * Payee");
+    expect(lines[1]).toBe("    ; groceries:");
+    expect(lines[2]).toBe("    ; source: manual");
+    expect(lines[3]).toBe("    ; weekly:");
+  });
+
+  test("should split a comma-separated tag line into sorted individual lines", () => {
+    const body: ParsedBodyLine[] = [
+      metadata("    ; weekly:, groceries:"),
+      posting("    ", "Expenses:Food", "45.00 USD", 0, false),
+    ];
+    const result = emitTransaction(tx(), body, 21);
+    const lines = result.split("\n");
+    expect(lines[1]).toBe("    ; groceries:");
+    expect(lines[2]).toBe("    ; weekly:");
+  });
+
+  test("should emit preContent before the header with a blank-line separator", () => {
+    const body: ParsedBodyLine[] = [posting("    ", "Expenses:Food", "45.00 USD", 0, false)];
+    const result = emitTransaction(tx({ preContent: ["; section divider"] }), body, 21);
+    const lines = result.split("\n");
+    expect(lines[0]).toBe("; section divider");
+    expect(lines[1]).toBe("");
+    expect(lines[2]).toBe("2026-03-15 * Payee");
+  });
+
+  test("should keep non-tag trailing comments attached to their posting under sign grouping", () => {
+    // Expenses:Food (positive) has a trailing note. Assets:Checking is negative
+    // and should sort BEFORE Expenses:Food. The note should travel with Food.
+    const body: ParsedBodyLine[] = [
+      posting("    ", "Expenses:Food", "45.00 USD", 0, false),
+      metadata("    ; note about food"),
+      posting("    ", "Assets:Checking", "-45.00 USD", 1, true),
+    ];
+    const result = emitTransaction(tx(), body, 24);
+    const lines = result.split("\n");
+    const foodIdx = lines.findIndex((l) => l.includes("Expenses:Food"));
+    const noteIdx = lines.findIndex((l) => l.includes("; note about food"));
+    expect(noteIdx).toBe(foodIdx + 1);
+  });
+});
+
+// ── assembleOutput() ─────────────────────────────────────────────
+
+describe("assembleOutput()", () => {
+  test("should join transactions with a single blank line between them", () => {
+    expect(assembleOutput([], ["tx1 line1\ntx1 line2", "tx2 line1"], [], false)).toBe(
+      "tx1 line1\ntx1 line2\n\ntx2 line1",
+    );
+  });
+
+  test("should prepend leading content with a blank-line separator before transactions", () => {
+    expect(assembleOutput(["; top note"], ["2026-01-01 * A"], [], false)).toBe("; top note\n\n2026-01-01 * A");
+  });
+
+  test("should append trailing content with a blank-line separator after transactions", () => {
+    expect(assembleOutput([], ["2026-01-01 * A"], ["; footer"], false)).toBe("2026-01-01 * A\n\n; footer");
+  });
+
+  test("should add a trailing newline when hadTrailingNewline is true", () => {
+    expect(assembleOutput([], ["2026-01-01 * A"], [], true)).toBe("2026-01-01 * A\n");
+  });
+
+  test("should omit a trailing newline when hadTrailingNewline is false", () => {
+    expect(assembleOutput([], ["2026-01-01 * A"], [], false)).toBe("2026-01-01 * A");
+  });
+
+  test("should handle leading + transactions + trailing + newline all together", () => {
+    expect(assembleOutput(["; top"], ["2026-01-01 * A"], ["; bottom"], true)).toBe(
+      "; top\n\n2026-01-01 * A\n\n; bottom\n",
+    );
+  });
+
+  test("should handle multiple leading lines joined with \\n", () => {
+    expect(assembleOutput(["; one", "; two"], ["2026-01-01 * A"], [], false)).toBe("; one\n; two\n\n2026-01-01 * A");
+  });
+});
+
+// ── assembleWithoutTransactions() ────────────────────────────────
+
+describe("assembleWithoutTransactions()", () => {
+  test("should return the original content when leading is empty", () => {
+    const original = "some content\n";
+    expect(assembleWithoutTransactions([], true, original)).toBe(original);
+  });
+
+  test("should emit leading lines joined by \\n when there is leading content", () => {
+    expect(assembleWithoutTransactions(["; one", "; two"], false, "ignored")).toBe("; one\n; two");
+  });
+
+  test("should append a trailing newline to the emitted leading content", () => {
+    expect(assembleWithoutTransactions(["; one"], true, "ignored")).toBe("; one\n");
+  });
+
+  test("should not append a trailing newline when hadTrailingNewline is false", () => {
+    expect(assembleWithoutTransactions(["; one"], false, "ignored")).toBe("; one");
+  });
+});

--- a/src/extension/data/format/__tests__/index.test.ts
+++ b/src/extension/data/format/__tests__/index.test.ts
@@ -1,0 +1,105 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Mock `../../../hledger` before importing `ledgerFormat` so the real
+// hledger CLI is never invoked. The mock lets tests control the file list
+// and whether the call throws.
+let mockFiles: string[] = [];
+let mockThrows: Error | null = null;
+const hledgerFilesCalls: Array<{ mainPath: string; opts?: unknown }> = [];
+
+mock.module("../../../hledger.js", () => ({
+  hledgerFiles: async (mainPath: string, opts?: unknown) => {
+    hledgerFilesCalls.push({ mainPath, opts });
+    if (mockThrows) throw mockThrows;
+    return mockFiles;
+  },
+}));
+
+const { ledgerFormat } = await import("../index");
+
+const BASE = mkdtempSync(join(tmpdir(), "ledger-format-"));
+
+afterAll(() => {
+  rmSync(BASE, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  mockFiles = [];
+  mockThrows = null;
+  hledgerFilesCalls.length = 0;
+});
+
+describe("ledgerFormat()", () => {
+  test("should call hledgerFiles with the main path", async () => {
+    await ledgerFormat("/tmp/main.journal");
+    expect(hledgerFilesCalls).toHaveLength(1);
+    expect(hledgerFilesCalls[0].mainPath).toBe("/tmp/main.journal");
+  });
+
+  test("should forward opts (cwd, signal) to hledgerFiles", async () => {
+    const signal = new AbortController().signal;
+    await ledgerFormat("/tmp/main.journal", { cwd: "/tmp", signal });
+    expect(hledgerFilesCalls[0].opts).toEqual({ cwd: "/tmp", signal });
+  });
+
+  test("should format every file returned by hledgerFiles", async () => {
+    const path1 = join(BASE, "a.journal");
+    const path2 = join(BASE, "b.journal");
+    writeFileSync(
+      path1,
+      [
+        "2026-01-10 * Later",
+        "    Expenses:Food    1.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-01-01 * Earlier",
+        "    Expenses:Food    2.00 USD",
+        "    Assets:Checking",
+      ].join("\n"),
+    );
+    writeFileSync(path2, "2026-03-01 * Single\n    Expenses:Food    3.00 USD\n    Assets:Checking\n");
+    mockFiles = [path1, path2];
+
+    await ledgerFormat("/tmp/main.journal");
+
+    // path1 was sorted (Earlier before Later)
+    const after1 = readFileSync(path1, "utf-8");
+    expect(after1.indexOf("Earlier")).toBeLessThan(after1.indexOf("Later"));
+    // path2 stays valid (single transaction, no reordering)
+    const after2 = readFileSync(path2, "utf-8");
+    expect(after2).toContain("Single");
+  });
+
+  test("should be a silent no-op when hledgerFiles throws", async () => {
+    const path = join(BASE, "broken.journal");
+    const original =
+      "2026-01-10 * Later\n    Expenses:Food  1.00 USD\n    Assets:Checking\n\n2026-01-01 * Earlier\n    Expenses:Food  2.00 USD\n    Assets:Checking\n";
+    writeFileSync(path, original);
+    mockThrows = new Error("hledger parse error");
+
+    await expect(ledgerFormat("/tmp/main.journal")).resolves.toBeUndefined();
+
+    // File is untouched (still out of order)
+    expect(readFileSync(path, "utf-8")).toBe(original);
+  });
+
+  test("should handle an empty file list", async () => {
+    mockFiles = [];
+    await expect(ledgerFormat("/tmp/main.journal")).resolves.toBeUndefined();
+  });
+
+  test("should tolerate a listed file that no longer exists", async () => {
+    const missing = join(BASE, "gone.journal");
+    const present = join(BASE, "present.journal");
+    writeFileSync(present, "2026-01-01 * X\n    Expenses:Food    1.00 USD\n    Assets:Checking\n");
+    // missing is intentionally not created
+    mockFiles = [missing, present];
+
+    // Should not throw; the present file should still be processed.
+    await expect(ledgerFormat("/tmp/main.journal")).resolves.toBeUndefined();
+    expect(readFileSync(present, "utf-8")).toContain("Expenses:Food");
+  });
+});

--- a/src/extension/data/format/__tests__/parse.test.ts
+++ b/src/extension/data/format/__tests__/parse.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, test } from "bun:test";
+import {
+  extractLeadingLines,
+  findTransactionHeaders,
+  parseContent,
+  parsePostingLine,
+  parseTransactions,
+  sortTransactionsByDate,
+} from "../parse";
+import type { Transaction } from "../types";
+
+describe("parseContent()", () => {
+  test("should return a single empty-string line for empty input (split('\\n') semantics)", () => {
+    // Note: formatJournalContent short-circuits on empty input before calling parseContent.
+    expect(parseContent("")).toEqual({ lines: [""], hadTrailingNewline: false });
+  });
+
+  test("should detect trailing newline and drop the trailing empty string", () => {
+    expect(parseContent("a\nb\n")).toEqual({ lines: ["a", "b"], hadTrailingNewline: true });
+  });
+
+  test("should detect absence of trailing newline", () => {
+    expect(parseContent("a\nb")).toEqual({ lines: ["a", "b"], hadTrailingNewline: false });
+  });
+
+  test("should normalize CRLF to LF", () => {
+    expect(parseContent("a\r\nb\r\n")).toEqual({ lines: ["a", "b"], hadTrailingNewline: true });
+  });
+
+  test("should handle a single line without trailing newline", () => {
+    expect(parseContent("only one")).toEqual({ lines: ["only one"], hadTrailingNewline: false });
+  });
+
+  test("should preserve internal blank lines", () => {
+    expect(parseContent("a\n\nb\n")).toEqual({ lines: ["a", "", "b"], hadTrailingNewline: true });
+  });
+});
+
+describe("findTransactionHeaders()", () => {
+  test("should return empty array when there are no date headers", () => {
+    expect(findTransactionHeaders(["; comment", "  Assets:Cash", ""])).toEqual([]);
+  });
+
+  test("should find all date-header line indices", () => {
+    const lines = ["2026-01-01 * A", "    posting", "", "2026-02-15 * B", "    posting"];
+    expect(findTransactionHeaders(lines)).toEqual([0, 3]);
+  });
+
+  test("should accept slash-separated dates", () => {
+    expect(findTransactionHeaders(["2026/03/05 * A"])).toEqual([0]);
+  });
+
+  test("should accept dot-separated dates", () => {
+    expect(findTransactionHeaders(["2026.03.05 * A"])).toEqual([0]);
+  });
+
+  test("should not match indented date-like lines", () => {
+    expect(findTransactionHeaders(["    2026-01-01 * A"])).toEqual([]);
+  });
+
+  test("should not match dates inside the middle of a line", () => {
+    expect(findTransactionHeaders(["foo 2026-01-01"])).toEqual([]);
+  });
+});
+
+describe("extractLeadingLines()", () => {
+  test("should return everything up to `until`", () => {
+    const lines = ["; one", "; two", "2026-01-01 * A"];
+    expect(extractLeadingLines(lines, 2)).toEqual(["; one", "; two"]);
+  });
+
+  test("should strip trailing blank lines", () => {
+    const lines = ["; one", "", "", "2026-01-01 * A"];
+    expect(extractLeadingLines(lines, 3)).toEqual(["; one"]);
+  });
+
+  test("should return empty array when until is 0", () => {
+    expect(extractLeadingLines(["a", "b"], 0)).toEqual([]);
+  });
+
+  test("should return everything when until equals length", () => {
+    expect(extractLeadingLines(["; one", "; two"], 2)).toEqual(["; one", "; two"]);
+  });
+
+  test("should return empty array for an all-blank leading region", () => {
+    expect(extractLeadingLines(["", "", ""], 3)).toEqual([]);
+  });
+});
+
+describe("parsePostingLine()", () => {
+  test("should classify a non-indented line as 'other'", () => {
+    expect(parsePostingLine("2026-01-01 * A")).toEqual({ kind: "other", raw: "2026-01-01 * A" });
+  });
+
+  test("should classify an indented ';' line as metadata", () => {
+    expect(parsePostingLine("    ; tag: value")).toEqual({ kind: "metadata", raw: "    ; tag: value" });
+  });
+
+  test("should classify an indented '#' line as metadata", () => {
+    expect(parsePostingLine("    # hash")).toEqual({ kind: "metadata", raw: "    # hash" });
+  });
+
+  test("should classify an indented account-only line as balancing", () => {
+    expect(parsePostingLine("    Assets:Checking")).toEqual({ kind: "balancing", raw: "    Assets:Checking" });
+  });
+
+  test("should parse a posting line with amount and mark unsigned as positive", () => {
+    const result = parsePostingLine("    Expenses:Food    45.00 USD");
+    expect(result).toEqual({
+      kind: "posting",
+      indent: "    ",
+      account: "Expenses:Food",
+      amount: "45.00 USD",
+      digitsPrefixLength: 0,
+      isNegative: false,
+    });
+  });
+
+  test("should mark a posting with a leading '-' as negative", () => {
+    const result = parsePostingLine("    Assets:Checking    -45.00 USD");
+    expect(result).toMatchObject({ kind: "posting", isNegative: true, digitsPrefixLength: 1 });
+  });
+
+  test("should mark 'EUR -45.00' as negative and compute prefix length 5", () => {
+    const result = parsePostingLine("    Assets:Checking    EUR -45.00");
+    expect(result).toMatchObject({ kind: "posting", amount: "EUR -45.00", digitsPrefixLength: 5, isNegative: true });
+  });
+
+  test("should mark 'EUR 45.00' as positive and compute prefix length 4", () => {
+    const result = parsePostingLine("    Assets:Checking    EUR 45.00");
+    expect(result).toMatchObject({ kind: "posting", digitsPrefixLength: 4, isNegative: false });
+  });
+
+  test("should mark '$-45.00' as negative and compute prefix length 2", () => {
+    const result = parsePostingLine("    Assets:Checking    $-45.00");
+    expect(result).toMatchObject({ kind: "posting", digitsPrefixLength: 2, isNegative: true });
+  });
+
+  test("should mark '+45.00 USD' as positive", () => {
+    const result = parsePostingLine("    Expenses:Food    +45.00 USD");
+    expect(result).toMatchObject({ kind: "posting", isNegative: false });
+  });
+
+  test("should set digitsPrefixLength = amount.length for a no-digit amount", () => {
+    // Covers the `idx === -1` branch in getDigitsPrefixLength.
+    const result = parsePostingLine("    Account    EUR");
+    expect(result).toMatchObject({ kind: "posting", amount: "EUR", digitsPrefixLength: 3, isNegative: false });
+  });
+
+  test("should accept tab as account/amount separator", () => {
+    const result = parsePostingLine("    Expenses:Food\t45.00 USD");
+    expect(result).toMatchObject({ kind: "posting", account: "Expenses:Food", amount: "45.00 USD" });
+  });
+
+  test("should trim trailing whitespace from the amount", () => {
+    const result = parsePostingLine("    Expenses:Food    45.00 USD   ");
+    expect(result).toMatchObject({ kind: "posting", amount: "45.00 USD" });
+  });
+
+  test("should preserve inline trailing ';' comment as part of the amount", () => {
+    const result = parsePostingLine("    Expenses:Food    45.00 USD ; note");
+    expect(result).toMatchObject({ kind: "posting", amount: "45.00 USD ; note" });
+  });
+
+  test("should preserve the original indent (tabs or spaces) verbatim", () => {
+    const result = parsePostingLine("\t\tExpenses:Food  45.00 USD");
+    expect(result).toMatchObject({ kind: "posting", indent: "\t\t" });
+  });
+});
+
+describe("parseTransactions()", () => {
+  test("should build a transaction from a header followed by indented body", () => {
+    const lines = ["2026-01-01 * A", "    Expenses:Food    10.00 USD", "    Assets:Checking"];
+    const result = parseTransactions(lines, [0]);
+    expect(result.transactions).toHaveLength(1);
+    expect(result.transactions[0]).toEqual({
+      date: "2026-01-01",
+      header: "2026-01-01 * A",
+      body: ["    Expenses:Food    10.00 USD", "    Assets:Checking"],
+      preContent: [],
+    });
+    expect(result.trailingContent).toEqual([]);
+  });
+
+  test("should attach non-indented content between txs to the NEXT tx as preContent", () => {
+    const lines = [
+      "2026-01-01 * A",
+      "    Expenses:Food    10.00 USD",
+      "    Assets:Checking",
+      "",
+      "; section divider",
+      "",
+      "2026-01-02 * B",
+      "    Expenses:Food    20.00 USD",
+      "    Assets:Checking",
+    ];
+    const result = parseTransactions(lines, [0, 6]);
+    expect(result.transactions[0].preContent).toEqual([]);
+    expect(result.transactions[1].preContent).toEqual(["; section divider"]);
+  });
+
+  test("should place loose content after the last tx into trailingContent", () => {
+    const lines = ["2026-01-01 * A", "    Expenses:Food    10.00 USD", "    Assets:Checking", "", "; trailing note"];
+    const result = parseTransactions(lines, [0]);
+    expect(result.trailingContent).toEqual(["; trailing note"]);
+  });
+
+  test("should handle a header with no body", () => {
+    const lines = ["2026-01-01 * Orphan", "", "2026-01-02 * With body", "    Expenses:Food    1.00 USD"];
+    const result = parseTransactions(lines, [0, 2]);
+    expect(result.transactions[0].body).toEqual([]);
+    expect(result.transactions[1].body).toEqual(["    Expenses:Food    1.00 USD"]);
+  });
+
+  test("should derive the date from the header regex", () => {
+    const lines = ["2026-03-15 * Payee", "    Expenses:Food    1.00 USD"];
+    const result = parseTransactions(lines, [0]);
+    expect(result.transactions[0].date).toBe("2026-03-15");
+  });
+
+  test("should normalize non-standard date separators to '-' in the sort key", () => {
+    const lines = ["2026/03/15 * Payee", "    Expenses:Food    1.00 USD"];
+    const result = parseTransactions(lines, [0]);
+    expect(result.transactions[0].date).toBe("2026-03-15");
+  });
+});
+
+describe("sortTransactionsByDate()", () => {
+  const makeTx = (date: string, header: string): Transaction => ({ date, header, body: [], preContent: [] });
+
+  test("should sort transactions ascending by date", () => {
+    const txs = [makeTx("2026-03-28", "Later"), makeTx("2026-01-05", "Earliest"), makeTx("2026-02-10", "Middle")];
+    sortTransactionsByDate(txs);
+    expect(txs.map((t) => t.date)).toEqual(["2026-01-05", "2026-02-10", "2026-03-28"]);
+  });
+
+  test("should be stable for same-date transactions", () => {
+    const txs = [makeTx("2026-03-15", "First"), makeTx("2026-03-15", "Second"), makeTx("2026-03-15", "Third")];
+    sortTransactionsByDate(txs);
+    expect(txs.map((t) => t.header)).toEqual(["First", "Second", "Third"]);
+  });
+
+  test("should sort in place (mutate the array)", () => {
+    const txs = [makeTx("2026-02-01", "B"), makeTx("2026-01-01", "A")];
+    const returned = sortTransactionsByDate(txs);
+    expect(returned).toBeUndefined();
+    expect(txs[0].header).toBe("A");
+  });
+});

--- a/src/extension/data/format/__tests__/pipeline.test.ts
+++ b/src/extension/data/format/__tests__/pipeline.test.ts
@@ -1,0 +1,872 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { formatJournalContent, formatJournalFile } from "../pipeline";
+
+const FILE_BASE = mkdtempSync(join(tmpdir(), "format-file-"));
+
+afterAll(() => {
+  rmSync(FILE_BASE, { recursive: true, force: true });
+});
+
+// Builds a formatted posting line with first-digit at column 70 (MIN_AMOUNT_COLUMN).
+// Shorthand for tests: `p("    ", "Expenses:Food", "45.00 USD")`.
+// prefixLen is the number of chars before the first digit in `amount`
+// (e.g., 1 for "-45.00 USD", 0 for "45.00 USD").
+const p = (indent: string, account: string, amount: string, prefixLen = 0): string => {
+  const padding = 70 - indent.length - account.length - prefixLen;
+  return `${indent}${account}${" ".repeat(padding)}${amount}`;
+};
+
+describe("formatJournalContent()", () => {
+  describe("sorting", () => {
+    test("should sort transactions by date ascending", () => {
+      const input = [
+        "2026-03-28 * Later",
+        "    Expenses:Misc    10.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-03-01 * Earlier",
+        "    Expenses:Misc    5.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const expected = [
+        "2026-03-01 * Earlier",
+        p("    ", "Expenses:Misc", "5.00 USD"),
+        "    Assets:Checking",
+        "",
+        "2026-03-28 * Later",
+        p("    ", "Expenses:Misc", "10.00 USD"),
+        "    Assets:Checking",
+      ].join("\n");
+      expect(formatJournalContent(input)).toBe(expected);
+    });
+
+    test("should preserve original order for transactions with the same date (stable sort)", () => {
+      const input = [
+        "2026-03-15 * First",
+        "    Expenses:Misc    1.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-03-15 * Second",
+        "    Expenses:Misc    2.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-03-15 * Third",
+        "    Expenses:Misc    3.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = formatJournalContent(input);
+      const firstIdx = result.indexOf("* First");
+      const secondIdx = result.indexOf("* Second");
+      const thirdIdx = result.indexOf("* Third");
+      expect(firstIdx).toBeGreaterThanOrEqual(0);
+      expect(secondIdx).toBeGreaterThan(firstIdx);
+      expect(thirdIdx).toBeGreaterThan(secondIdx);
+    });
+
+    test("should sort across three transactions with mixed dates", () => {
+      const input = [
+        "2026-03-20 * B",
+        "    Expenses:Misc    2.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-03-10 * A",
+        "    Expenses:Misc    1.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-03-30 * C",
+        "    Expenses:Misc    3.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = formatJournalContent(input);
+      const aIdx = result.indexOf("* A");
+      const bIdx = result.indexOf("* B");
+      const cIdx = result.indexOf("* C");
+      expect(aIdx).toBeLessThan(bIdx);
+      expect(bIdx).toBeLessThan(cIdx);
+    });
+  });
+
+  describe("per-file alignment", () => {
+    test("should align amounts to a column derived from MIN_AMOUNT_COLUMN when all accounts are short", () => {
+      const input = [
+        "2026-03-01 * A",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-03-02 * B",
+        "    Expenses:Transport:PublicTransit    10.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      // Widest account: "Expenses:Transport:PublicTransit" = 32 chars
+      // widestEnd = 4 + 32 + 0 = 36, + MIN_GAP(4) = 40 < 70 → clamped to 70.
+      // Expenses:Food padding                    = 70 - 4 - 13 = 53
+      // Expenses:Transport:PublicTransit padding = 70 - 4 - 32 = 34
+      const expected = [
+        "2026-03-01 * A",
+        p("    ", "Expenses:Food", "45.00 USD"),
+        "    Assets:Checking",
+        "",
+        "2026-03-02 * B",
+        p("    ", "Expenses:Transport:PublicTransit", "10.00 USD"),
+        "    Assets:Checking",
+      ].join("\n");
+      expect(formatJournalContent(input)).toBe(expected);
+    });
+
+    test("should push amounts out to MIN_AMOUNT_COLUMN=70 even for the widest account in a short file", () => {
+      const input = ["2026-03-01 * A", "    Expenses:Transport:PublicTransit    10.00 USD", "    Assets:Checking"].join(
+        "\n",
+      );
+      const result = formatJournalContent(input);
+      // Widest posting's first digit lands at column 70 (0-indexed).
+      const line = result.split("\n").find((l) => l.includes("10.00 USD"))!;
+      expect(line.indexOf("1")).toBe(70);
+    });
+
+    test("should not add padding to balancing postings (no amount)", () => {
+      const input = ["2026-03-01 * A", "    Expenses:Transport:PublicTransit    10.00 USD", "    Assets:Checking"].join(
+        "\n",
+      );
+      const result = formatJournalContent(input);
+      // Balancing posting emitted verbatim: indent + account, no trailing padding
+      expect(result).toContain("\n    Assets:Checking");
+      expect(result).not.toContain("    Assets:Checking    ");
+    });
+
+    test("should align all postings within a transaction when they have different account widths", () => {
+      const input = ["2026-03-01 * A", "    Expenses:Food    45.00 USD", "    Assets:Checking    -45.00 USD"].join(
+        "\n",
+      );
+      // Widest candidate:
+      //   Expenses:Food    → 4 + 13 + 0 = 17
+      //   Assets:Checking  → 4 + 15 + 1 = 20  (prefix "-" has length 1)
+      // widestEnd + MIN_GAP = 24 < 70 → clamped to 70.
+      // Padding:
+      //   Expenses:Food    → 70 - 4 - 13 - 0 = 53
+      //   Assets:Checking  → 70 - 4 - 15 - 1 = 50
+      // Order: negative postings first, then positive.
+      const expected = [
+        "2026-03-01 * A",
+        p("    ", "Assets:Checking", "-45.00 USD", 1),
+        p("    ", "Expenses:Food", "45.00 USD"),
+      ].join("\n");
+      expect(formatJournalContent(input)).toBe(expected);
+    });
+
+    test("should align negative and positive amounts on the first digit (sign sticks out left)", () => {
+      // User's real case: "-111.00 EUR" and "111.00 EUR" should have their "1"s in the same column,
+      // with the "-" one column to the left.
+      const input = [
+        "2026-01-17 * Knuspr",
+        "    assets:volo:mono:eur    -111.00 EUR",
+        "    expenses:food:groceries    111.00 EUR",
+      ].join("\n");
+      // Widest candidate: expenses:food:groceries → 4 + 23 + 0 = 27, clamped to 70.
+      // Padding:
+      //   assets:volo:mono:eur     → 70 - 4 - 20 - 1 = 45
+      //   expenses:food:groceries  → 70 - 4 - 23 - 0 = 43
+      const expected = [
+        "2026-01-17 * Knuspr",
+        p("    ", "assets:volo:mono:eur", "-111.00 EUR", 1),
+        p("    ", "expenses:food:groceries", "111.00 EUR"),
+      ].join("\n");
+      const result = formatJournalContent(input);
+      expect(result).toBe(expected);
+      // Sanity: both first digits land at column 70
+      const lines = result.split("\n");
+      const negLine = lines.find((l) => l.includes("-111.00"))!;
+      const posLine = lines.find((l) => l.includes("expenses:food:groceries"))!;
+      const negFirstDigit = negLine.indexOf("1");
+      const posFirstDigit = posLine.indexOf("111.00");
+      expect(negFirstDigit).toBe(70);
+      expect(posFirstDigit).toBe(70);
+    });
+  });
+
+  describe("preservation — amounts", () => {
+    test("should preserve negative amount verbatim: -45.00 USD", () => {
+      const input = ["2026-03-15 * A", "    Expenses:Food    -45.00 USD", "    Assets:Checking"].join("\n");
+      expect(formatJournalContent(input)).toContain("-45.00 USD");
+    });
+
+    test("should preserve currency-first amount verbatim: EUR -45.00", () => {
+      const input = ["2026-03-15 * A", "    Expenses:Food    EUR -45.00", "    Assets:Checking"].join("\n");
+      expect(formatJournalContent(input)).toContain("EUR -45.00");
+    });
+
+    test("should preserve dollar sign amount verbatim: $45.00", () => {
+      const input = ["2026-03-15 * A", "    Expenses:Food    $45.00", "    Assets:Checking"].join("\n");
+      expect(formatJournalContent(input)).toContain("$45.00");
+    });
+
+    test("should preserve thousand separators in amount verbatim: 1,000.00 USD", () => {
+      const input = ["2026-03-15 * A", "    Expenses:Food    1,000.00 USD", "    Assets:Checking"].join("\n");
+      expect(formatJournalContent(input)).toContain("1,000.00 USD");
+    });
+
+    test("should preserve balance assertion verbatim", () => {
+      const input = ["2026-03-15 * A", "    Assets:Checking    100.00 USD = 500.00 USD", "    Assets:Savings"].join(
+        "\n",
+      );
+      expect(formatJournalContent(input)).toContain("100.00 USD = 500.00 USD");
+    });
+
+    test("should preserve inline trailing ';' comment on a posting verbatim", () => {
+      const input = ["2026-03-15 * A", "    Expenses:Food    45.00 USD ; inline note", "    Assets:Checking"].join(
+        "\n",
+      );
+      expect(formatJournalContent(input)).toContain("45.00 USD ; inline note");
+    });
+  });
+
+  describe("preservation — structure", () => {
+    test("should preserve transaction header with status, code, and narration", () => {
+      const input = [
+        "2026-03-15 * (CODE-1) Whole Foods | Groceries trip",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      expect(formatJournalContent(input)).toContain("2026-03-15 * (CODE-1) Whole Foods | Groceries trip");
+    });
+
+    test("should preserve pending (!) status flag in header", () => {
+      const input = ["2026-03-15 ! Payee | Pending", "    Expenses:Food    45.00 USD", "    Assets:Checking"].join(
+        "\n",
+      );
+      expect(formatJournalContent(input)).toContain("2026-03-15 ! Payee | Pending");
+    });
+
+    test("should preserve ';' metadata comment lines inside a transaction verbatim", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    ; related_file: foo.pdf",
+        "    ; tag: value",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = formatJournalContent(input);
+      expect(result).toContain("    ; related_file: foo.pdf");
+      expect(result).toContain("    ; tag: value");
+    });
+
+    test("should not produce any indented '#' comment lines", () => {
+      // Regression for the user's reported error: indented '#' is invalid
+      // hledger syntax and causes "multi-commodity transaction is unbalanced".
+      const input = [
+        "2026-01-02 * Berliner Verkehrsbetriebe (BVG) | Abo Sollstellung",
+        "    ; mck_transportation_refund:",
+        "    ; related_file: files/2026/04/foo.pdf",
+        "    assets:volo:n26                    -63.00 EUR",
+        "    expenses:transport:public-transit    63.00 EUR",
+      ].join("\n");
+      const result = formatJournalContent(input);
+      // No line in the output starts with indented '#'
+      expect(result.split("\n").some((l) => /^\s+#/.test(l))).toBe(false);
+      // Metadata comments are preserved as ';'
+      expect(result).toContain("    ; mck_transportation_refund:");
+      expect(result).toContain("    ; related_file: files/2026/04/foo.pdf");
+    });
+
+    test("should preserve top-level ';' comments at the start of the file", () => {
+      const input = [
+        "; top-level note",
+        "; another top note",
+        "",
+        "2026-03-15 * Payee",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = formatJournalContent(input);
+      expect(result).toContain("; top-level note");
+      expect(result).toContain("; another top note");
+      expect(result.indexOf("; top-level note")).toBeLessThan(result.indexOf("2026-03-15"));
+    });
+
+    test("should preserve the original indent width of a posting line (2 spaces)", () => {
+      const input = ["2026-03-15 * A", "  Expenses:Food    45.00 USD", "  Assets:Checking"].join("\n");
+      // 2-space indent + Expenses:Food (13) + 0 prefix = 15, clamped to 70.
+      // Padding = 70 - 2 - 13 = 55
+      const expected = ["2026-03-15 * A", p("  ", "Expenses:Food", "45.00 USD"), "  Assets:Checking"].join("\n");
+      expect(formatJournalContent(input)).toBe(expected);
+    });
+
+    test("should preserve the original indent width of a posting line (6 spaces)", () => {
+      const input = ["2026-03-15 * A", "      Expenses:Food    45.00 USD", "      Assets:Checking"].join("\n");
+      // 6-space indent + 13 + 0 = 19, clamped to 70. Padding = 70 - 6 - 13 = 51.
+      const expected = ["2026-03-15 * A", p("      ", "Expenses:Food", "45.00 USD"), "      Assets:Checking"].join(
+        "\n",
+      );
+      expect(formatJournalContent(input)).toBe(expected);
+    });
+
+    test("should normalize tab separator to spaces (the one thing we do touch)", () => {
+      const input = `2026-03-15 * A\n    Expenses:Food\t45.00 USD\n    Assets:Checking`;
+      const result = formatJournalContent(input);
+      // Tab between account and amount gets replaced by alignment padding
+      expect(result).toContain(p("    ", "Expenses:Food", "45.00 USD"));
+      expect(result).not.toContain("\t");
+    });
+  });
+
+  describe("idempotency", () => {
+    test("should produce identical output when run twice", () => {
+      const input = [
+        "2026-03-28 * Later",
+        "    Expenses:Transport:PublicTransit    63.00 EUR",
+        "    Assets:Checking",
+        "",
+        "2026-03-01 * Earlier",
+        "    Expenses:Food    -55.08 EUR",
+        "    Assets:Checking",
+      ].join("\n");
+      const first = formatJournalContent(input);
+      const second = formatJournalContent(first);
+      expect(second).toBe(first);
+    });
+
+    test("should be a no-op on an already sorted and aligned file", () => {
+      // Input is pre-aligned to column 70, so formatting is a no-op.
+      const input = [
+        "2026-03-01 * A",
+        p("    ", "Expenses:Transport:PublicTransit", "10.00 USD"),
+        "    Assets:Checking",
+        "",
+        "2026-03-02 * B",
+        p("    ", "Expenses:Transport:PublicTransit", "20.00 USD"),
+        "    Assets:Checking",
+      ].join("\n");
+      expect(formatJournalContent(input)).toBe(input);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("should return empty string for empty input", () => {
+      expect(formatJournalContent("")).toBe("");
+    });
+
+    test("should preserve ';' comments in a file with no transactions", () => {
+      const input = "; just a comment\n";
+      expect(formatJournalContent(input)).toBe(input);
+    });
+
+    test("should preserve ';' comments in a file with only leading comments", () => {
+      const input = "; one\n; two\n; three\n";
+      expect(formatJournalContent(input)).toBe(input);
+    });
+
+    test("should preserve '#' comments in a file with no transactions", () => {
+      const input = "# top-level hash comment\n";
+      expect(formatJournalContent(input)).toBe(input);
+    });
+
+    test("should preserve trailing newline when present in input", () => {
+      const input = ["2026-03-15 * A", "    Expenses:Food    45.00 USD", "    Assets:Checking", ""].join("\n");
+      const result = formatJournalContent(input);
+      expect(result.endsWith("\n")).toBe(true);
+    });
+
+    test("should preserve trailing newline absence when input has none", () => {
+      const input = ["2026-03-15 * A", "    Expenses:Food    45.00 USD", "    Assets:Checking"].join("\n");
+      const result = formatJournalContent(input);
+      expect(result.endsWith("\n")).toBe(false);
+    });
+
+    test("should normalize CRLF line endings to LF", () => {
+      const input = "2026-03-15 * A\r\n    Expenses:Food    45.00 USD\r\n    Assets:Checking\r\n";
+      const result = formatJournalContent(input);
+      expect(result).not.toContain("\r");
+      expect(result).toContain("\n");
+    });
+
+    test("should handle a single transaction file as a no-op when already aligned to MIN_AMOUNT_COLUMN", () => {
+      const input = `2026-03-15 * A\n${p("    ", "Expenses:Food", "45.00 USD")}\n    Assets:Checking\n`;
+      expect(formatJournalContent(input)).toBe(input);
+    });
+
+    test("should handle a transaction with no postings (just a header)", () => {
+      const input =
+        "2026-03-15 * Orphan header\n\n2026-03-16 * With postings\n    Expenses:Food    45.00 USD\n    Assets:Checking\n";
+      // Should not crash; orphan header is preserved
+      const result = formatJournalContent(input);
+      expect(result).toContain("2026-03-15 * Orphan header");
+      expect(result).toContain("2026-03-16 * With postings");
+    });
+
+    test("should handle a transaction with only balancing postings (no amounts anywhere)", () => {
+      const input = "2026-03-15 * A\n    Assets:Checking\n    Assets:Savings\n";
+      // No postings with amounts → no alignment computation, body preserved verbatim
+      expect(formatJournalContent(input)).toBe(input);
+    });
+
+    test("should collapse multiple blank lines between transactions to exactly one", () => {
+      const input = [
+        "2026-03-01 * A",
+        "    Expenses:Food    1.00 USD",
+        "    Assets:Checking",
+        "",
+        "",
+        "",
+        "2026-03-02 * B",
+        "    Expenses:Food    2.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const expected = [
+        "2026-03-01 * A",
+        p("    ", "Expenses:Food", "1.00 USD"),
+        "    Assets:Checking",
+        "",
+        "2026-03-02 * B",
+        p("    ", "Expenses:Food", "2.00 USD"),
+        "    Assets:Checking",
+      ].join("\n");
+      expect(formatJournalContent(input)).toBe(expected);
+    });
+  });
+
+  describe("within-transaction ordering — tags", () => {
+    test("should split a comma-separated tag line into individual tag lines", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    ; groceries:, weekly:",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = formatJournalContent(input);
+      expect(result).toContain("    ; groceries:");
+      expect(result).toContain("    ; weekly:");
+      expect(result).not.toContain("    ; groceries:, weekly:");
+    });
+
+    test("should sort tag lines alphabetically", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    ; weekly:",
+        "    ; source: manual",
+        "    ; groceries:",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = formatJournalContent(input);
+      // Expected alphabetical order: groceries:, source: manual, weekly:
+      const groceriesIdx = result.indexOf("; groceries:");
+      const sourceIdx = result.indexOf("; source: manual");
+      const weeklyIdx = result.indexOf("; weekly:");
+      expect(groceriesIdx).toBeGreaterThanOrEqual(0);
+      expect(sourceIdx).toBeGreaterThan(groceriesIdx);
+      expect(weeklyIdx).toBeGreaterThan(sourceIdx);
+    });
+
+    test("should emit the sorted tag block immediately after the transaction header", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    ; groceries:, weekly:",
+        "    ; source: manual",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const expected = [
+        "2026-03-15 * Payee",
+        "    ; groceries:",
+        "    ; source: manual",
+        "    ; weekly:",
+        p("    ", "Expenses:Food", "45.00 USD"),
+        "    Assets:Checking",
+      ].join("\n");
+      expect(formatJournalContent(input)).toBe(expected);
+    });
+
+    test('should treat "; key: value" metadata lines as tags', () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    ; source: manual",
+        "    ; related_file: foo.pdf",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = formatJournalContent(input);
+      // Both are "tags" (contain ':'), should be sorted alphabetically: related_file before source
+      const relatedIdx = result.indexOf("; related_file:");
+      const sourceIdx = result.indexOf("; source:");
+      expect(relatedIdx).toBeGreaterThanOrEqual(0);
+      expect(sourceIdx).toBeGreaterThan(relatedIdx);
+    });
+
+    test("should NOT split a comment line whose parts don't all contain ':'", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    ; just a random note, with a comma",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = formatJournalContent(input);
+      expect(result).toContain("    ; just a random note, with a comma");
+    });
+
+    test("should leave non-tag comment lines in their original relative order at the header", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    ; first note",
+        "    ; second note",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = formatJournalContent(input);
+      const firstIdx = result.indexOf("; first note");
+      const secondIdx = result.indexOf("; second note");
+      expect(firstIdx).toBeGreaterThanOrEqual(0);
+      expect(secondIdx).toBeGreaterThan(firstIdx);
+    });
+
+    test("should pull a tag line that appeared between postings up into the header tag block", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    Expenses:Food    45.00 USD",
+        "    ; tag: interleaved",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = formatJournalContent(input);
+      const tagIdx = result.indexOf("; tag: interleaved");
+      const foodIdx = result.indexOf("Expenses:Food");
+      expect(tagIdx).toBeGreaterThanOrEqual(0);
+      expect(tagIdx).toBeLessThan(foodIdx);
+    });
+  });
+
+  describe("within-transaction ordering — sign grouping", () => {
+    test("should put postings with a negative amount before postings with a positive amount", () => {
+      const input = ["2026-03-15 * Payee", "    Expenses:Food    45.00 USD", "    Assets:Checking    -45.00 USD"].join(
+        "\n",
+      );
+      const result = formatJournalContent(input);
+      const checkingIdx = result.indexOf("Assets:Checking");
+      const foodIdx = result.indexOf("Expenses:Food");
+      expect(checkingIdx).toBeLessThan(foodIdx);
+    });
+
+    test("should put balancing postings last, after both negative and positive", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    Assets:Checking",
+        "    Expenses:Food    45.00 USD",
+        "    Liabilities:CreditCard    -45.00 USD",
+      ].join("\n");
+      const result = formatJournalContent(input);
+      const creditIdx = result.indexOf("Liabilities:CreditCard");
+      const foodIdx = result.indexOf("Expenses:Food");
+      const checkingIdx = result.indexOf("Assets:Checking");
+      expect(creditIdx).toBeLessThan(foodIdx);
+      expect(foodIdx).toBeLessThan(checkingIdx);
+    });
+
+    test("should preserve original order for postings in the same sign group (stable)", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    Expenses:A    1.00 USD",
+        "    Expenses:B    2.00 USD",
+        "    Expenses:C    3.00 USD",
+        "    Assets:Checking    -6.00 USD",
+      ].join("\n");
+      const result = formatJournalContent(input);
+      const aIdx = result.indexOf("Expenses:A");
+      const bIdx = result.indexOf("Expenses:B");
+      const cIdx = result.indexOf("Expenses:C");
+      expect(aIdx).toBeLessThan(bIdx);
+      expect(bIdx).toBeLessThan(cIdx);
+    });
+
+    test('should classify "EUR -45.00" as negative', () => {
+      const input = ["2026-03-15 * Payee", "    Expenses:Food    45.00 EUR", "    Assets:Checking    EUR -45.00"].join(
+        "\n",
+      );
+      const result = formatJournalContent(input);
+      const checkingIdx = result.indexOf("Assets:Checking");
+      const foodIdx = result.indexOf("Expenses:Food");
+      expect(checkingIdx).toBeLessThan(foodIdx);
+    });
+
+    test('should classify "-$45.00" as negative', () => {
+      const input = ["2026-03-15 * Payee", "    Expenses:Food    $45.00", "    Assets:Checking    -$45.00"].join("\n");
+      const result = formatJournalContent(input);
+      const checkingIdx = result.indexOf("Assets:Checking");
+      const foodIdx = result.indexOf("Expenses:Food");
+      expect(checkingIdx).toBeLessThan(foodIdx);
+    });
+
+    test('should classify "$-45.00" as negative', () => {
+      const input = ["2026-03-15 * Payee", "    Expenses:Food    $45.00", "    Assets:Checking    $-45.00"].join("\n");
+      const result = formatJournalContent(input);
+      const checkingIdx = result.indexOf("Assets:Checking");
+      const foodIdx = result.indexOf("Expenses:Food");
+      expect(checkingIdx).toBeLessThan(foodIdx);
+    });
+
+    test('should classify "+45.00 USD" as positive', () => {
+      const input = ["2026-03-15 * Payee", "    Expenses:Food    +45.00 USD", "    Assets:Checking    -45.00 USD"].join(
+        "\n",
+      );
+      const result = formatJournalContent(input);
+      const checkingIdx = result.indexOf("Assets:Checking");
+      const foodIdx = result.indexOf("Expenses:Food");
+      expect(checkingIdx).toBeLessThan(foodIdx);
+    });
+
+    test('should classify unsigned "45.00 USD" as positive', () => {
+      const input = ["2026-03-15 * Payee", "    Expenses:Food    45.00 USD", "    Assets:Checking    -45.00 USD"].join(
+        "\n",
+      );
+      const result = formatJournalContent(input);
+      const checkingIdx = result.indexOf("Assets:Checking");
+      const foodIdx = result.indexOf("Expenses:Food");
+      expect(checkingIdx).toBeLessThan(foodIdx);
+    });
+  });
+
+  describe("within-transaction ordering — attachment", () => {
+    test("should keep a non-tag comment attached to its preceding posting when the posting is moved by sign grouping", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    Expenses:Food    45.00 USD",
+        "    # note about the food line",
+        "    Assets:Checking    -45.00 USD",
+      ].join("\n");
+      const result = formatJournalContent(input);
+      const lines = result.split("\n");
+      const foodIdx = lines.findIndex((l) => l.includes("Expenses:Food"));
+      const noteIdx = lines.findIndex((l) => l.includes("# note about the food line"));
+      expect(foodIdx).toBeGreaterThanOrEqual(0);
+      // The note should still be immediately after the Expenses:Food posting line
+      expect(noteIdx).toBe(foodIdx + 1);
+      // Sign grouping moved Expenses:Food AFTER the negative Assets:Checking;
+      // the note came with it
+      const checkingIdx = lines.findIndex((l) => l.includes("Assets:Checking"));
+      expect(checkingIdx).toBeLessThan(foodIdx);
+    });
+  });
+
+  describe("inter-transaction top-level content", () => {
+    test("should preserve a top-level comment between transactions (not absorb it into the previous tx)", () => {
+      const input = [
+        "2026-01-01 * Scalable Capital | Received interest",
+        "    assets:volo:scalable-capital:cash          365.27 EUR",
+        "    income:volo:scalable-capital:interest      -365.27 EUR",
+        "",
+        "; Regular transactions",
+        "",
+        "2026-01-02 * Berliner Verkehrsbetriebe (BVG)",
+        "    assets:volo:n26                    -63.00 EUR",
+        "    expenses:transport:public-transit    63.00 EUR",
+      ].join("\n");
+      const result = formatJournalContent(input);
+      // The comment stays OUTSIDE the first transaction's body
+      const firstTxIdx = result.indexOf("Scalable Capital");
+      const commentIdx = result.indexOf("; Regular transactions");
+      const secondTxIdx = result.indexOf("Berliner Verkehrsbetriebe");
+      expect(firstTxIdx).toBeGreaterThanOrEqual(0);
+      expect(commentIdx).toBeGreaterThan(firstTxIdx);
+      expect(commentIdx).toBeLessThan(secondTxIdx);
+      // And it's NOT part of the first transaction body — the cash/interest
+      // lines of the first tx come BEFORE the comment, not mixed with it
+      const interestIdx = result.indexOf("income:volo:scalable-capital:interest");
+      const cashIdx = result.indexOf("assets:volo:scalable-capital:cash");
+      expect(interestIdx).toBeLessThan(commentIdx);
+      expect(cashIdx).toBeLessThan(commentIdx);
+    });
+
+    test("should preserve ';' inter-transaction comments verbatim", () => {
+      const input = [
+        "2026-01-01 * A",
+        "    Expenses:Food    10.00 USD",
+        "    Assets:Checking",
+        "",
+        "; section divider",
+        "",
+        "2026-01-02 * B",
+        "    Expenses:Food    20.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = formatJournalContent(input);
+      expect(result).toContain("; section divider");
+    });
+
+    test("should emit inter-transaction comments with blank lines around them", () => {
+      const input = [
+        "2026-01-01 * A",
+        "    Expenses:Food    10.00 USD",
+        "    Assets:Checking",
+        "",
+        "; section divider",
+        "",
+        "2026-01-02 * B",
+        "    Expenses:Food    20.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const expected = [
+        "2026-01-01 * A",
+        p("    ", "Expenses:Food", "10.00 USD"),
+        "    Assets:Checking",
+        "",
+        "; section divider",
+        "",
+        "2026-01-02 * B",
+        p("    ", "Expenses:Food", "20.00 USD"),
+        "    Assets:Checking",
+      ].join("\n");
+      expect(formatJournalContent(input)).toBe(expected);
+    });
+
+    test("should keep inter-transaction content with its following transaction when sorted", () => {
+      // tx1 has a LATER date than tx2; beautifier will sort tx2 first.
+      // The comment between them was "before tx2" in the file, so it travels with tx2.
+      const input = [
+        "2026-01-10 * Later",
+        "    Expenses:Food    1.00 USD",
+        "    Assets:Checking",
+        "",
+        "; section divider",
+        "",
+        "2026-01-01 * Earlier",
+        "    Expenses:Food    2.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const result = formatJournalContent(input);
+      const earlierIdx = result.indexOf("Earlier");
+      const laterIdx = result.indexOf("Later");
+      expect(earlierIdx).toBeLessThan(laterIdx);
+      const commentIdx = result.indexOf("; section divider");
+      expect(commentIdx).toBeLessThan(earlierIdx);
+    });
+
+    test("should preserve trailing content after the last transaction", () => {
+      const input = [
+        "2026-01-01 * A",
+        "    Expenses:Food    10.00 USD",
+        "    Assets:Checking",
+        "",
+        "; trailing footer note",
+      ].join("\n");
+      const result = formatJournalContent(input);
+      expect(result).toContain("; trailing footer note");
+      const txIdx = result.indexOf("2026-01-01");
+      const footerIdx = result.indexOf("; trailing footer note");
+      expect(footerIdx).toBeGreaterThan(txIdx);
+    });
+
+    test("should be idempotent with inter-transaction comments", () => {
+      const input = [
+        "2026-01-01 * A",
+        "    Expenses:Food    10.00 USD",
+        "    Assets:Checking",
+        "",
+        "; section divider",
+        "",
+        "2026-01-02 * B",
+        "    Expenses:Food    20.00 USD",
+        "    Assets:Checking",
+      ].join("\n");
+      const first = formatJournalContent(input);
+      const second = formatJournalContent(first);
+      expect(second).toBe(first);
+    });
+  });
+
+  describe("within-transaction ordering — idempotency", () => {
+    test("should produce identical output when run twice on a mixed-sign transaction with tags", () => {
+      const input = [
+        "2026-03-15 * Payee",
+        "    ; weekly:, groceries:",
+        "    ; source: manual",
+        "    Expenses:Food    45.00 USD",
+        "    Assets:Checking    -45.00 USD",
+      ].join("\n");
+      const first = formatJournalContent(input);
+      const second = formatJournalContent(first);
+      expect(second).toBe(first);
+    });
+
+    test("should be a no-op on an already-ordered canonical transaction", () => {
+      // Candidates:
+      //   Assets:Checking (15) + prefix "-" (1) = 20
+      //   Expenses:Food (13)   + prefix ""  (0) = 17
+      // widestEnd + MIN_GAP = 24 < 70 → clamped to 70.
+      //   Assets:Checking padding = 70 - 4 - 15 - 1 = 50
+      //   Expenses:Food padding   = 70 - 4 - 13 - 0 = 53
+      const canonical = [
+        "2026-03-15 * Payee",
+        "    ; groceries:",
+        "    ; source: manual",
+        "    ; weekly:",
+        p("    ", "Assets:Checking", "-45.00 USD", 1),
+        p("    ", "Expenses:Food", "45.00 USD"),
+      ].join("\n");
+      expect(formatJournalContent(canonical)).toBe(canonical);
+    });
+  });
+});
+
+describe("formatJournalFile()", () => {
+  test("should return null when the file does not exist", () => {
+    const absent = join(FILE_BASE, "does-not-exist.journal");
+    expect(existsSync(absent)).toBe(false);
+    expect(formatJournalFile(absent)).toBeNull();
+  });
+
+  test("should rethrow non-ENOENT errors (e.g. EISDIR when path is a directory)", () => {
+    // FILE_BASE is a directory, so readFileSync(FILE_BASE) throws an error
+    // whose code is not ENOENT (commonly EISDIR). formatJournalFile should
+    // rethrow.
+    expect(() => formatJournalFile(FILE_BASE)).toThrow();
+  });
+
+  test("should return the final content and write it when formatting changes the file", () => {
+    const path = join(FILE_BASE, "needs-formatting.journal");
+    // Out-of-order dates — the formatter will sort them.
+    writeFileSync(
+      path,
+      [
+        "2026-03-28 * Later",
+        "    Expenses:Food    10.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-03-01 * Earlier",
+        "    Expenses:Food    5.00 USD",
+        "    Assets:Checking",
+      ].join("\n"),
+    );
+    const result = formatJournalFile(path);
+    if (result === null) throw new Error("file was just written, should not be null");
+    // Earlier comes first after sort
+    const onDisk = readFileSync(path, "utf-8");
+    expect(onDisk).toBe(result);
+    expect(onDisk.indexOf("Earlier")).toBeLessThan(onDisk.indexOf("Later"));
+  });
+
+  test("should return the content and NOT touch the file when it is already formatted", () => {
+    const path = join(FILE_BASE, "already-formatted.journal");
+    const input = [
+      "2026-03-01 * Earlier",
+      p("    ", "Expenses:Food", "5.00 USD"),
+      "    Assets:Checking",
+      "",
+      "2026-03-28 * Later",
+      p("    ", "Expenses:Food", "10.00 USD"),
+      "    Assets:Checking",
+      "",
+    ].join("\n");
+    writeFileSync(path, input);
+    const mtimeBefore = statSync(path).mtimeMs;
+
+    // Busy-wait briefly so a write would produce a different mtime
+    const until = Date.now() + 15;
+    while (Date.now() < until) {
+      /* spin */
+    }
+
+    const result = formatJournalFile(path);
+    const mtimeAfter = statSync(path).mtimeMs;
+    expect(result).toBe(input);
+    expect(mtimeAfter).toBe(mtimeBefore);
+  });
+});

--- a/src/extension/data/format/__tests__/transform.test.ts
+++ b/src/extension/data/format/__tests__/transform.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, test } from "bun:test";
+import {
+  categorizeBody,
+  computeTargetDigitsColumn,
+  isTagCommentLine,
+  partitionPostings,
+  splitTagCommentLine,
+  tagSortKey,
+} from "../transform";
+import type { ParsedBodyLine, PostingGroup } from "../types";
+
+// ── Test helpers for constructing ParsedBodyLine values ─────────────
+
+const posting = (
+  indent: string,
+  account: string,
+  amount: string,
+  digitsPrefixLength: number,
+  isNegative: boolean,
+): ParsedBodyLine => ({ kind: "posting", indent, account, amount, digitsPrefixLength, isNegative });
+
+const balancing = (raw: string): ParsedBodyLine => ({ kind: "balancing", raw });
+const metadata = (raw: string): ParsedBodyLine => ({ kind: "metadata", raw });
+const other = (raw: string): ParsedBodyLine => ({ kind: "other", raw });
+
+const postingGroup = (parsed: ParsedBodyLine, trailing: string[] = []): PostingGroup => ({ parsed, trailing });
+
+// ── isTagCommentLine() ─────────────────────────────────────────────
+
+describe("isTagCommentLine()", () => {
+  test("should accept a single-tag line", () => {
+    expect(isTagCommentLine("    ; tag1:")).toBe(true);
+  });
+
+  test("should accept a comma-separated tag list", () => {
+    expect(isTagCommentLine("    ; tag1:, tag2:")).toBe(true);
+  });
+
+  test("should accept a key:value metadata line", () => {
+    expect(isTagCommentLine("    ; source: manual")).toBe(true);
+  });
+
+  test("should accept a mixed list where every part has a colon", () => {
+    expect(isTagCommentLine("    ; tag1:, key: value")).toBe(true);
+  });
+
+  test("should reject a free-form comment (no colon)", () => {
+    expect(isTagCommentLine("    ; just a note")).toBe(false);
+  });
+
+  test("should reject a comma-separated list where one part lacks a colon", () => {
+    expect(isTagCommentLine("    ; tag1:, no colon")).toBe(false);
+  });
+
+  test("should reject a line that does not start with ';'", () => {
+    expect(isTagCommentLine("    not a comment")).toBe(false);
+  });
+
+  test("should reject an empty-content comment", () => {
+    expect(isTagCommentLine("    ;")).toBe(false);
+  });
+
+  test("should work without any indent", () => {
+    expect(isTagCommentLine("; tag1:")).toBe(true);
+  });
+});
+
+// ── splitTagCommentLine() ──────────────────────────────────────────
+
+describe("splitTagCommentLine()", () => {
+  test("should split a comma-separated tag list into individual lines", () => {
+    expect(splitTagCommentLine("    ; tag1:, tag2:, tag3:")).toEqual(["    ; tag1:", "    ; tag2:", "    ; tag3:"]);
+  });
+
+  test("should preserve the original indent on each emitted line", () => {
+    expect(splitTagCommentLine("      ; a:, b:")).toEqual(["      ; a:", "      ; b:"]);
+  });
+
+  test("should preserve the 'value' part for key:value items", () => {
+    expect(splitTagCommentLine("    ; source: manual, weekly:")).toEqual(["    ; source: manual", "    ; weekly:"]);
+  });
+
+  test("should return the line unchanged when it is not a tag list", () => {
+    expect(splitTagCommentLine("    ; just a note")).toEqual(["    ; just a note"]);
+  });
+
+  test("should return the line unchanged when one comma-separated part lacks ':'", () => {
+    expect(splitTagCommentLine("    ; tag1:, no colon")).toEqual(["    ; tag1:, no colon"]);
+  });
+
+  test("should return a single-element array for a single-tag input (idempotent)", () => {
+    expect(splitTagCommentLine("    ; tag1:")).toEqual(["    ; tag1:"]);
+  });
+
+  test("should return the raw line when it is not a comment at all", () => {
+    expect(splitTagCommentLine("    posting line")).toEqual(["    posting line"]);
+  });
+});
+
+// ── tagSortKey() ───────────────────────────────────────────────────
+
+describe("tagSortKey()", () => {
+  test("should return content after '; '", () => {
+    expect(tagSortKey("    ; weekly:")).toBe("weekly:");
+  });
+
+  test("should handle an unindented comment", () => {
+    expect(tagSortKey("; tag:")).toBe("tag:");
+  });
+
+  test("should return the raw line when no ';' matches", () => {
+    expect(tagSortKey("    posting")).toBe("    posting");
+  });
+
+  test("should enable alphabetical sort of mixed tags", () => {
+    const tags = ["    ; weekly:", "    ; groceries:", "    ; source: manual"];
+    tags.sort((a, b) => tagSortKey(a).localeCompare(tagSortKey(b)));
+    expect(tags).toEqual(["    ; groceries:", "    ; source: manual", "    ; weekly:"]);
+  });
+});
+
+// ── categorizeBody() ───────────────────────────────────────────────
+
+describe("categorizeBody()", () => {
+  test("should collect tag lines as tagLines", () => {
+    const body: ParsedBodyLine[] = [metadata("    ; tag1:"), metadata("    ; tag2:")];
+    const result = categorizeBody(body);
+    expect(result.tagLines).toEqual(["    ; tag1:", "    ; tag2:"]);
+    expect(result.headerNonTag).toEqual([]);
+    expect(result.postingGroups).toEqual([]);
+  });
+
+  test("should put non-tag metadata before any posting in headerNonTag", () => {
+    const body: ParsedBodyLine[] = [metadata("    ; just a note")];
+    const result = categorizeBody(body);
+    expect(result.headerNonTag).toEqual(["    ; just a note"]);
+    expect(result.tagLines).toEqual([]);
+  });
+
+  test("should attach non-tag metadata after a posting to that posting's trailing", () => {
+    const p = posting("    ", "Expenses:Food", "45.00 USD", 0, false);
+    const body: ParsedBodyLine[] = [p, metadata("    ; note for food")];
+    const result = categorizeBody(body);
+    expect(result.postingGroups).toHaveLength(1);
+    expect(result.postingGroups[0].parsed).toBe(p);
+    expect(result.postingGroups[0].trailing).toEqual(["    ; note for food"]);
+  });
+
+  test("should build a posting group for each posting and balancing line", () => {
+    const p1 = posting("    ", "Expenses:Food", "45.00 USD", 0, false);
+    const b1 = balancing("    Assets:Checking");
+    const body: ParsedBodyLine[] = [p1, b1];
+    const result = categorizeBody(body);
+    expect(result.postingGroups.map((g) => g.parsed)).toEqual([p1, b1]);
+  });
+
+  test("should attach 'other' kind lines to the current posting (or headerNonTag before first posting)", () => {
+    const p = posting("    ", "Expenses:Food", "45.00 USD", 0, false);
+    const body: ParsedBodyLine[] = [other("stray line"), p, other("another stray")];
+    const result = categorizeBody(body);
+    expect(result.headerNonTag).toEqual(["stray line"]);
+    expect(result.postingGroups[0].trailing).toEqual(["another stray"]);
+  });
+
+  test("should pull tag metadata from anywhere in the body into tagLines", () => {
+    const p = posting("    ", "Expenses:Food", "45.00 USD", 0, false);
+    const body: ParsedBodyLine[] = [p, metadata("    ; mid-tx: tag")];
+    const result = categorizeBody(body);
+    expect(result.tagLines).toEqual(["    ; mid-tx: tag"]);
+    // The tag is NOT attached to the posting's trailing
+    expect(result.postingGroups[0].trailing).toEqual([]);
+  });
+});
+
+// ── partitionPostings() ────────────────────────────────────────────
+
+describe("partitionPostings()", () => {
+  test("should put postings with isNegative=true into negatives", () => {
+    const g = postingGroup(posting("    ", "Assets:Checking", "-45.00 USD", 1, true));
+    const result = partitionPostings([g]);
+    expect(result.negatives).toEqual([g]);
+    expect(result.positives).toEqual([]);
+    expect(result.balancings).toEqual([]);
+  });
+
+  test("should put postings with isNegative=false into positives", () => {
+    const g = postingGroup(posting("    ", "Expenses:Food", "45.00 USD", 0, false));
+    const result = partitionPostings([g]);
+    expect(result.positives).toEqual([g]);
+    expect(result.negatives).toEqual([]);
+  });
+
+  test("should put balancing postings into balancings", () => {
+    const g = postingGroup(balancing("    Assets:Checking"));
+    const result = partitionPostings([g]);
+    expect(result.balancings).toEqual([g]);
+    expect(result.positives).toEqual([]);
+    expect(result.negatives).toEqual([]);
+  });
+
+  test("should put 'other' kind groups into balancings as a fallthrough", () => {
+    const g = postingGroup(other("weird"));
+    const result = partitionPostings([g]);
+    expect(result.balancings).toEqual([g]);
+  });
+
+  test("should preserve stable order within each bucket", () => {
+    const n1 = postingGroup(posting("    ", "A", "-1 USD", 1, true));
+    const n2 = postingGroup(posting("    ", "B", "-2 USD", 1, true));
+    const p1 = postingGroup(posting("    ", "C", "3 USD", 0, false));
+    const p2 = postingGroup(posting("    ", "D", "4 USD", 0, false));
+    const result = partitionPostings([n1, p1, n2, p2]);
+    expect(result.negatives).toEqual([n1, n2]);
+    expect(result.positives).toEqual([p1, p2]);
+  });
+});
+
+// ── computeTargetDigitsColumn() ────────────────────────────────────
+
+describe("computeTargetDigitsColumn()", () => {
+  test("should return 0 when there are no postings with amounts", () => {
+    const body: ParsedBodyLine[][] = [[balancing("    Assets:Checking"), balancing("    Assets:Savings")]];
+    expect(computeTargetDigitsColumn(body)).toBe(0);
+  });
+
+  test("should clamp up to MIN_AMOUNT_COLUMN (70) for a short single posting", () => {
+    // indent 4 + account "Expenses:Food" (13) + prefix 0 = 17, + MIN_GAP(4) = 21
+    // 21 < 70, so the target is clamped to 70.
+    const body: ParsedBodyLine[][] = [[posting("    ", "Expenses:Food", "45.00 USD", 0, false)]];
+    expect(computeTargetDigitsColumn(body)).toBe(70);
+  });
+
+  test("should clamp up to MIN_AMOUNT_COLUMN when the widest-candidate posting is still short", () => {
+    // posting 1: 4 + 15 (Assets:Checking) + 1 (neg prefix) = 20  ← max
+    // posting 2: 4 + 13 (Expenses:Food)   + 0             = 17
+    // target = max(70, 20 + 4) = 70
+    const body: ParsedBodyLine[][] = [
+      [
+        posting("    ", "Assets:Checking", "-45.00 USD", 1, true),
+        posting("    ", "Expenses:Food", "45.00 USD", 0, false),
+      ],
+    ];
+    expect(computeTargetDigitsColumn(body)).toBe(70);
+  });
+
+  test("should clamp across all transactions when the widest file-wide candidate is still short", () => {
+    // tx 1 posting: 4 + 13 + 0 = 17
+    // tx 2 posting: 4 + 32 + 0 = 36 ← max
+    // target = max(70, 36 + 4) = 70
+    const body: ParsedBodyLine[][] = [
+      [posting("    ", "Expenses:Food", "45.00 USD", 0, false)],
+      [posting("    ", "Expenses:Transport:PublicTransit", "10.00 USD", 0, false)],
+    ];
+    expect(computeTargetDigitsColumn(body)).toBe(70);
+  });
+
+  test("should return widestEnd + MIN_GAP when that exceeds MIN_AMOUNT_COLUMN", () => {
+    // A 70-char account pushes past the 70 floor.
+    // 4 + 70 + 0 = 74, + MIN_GAP = 78.
+    const longAccount = "expenses:really:very:long:nested:account:name:that:is:seventy:chars:ok"; // 70 chars
+    const body: ParsedBodyLine[][] = [[posting("    ", longAccount, "1.00 USD", 0, false)]];
+    expect(longAccount.length).toBe(70);
+    expect(computeTargetDigitsColumn(body)).toBe(78);
+  });
+
+  test("should return exactly MIN_AMOUNT_COLUMN (70) when widestEnd + MIN_GAP is exactly 70", () => {
+    // 4 + 62 + 0 = 66, + MIN_GAP(4) = 70 → exactly the floor.
+    const account62 = "a".repeat(62);
+    const body: ParsedBodyLine[][] = [[posting("    ", account62, "1.00 USD", 0, false)]];
+    expect(computeTargetDigitsColumn(body)).toBe(70);
+  });
+
+  test("should ignore non-posting lines", () => {
+    const body: ParsedBodyLine[][] = [
+      [
+        metadata("    ; tag:"),
+        balancing("    Assets:Checking"),
+        posting("    ", "Expenses:Food", "45.00 USD", 0, false),
+      ],
+    ];
+    // Widest posting is Expenses:Food (13) → 4+13+0+4 = 21, clamped to 70.
+    expect(computeTargetDigitsColumn(body)).toBe(70);
+  });
+
+  test("should preserve per-posting indent in the calculation", () => {
+    // 6-space indent + 13 account + 0 prefix = 19, + MIN_GAP(4) = 23 < 70, clamped to 70.
+    const body: ParsedBodyLine[][] = [[posting("      ", "Expenses:Food", "45.00 USD", 0, false)]];
+    expect(computeTargetDigitsColumn(body)).toBe(70);
+  });
+});

--- a/src/extension/data/format/emit.ts
+++ b/src/extension/data/format/emit.ts
@@ -1,0 +1,74 @@
+import { categorizeBody, partitionPostings, splitTagCommentLine, tagSortKey } from "./transform";
+import type { ParsedBodyLine, Transaction } from "./types";
+
+export function emitTransaction(tx: Transaction, parsedBody: ParsedBodyLine[], targetColumn: number): string {
+  const out: string[] = [];
+
+  // preContent travels with this transaction, emitted before the header
+  // and separated by a blank line.
+  if (tx.preContent.length > 0) {
+    out.push(...tx.preContent);
+    out.push("");
+  }
+  out.push(tx.header);
+
+  const { tagLines, headerNonTag, postingGroups } = categorizeBody(parsedBody);
+  out.push(...formatTagBlock(tagLines));
+  out.push(...headerNonTag);
+
+  const { negatives, positives, balancings } = partitionPostings(postingGroups);
+  for (const groups of [negatives, positives, balancings]) {
+    for (const g of groups) {
+      if (g.parsed.kind === "posting") {
+        out.push(formatPostingLine(g.parsed, targetColumn));
+      } else {
+        out.push(g.parsed.raw);
+      }
+      out.push(...g.trailing);
+    }
+  }
+
+  return out.join("\n");
+}
+
+export function assembleOutput(
+  leading: string[],
+  emittedTransactions: string[],
+  trailingContent: string[],
+  hadTrailingNewline: boolean,
+): string {
+  let output = "";
+  if (leading.length > 0) {
+    output += leading.join("\n");
+    output += "\n\n";
+  }
+  output += emittedTransactions.join("\n\n");
+  if (trailingContent.length > 0) {
+    output += "\n\n";
+    output += trailingContent.join("\n");
+  }
+  if (hadTrailingNewline) output += "\n";
+  return output;
+}
+
+export function assembleWithoutTransactions(
+  leading: string[],
+  hadTrailingNewline: boolean,
+  originalContent: string,
+): string {
+  if (leading.length === 0) return originalContent;
+  let output = leading.join("\n");
+  if (hadTrailingNewline) output += "\n";
+  return output;
+}
+
+// ── Private helpers ─────────────────────────────────────────────────
+
+function formatTagBlock(tagLines: string[]): string[] {
+  return tagLines.flatMap(splitTagCommentLine).sort((a, b) => tagSortKey(a).localeCompare(tagSortKey(b)));
+}
+
+function formatPostingLine(posting: Extract<ParsedBodyLine, { kind: "posting" }>, targetColumn: number): string {
+  const padding = targetColumn - posting.indent.length - posting.account.length - posting.digitsPrefixLength;
+  return `${posting.indent}${posting.account}${" ".repeat(padding)}${posting.amount}`;
+}

--- a/src/extension/data/format/index.ts
+++ b/src/extension/data/format/index.ts
@@ -1,0 +1,16 @@
+import { hledgerFiles } from "../../hledger";
+import { formatJournalFile } from "./pipeline";
+
+// Silent no-op on a malformed journal: a subsequent `hledgerCheck` call
+// is expected to surface the real error with line numbers.
+export async function ledgerFormat(mainPath: string, opts?: { cwd?: string; signal?: AbortSignal }): Promise<void> {
+  let files: string[];
+  try {
+    files = await hledgerFiles(mainPath, opts);
+  } catch {
+    return;
+  }
+  for (const file of files) {
+    formatJournalFile(file);
+  }
+}

--- a/src/extension/data/format/parse.ts
+++ b/src/extension/data/format/parse.ts
@@ -1,0 +1,106 @@
+import { DATE_HEADER_REGEX, type ParsedBodyLine, type ParsedContent, type Transaction } from "./types";
+
+export function parseContent(content: string): ParsedContent {
+  const hadTrailingNewline = content.endsWith("\n");
+  const normalized = content.replace(/\r\n/g, "\n");
+  const split = normalized.split("\n");
+  // split("\n") on a string ending in "\n" produces a trailing "" — drop it
+  const lines = hadTrailingNewline && split.length > 0 && split[split.length - 1] === "" ? split.slice(0, -1) : split;
+  return { lines, hadTrailingNewline };
+}
+
+export function findTransactionHeaders(lines: string[]): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (DATE_HEADER_REGEX.test(lines[i])) out.push(i);
+  }
+  return out;
+}
+
+export function extractLeadingLines(lines: string[], until: number): string[] {
+  const out = lines.slice(0, until);
+  while (out.length > 0 && out[out.length - 1].trim() === "") {
+    out.pop();
+  }
+  return out;
+}
+
+export function parseTransactions(
+  lines: string[],
+  headerIndices: number[],
+): { transactions: Transaction[]; trailingContent: string[] } {
+  const transactions: Transaction[] = [];
+  let pendingPreContent: string[] = [];
+
+  for (let k = 0; k < headerIndices.length; k++) {
+    const start = headerIndices[k];
+    const nextStart = k < headerIndices.length - 1 ? headerIndices[k + 1] : lines.length;
+    const header = lines[start];
+
+    const body: string[] = [];
+    let i = start + 1;
+    while (i < nextStart && isIndentedLine(lines[i])) {
+      body.push(lines[i]);
+      i++;
+    }
+
+    // Non-indented, non-blank content before the next header becomes the
+    // preContent of the NEXT transaction (so it stays between transactions
+    // instead of being absorbed into the preceding transaction's body).
+    const looseAfterBody: string[] = [];
+    while (i < nextStart) {
+      if (lines[i].trim() !== "") looseAfterBody.push(lines[i]);
+      i++;
+    }
+
+    transactions.push({
+      date: extractDateFromHeader(header),
+      header,
+      body,
+      preContent: pendingPreContent,
+    });
+    pendingPreContent = looseAfterBody;
+  }
+
+  return { transactions, trailingContent: pendingPreContent };
+}
+
+export function parsePostingLine(rawLine: string): ParsedBodyLine {
+  const indentMatch = rawLine.match(/^([\t ]*)/);
+  const indent = indentMatch ? indentMatch[1] : "";
+  if (indent.length === 0) return { kind: "other", raw: rawLine };
+  const rest = rawLine.slice(indent.length);
+  if (rest[0] === ";" || rest[0] === "#") return { kind: "metadata", raw: rawLine };
+  // hledger account/amount separator: 2+ spaces or 1+ tabs
+  const m = rest.match(/^(.+?)(?: {2,}|\t+)(.+)$/);
+  if (!m) return { kind: "balancing", raw: rawLine };
+  const amount = m[2].replace(/\s+$/, "");
+  const digitsPrefixLength = getDigitsPrefixLength(amount);
+  // Negative iff the amount has a '-' somewhere before the first digit.
+  // Covers "-45", "$-45", "EUR -45". "+45" and unsigned are positive.
+  const isNegative = amount.slice(0, digitsPrefixLength).includes("-");
+  return { kind: "posting", indent, account: m[1], amount, digitsPrefixLength, isNegative };
+}
+
+export function sortTransactionsByDate(transactions: Transaction[]): void {
+  transactions.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+}
+
+// ── Private helpers ─────────────────────────────────────────────────
+
+function isIndentedLine(line: string): boolean {
+  return line.startsWith(" ") || line.startsWith("\t");
+}
+
+function extractDateFromHeader(header: string): string {
+  const m = header.match(DATE_HEADER_REGEX);
+  return m ? `${m[1]}-${m[2]}-${m[3]}` : header.slice(0, 10);
+}
+
+function getDigitsPrefixLength(amount: string): number {
+  // Number of characters before the first digit in the amount token.
+  // "-111.00 EUR" → 1, "111.00 EUR" → 0, "EUR -111.00" → 5,
+  // "$100" → 1, "$-100" → 2, no-digit amount → full length.
+  const idx = amount.search(/\d/);
+  return idx === -1 ? amount.length : idx;
+}

--- a/src/extension/data/format/pipeline.ts
+++ b/src/extension/data/format/pipeline.ts
@@ -1,0 +1,49 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { assembleOutput, assembleWithoutTransactions, emitTransaction } from "./emit";
+import {
+  extractLeadingLines,
+  findTransactionHeaders,
+  parseContent,
+  parsePostingLine,
+  parseTransactions,
+  sortTransactionsByDate,
+} from "./parse";
+import { computeTargetDigitsColumn } from "./transform";
+
+export function formatJournalContent(content: string): string {
+  if (content.length === 0) return content;
+
+  const { lines, hadTrailingNewline } = parseContent(content);
+  const headerIndices = findTransactionHeaders(lines);
+  const leading = extractLeadingLines(lines, headerIndices[0] ?? lines.length);
+
+  if (headerIndices.length === 0) {
+    return assembleWithoutTransactions(leading, hadTrailingNewline, content);
+  }
+
+  const { transactions, trailingContent } = parseTransactions(lines, headerIndices);
+  sortTransactionsByDate(transactions);
+
+  const parsedBodies = transactions.map((tx) => tx.body.map(parsePostingLine));
+  const targetDigitsColumn = computeTargetDigitsColumn(parsedBodies);
+  const emittedTransactions = transactions.map((tx, i) => emitTransaction(tx, parsedBodies[i], targetDigitsColumn));
+
+  return assembleOutput(leading, emittedTransactions, trailingContent, hadTrailingNewline);
+}
+
+// Returns null for a missing file so callers like `ledgerFormat` tolerate
+// a file disappearing between enumeration and formatting.
+export function formatJournalFile(absPath: string): string | null {
+  let content: string;
+  try {
+    content = readFileSync(absPath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return null;
+    throw err;
+  }
+  const formatted = formatJournalContent(content);
+  if (formatted !== content) {
+    writeFileSync(absPath, formatted);
+  }
+  return formatted;
+}

--- a/src/extension/data/format/transform.ts
+++ b/src/extension/data/format/transform.ts
@@ -1,0 +1,97 @@
+import {
+  type CategorizedBody,
+  MIN_AMOUNT_COLUMN,
+  MIN_GAP,
+  type ParsedBodyLine,
+  type PartitionedPostings,
+  type PostingGroup,
+} from "./types";
+
+export function categorizeBody(parsedBody: ParsedBodyLine[]): CategorizedBody {
+  const tagLines: string[] = [];
+  const headerNonTag: string[] = [];
+  const postingGroups: PostingGroup[] = [];
+  let current: PostingGroup | null = null;
+
+  const attachNonTag = (raw: string) => {
+    if (current === null) headerNonTag.push(raw);
+    else current.trailing.push(raw);
+  };
+
+  for (const line of parsedBody) {
+    if (line.kind === "posting" || line.kind === "balancing") {
+      current = { parsed: line, trailing: [] };
+      postingGroups.push(current);
+    } else if (line.kind === "metadata" && isTagCommentLine(line.raw)) {
+      tagLines.push(line.raw);
+    } else {
+      attachNonTag(line.raw);
+    }
+  }
+
+  return { tagLines, headerNonTag, postingGroups };
+}
+
+export function partitionPostings(postingGroups: PostingGroup[]): PartitionedPostings {
+  const negatives: PostingGroup[] = [];
+  const positives: PostingGroup[] = [];
+  const balancings: PostingGroup[] = [];
+  for (const g of postingGroups) {
+    if (g.parsed.kind === "posting") {
+      if (g.parsed.isNegative) negatives.push(g);
+      else positives.push(g);
+    } else {
+      balancings.push(g);
+    }
+  }
+  return { negatives, positives, balancings };
+}
+
+// Column where the first DIGIT of every amount should land. Aligning on
+// the digit (not the amount-token start) lets negative signs stick out one
+// column to the left, so "-111" and "111" still align on "1".
+export function computeTargetDigitsColumn(parsedBodies: ParsedBodyLine[][]): number {
+  let widestEnd = 0;
+  let hasAny = false;
+  for (const body of parsedBodies) {
+    for (const line of body) {
+      if (line.kind === "posting") {
+        hasAny = true;
+        const candidate = line.indent.length + line.account.length + line.digitsPrefixLength;
+        if (candidate > widestEnd) widestEnd = candidate;
+      }
+    }
+  }
+  if (!hasAny) return 0;
+  return Math.max(MIN_AMOUNT_COLUMN, widestEnd + MIN_GAP);
+}
+
+// ── Tag comment helpers ─────────────────────────────────────────────
+
+// A tag-list comment line is a ";" line whose comma-separated parts all
+// contain ':'. Examples: "; tag1:", "; tag1:, tag2:", "; key: value".
+// Counter-examples: "; just a note", "; notes, one, two".
+export function isTagCommentLine(rawLine: string): boolean {
+  const match = rawLine.match(/^\s*;\s*(.*)$/);
+  if (!match) return false;
+  const parts = match[1].split(/,\s*/).filter((p) => p.length > 0);
+  return parts.length > 0 && parts.every((p) => p.includes(":"));
+}
+
+// Split a tag-list comment line into individual tag lines.
+// "    ; tag1:, tag2: value" → ["    ; tag1:", "    ; tag2: value"]
+// Non-tag lines are returned as-is (single-element array).
+export function splitTagCommentLine(rawLine: string): string[] {
+  const match = rawLine.match(/^(\s*);\s*(.*)$/);
+  if (!match) return [rawLine];
+  const [, indent, content] = match;
+  const parts = content.split(/,\s*/).filter((p) => p.length > 0);
+  if (parts.length === 0 || !parts.every((p) => p.includes(":"))) return [rawLine];
+  return parts.map((p) => `${indent}; ${p.trim()}`);
+}
+
+// Sort key for a tag line: the content after the ';' prefix.
+export function tagSortKey(rawLine: string): string {
+  const match = rawLine.match(/^\s*;\s*(.*)$/);
+  return match ? match[1] : rawLine;
+}

--- a/src/extension/data/format/types.ts
+++ b/src/extension/data/format/types.ts
@@ -1,0 +1,53 @@
+// Shared constants and types for the journal formatter pipeline.
+
+export const MIN_GAP = 4;
+// Minimum 0-indexed column where the first digit of every amount should
+// land. Short-account files are padded out to this column; files with
+// unusually long accounts push the amount column further right.
+export const MIN_AMOUNT_COLUMN = 70;
+export const DATE_HEADER_REGEX = /^(\d{4})[-/.](\d{2})[-/.](\d{2})\b/;
+
+export interface Transaction {
+  date: string;
+  header: string;
+  body: string[];
+  // Non-indented content that appeared between the previous transaction's
+  // body and this transaction's header. Emitted before this transaction's
+  // header and moves with the transaction under sort.
+  preContent: string[];
+}
+
+export type ParsedBodyLine =
+  | { kind: "metadata"; raw: string }
+  | { kind: "balancing"; raw: string }
+  | {
+      kind: "posting";
+      indent: string;
+      account: string;
+      amount: string;
+      digitsPrefixLength: number;
+      isNegative: boolean;
+    }
+  | { kind: "other"; raw: string };
+
+export interface PostingGroup {
+  parsed: ParsedBodyLine; // posting | balancing | other
+  trailing: string[]; // raw comments / other lines attached to this posting
+}
+
+export interface ParsedContent {
+  lines: string[];
+  hadTrailingNewline: boolean;
+}
+
+export interface CategorizedBody {
+  tagLines: string[];
+  headerNonTag: string[];
+  postingGroups: PostingGroup[];
+}
+
+export interface PartitionedPostings {
+  negatives: PostingGroup[];
+  positives: PostingGroup[];
+  balancings: PostingGroup[];
+}

--- a/src/extension/data/ledger.ts
+++ b/src/extension/data/ledger.ts
@@ -3,6 +3,7 @@ import { dirname, normalize, resolve } from "node:path";
 import { ACCOUNTANT24_HOME, LEDGER_DIR } from "../config";
 import { HledgerCommandError, hledgerCheck, runHledger } from "../hledger";
 import { generateDiff } from "./diff";
+import { ledgerFormat } from "./format";
 
 const PERIOD_FLAGS: Record<string, string> = {
   daily: "--daily",
@@ -141,8 +142,6 @@ export async function addTransaction(
     const separator = oldContent.endsWith("\n") ? "\n" : "\n\n";
     writeFileSync(fullFilePath, `${oldContent}${separator}${transactionText}\n`);
   }
-  const newContent = readFileSync(fullFilePath, "utf-8");
-  const diff = generateDiff(oldContent, newContent);
 
   // Update main.journal: includes and commodity declarations
   if (existsSync(mainPath)) {
@@ -171,7 +170,10 @@ export async function addTransaction(
     }
   }
 
-  // Validate
+  // Format every file in the ledger's include graph before validation so
+  // any formatter regression is caught immediately by hledgerCheck.
+  await ledgerFormat(mainPath, { cwd: ACCOUNTANT24_HOME, signal });
+
   try {
     await hledgerCheck(mainPath, { cwd: ACCOUNTANT24_HOME, signal });
   } catch (e) {
@@ -180,6 +182,9 @@ export async function addTransaction(
     }
     throw e;
   }
+
+  const newContent = readFileSync(fullFilePath, "utf-8");
+  const diff = generateDiff(oldContent, newContent);
 
   return { transactionText, fullFilePath, ledgerIsValid: true, diff };
 }
@@ -238,10 +243,14 @@ export interface ValidateLedgerResult {
 }
 
 export async function validateLedger(signal?: AbortSignal): Promise<ValidateLedgerResult> {
-  const resolved = resolveSafePath("main.journal", LEDGER_DIR);
+  const mainPath = resolveSafePath("main.journal", LEDGER_DIR);
+
+  // Format every file in the ledger's include graph before running
+  // hledger check so any formatter regression is caught immediately.
+  await ledgerFormat(mainPath, { signal });
 
   try {
-    await hledgerCheck(resolved, { signal });
+    await hledgerCheck(mainPath, { signal });
   } catch (e) {
     if (e instanceof HledgerCommandError) {
       throw new Error(e.stderr);

--- a/src/extension/hledger.ts
+++ b/src/extension/hledger.ts
@@ -44,6 +44,20 @@ export async function hledgerCheck(journalPath: string, opts?: { cwd?: string; s
   await runHledger(["check", "--strict", "-f", journalPath], opts);
 }
 
+// Returns every file in the include graph of the given journal, one path
+// per line from `hledger files`. Throws HledgerCommandError if the journal
+// cannot be parsed.
+export async function hledgerFiles(
+  journalPath: string,
+  opts?: { cwd?: string; signal?: AbortSignal },
+): Promise<string[]> {
+  const stdout = await runHledger(["files", "-f", journalPath], opts);
+  return stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+}
+
 // ── Internals ───────────────────────────────────────────────────────
 
 async function spawn(

--- a/src/extension/tools/__tests__/add-transaction.test.ts
+++ b/src/extension/tools/__tests__/add-transaction.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -10,10 +10,14 @@ mock.module("../../config.js", () => ({
   ACCOUNTANT24_HOME: BASE,
   LEDGER_DIR: LEDGER,
   MEMORY_PATH: join(BASE, "memory.md"),
+  FILES_DIR: join(BASE, "files"),
   setBaseDir: () => {},
 }));
 
-// Mock at Bun.spawn level so real hledger.ts functions execute for coverage
+// Mock at Bun.spawn level so real hledger.ts functions execute for coverage.
+// Dispatch on argv: `hledger files` returns the set of .journal files in the
+// test LEDGER dir (simulating hledger's include-graph resolution); anything
+// else (primarily `hledger check`) returns the configurable mock result.
 const origSpawn = Bun.spawn;
 
 function makeMockProc(exitCode: number, stdout = "", stderr = "") {
@@ -25,7 +29,32 @@ function makeMockProc(exitCode: number, stdout = "", stderr = "") {
   };
 }
 
-let mockProc: ReturnType<typeof makeMockProc>;
+// Walk LEDGER and return every .journal file: top-level files (main.journal,
+// accounts.journal) + monthly files under YYYY/MM.journal.
+function collectLedgerJournalFiles(): string[] {
+  if (!existsSync(LEDGER)) return [];
+  const result: string[] = [];
+  for (const entry of readdirSync(LEDGER, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.endsWith(".journal")) {
+      result.push(join(LEDGER, entry.name));
+    } else if (entry.isDirectory() && /^\d{4}$/.test(entry.name)) {
+      for (const f of readdirSync(join(LEDGER, entry.name))) {
+        if (/^\d{2}\.journal$/.test(f)) result.push(join(LEDGER, entry.name, f));
+      }
+    }
+  }
+  return result.sort();
+}
+
+let mockExitCode: number;
+let mockStdout: string;
+let mockStderr: string;
+
+const setMock = (exit: number, stdout = "", stderr = "") => {
+  mockExitCode = exit;
+  mockStdout = stdout;
+  mockStderr = stderr;
+};
 
 const { addTransactionTool } = await import("../add-transaction.js");
 
@@ -35,9 +64,15 @@ afterAll(() => {
 });
 
 beforeEach(() => {
-  mockProc = makeMockProc(0);
+  setMock(0);
   // @ts-expect-error - mocking Bun.spawn
-  Bun.spawn = mock(() => mockProc);
+  Bun.spawn = mock((argv: string[]) => {
+    if (argv.includes("files")) {
+      const list = collectLedgerJournalFiles().join("\n");
+      return makeMockProc(0, list.length > 0 ? `${list}\n` : "");
+    }
+    return makeMockProc(mockExitCode, mockStdout, mockStderr);
+  });
   // Clean and recreate ledger dir
   rmSync(LEDGER, { recursive: true, force: true });
   mkdirSync(LEDGER, { recursive: true });
@@ -128,7 +163,7 @@ test("calls hledger check after writing", async () => {
 
 test("throws on validation failure", async () => {
   writeFileSync(join(LEDGER, "main.journal"), "");
-  mockProc = makeMockProc(1, "", "account not declared");
+  setMock(1, "", "account not declared");
   await expect(run(basicParams)).rejects.toThrow("account not declared");
 });
 
@@ -197,7 +232,7 @@ test("rejects multiple postings without amount", async () => {
 
 test("hledger not found throws error", async () => {
   writeFileSync(join(LEDGER, "main.journal"), "");
-  mockProc = makeMockProc(127);
+  setMock(127);
   await expect(run(basicParams)).rejects.toThrow("hledger not found");
 });
 
@@ -273,6 +308,102 @@ test("should re-throw unexpected validation errors", async () => {
     throw new TypeError("unexpected");
   });
   await expect(run(basicParams)).rejects.toThrow("unexpected");
+});
+
+// ── beautification ─────────────────────────────────────────────────
+
+describe("beautification", () => {
+  test("should sort transactions by date in the monthly file after hledger check succeeds", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    // Pre-seed with a later-dated transaction; adding an earlier-dated one should push it above
+    writeFileSync(
+      join(LEDGER, "2026", "03.journal"),
+      "2026-03-28 * Later | After\n    Expenses:Misc    10.00 USD\n    Assets:Checking\n",
+    );
+    await run(basicParams);
+    const content = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    const earlierIdx = content.indexOf("2026-03-15");
+    const laterIdx = content.indexOf("2026-03-28");
+    expect(earlierIdx).toBeGreaterThanOrEqual(0);
+    expect(laterIdx).toBeGreaterThanOrEqual(0);
+    expect(earlierIdx).toBeLessThan(laterIdx);
+  });
+
+  test("should align all posting amounts in the file to column 70 (MIN_AMOUNT_COLUMN)", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    // Pre-seed with a shorter-account transaction
+    writeFileSync(
+      join(LEDGER, "2026", "03.journal"),
+      "2026-03-01 * Old | Existing\n    Expenses:Misc    10.00 USD\n    Assets:Checking\n",
+    );
+    await run(basicParams);
+    const content = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    // All accounts are shorter than 70 - MIN_GAP, so the amount column is
+    // clamped to MIN_AMOUNT_COLUMN = 70.
+    //   Expenses:Misc (13) → padding = 70 - 4 - 13 = 53
+    //   Expenses:Food:Groceries (23) → padding = 70 - 4 - 23 = 43
+    expect(content).toContain(`    Expenses:Misc${" ".repeat(53)}10.00 USD`);
+    expect(content).toContain(`    Expenses:Food:Groceries${" ".repeat(43)}45.00 USD`);
+  });
+
+  test("should leave the file in its beautified form when hledger check fails", async () => {
+    // Beautify runs BEFORE hledgerCheck, so even when the check fails, the
+    // file on disk reflects the beautified (sorted/aligned) state.
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    const preSeeded = "2026-03-20 * Existing\n    Expenses:Misc  10.00 USD\n    Assets:Checking\n";
+    writeFileSync(join(LEDGER, "2026", "03.journal"), preSeeded);
+    setMock(1, "", "account not declared");
+
+    await expect(run(basicParams)).rejects.toThrow("account not declared");
+
+    // All accounts are short → clamped to MIN_AMOUNT_COLUMN = 70.
+    // Expenses:Misc (13) padding = 70 - 4 - 13 = 53.
+    const content = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    expect(content).toContain(`    Expenses:Misc${" ".repeat(53)}10.00 USD`);
+  });
+
+  test("should return a diff reflecting the beautified file content", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    // Pre-seed: an OUT-OF-ORDER transaction dated AFTER basicParams
+    writeFileSync(
+      join(LEDGER, "2026", "03.journal"),
+      "2026-03-28 * Later\n    Expenses:Misc    10.00 USD\n    Assets:Checking\n",
+    );
+    const result = await run(basicParams);
+    const diff = result.details.diff;
+    // Diff should contain additions for the new transaction (Whole Foods)
+    expect(diff).toContain("Whole Foods");
+    // The final file should have the new (earlier) transaction sorted to the top
+    const finalContent = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    expect(finalContent.indexOf("Whole Foods")).toBeLessThan(finalContent.indexOf("Later"));
+  });
+
+  test("should not modify main.journal during beautification", async () => {
+    const originalMain = "; Accountant24 Personal Finances\naccount Assets:Checking\n";
+    writeFileSync(join(LEDGER, "main.journal"), originalMain);
+    await run(basicParams);
+    const mainAfter = readFileSync(join(LEDGER, "main.journal"), "utf-8");
+    // main.journal still has its original opening content (commodity may be prepended, include may be appended)
+    expect(mainAfter).toContain("; Accountant24 Personal Finances");
+    expect(mainAfter).toContain("account Assets:Checking");
+  });
+
+  test("should be idempotent: formatting a second time should produce identical content", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    await run(basicParams);
+    const afterFirst = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    // Run the same add again — it'll add a duplicate transaction; we only check that the format is stable
+    await run({ ...basicParams, payee: "Different Store" });
+    const afterSecond = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    // Verify the first transaction's line is byte-identical in the second state
+    const firstLine = afterFirst.split("\n").find((l) => l.includes("45.00 USD"));
+    expect(firstLine).toBeDefined();
+    expect(afterSecond).toContain(firstLine!);
+  });
 });
 
 // ── rendering wiring ──────────────────────────────────────────────

--- a/src/extension/tools/__tests__/validate.test.ts
+++ b/src/extension/tools/__tests__/validate.test.ts
@@ -1,18 +1,23 @@
-import { afterAll, afterEach, beforeEach, expect, mock, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const BASE = mkdtempSync(join(tmpdir(), "accountant24-validate-"));
+const LEDGER = join(BASE, "ledger");
 
 mock.module("../../config.js", () => ({
   ACCOUNTANT24_HOME: BASE,
   MEMORY_PATH: join(BASE, "memory.md"),
-  LEDGER_DIR: join(BASE, "ledger"),
+  LEDGER_DIR: LEDGER,
+  FILES_DIR: join(BASE, "files"),
   setBaseDir: () => {},
 }));
 
-// Mock at Bun.spawn level so real hledger.ts functions execute for coverage
+// Mock at Bun.spawn level. Dispatch on argv: `hledger files` returns the set
+// of .journal files in the test LEDGER dir (simulating hledger's include-
+// graph resolution); anything else (primarily `hledger check`) returns the
+// configurable mock result.
 const origSpawn = Bun.spawn;
 
 function makeMockProc(exitCode: number, stdout = "", stderr = "") {
@@ -24,7 +29,32 @@ function makeMockProc(exitCode: number, stdout = "", stderr = "") {
   };
 }
 
-let mockProc: ReturnType<typeof makeMockProc>;
+// Walk LEDGER and return every .journal file: top-level files + monthly
+// files under YYYY/MM.journal.
+function collectLedgerJournalFiles(): string[] {
+  if (!existsSync(LEDGER)) return [];
+  const result: string[] = [];
+  for (const entry of readdirSync(LEDGER, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.endsWith(".journal")) {
+      result.push(join(LEDGER, entry.name));
+    } else if (entry.isDirectory() && /^\d{4}$/.test(entry.name)) {
+      for (const f of readdirSync(join(LEDGER, entry.name))) {
+        if (/^\d{2}\.journal$/.test(f)) result.push(join(LEDGER, entry.name, f));
+      }
+    }
+  }
+  return result.sort();
+}
+
+let mockExitCode: number;
+let mockStdout: string;
+let mockStderr: string;
+
+const setMock = (exit: number, stdout = "", stderr = "") => {
+  mockExitCode = exit;
+  mockStdout = stdout;
+  mockStderr = stderr;
+};
 
 const { validateTool } = await import("../validate.js");
 
@@ -34,9 +64,18 @@ afterAll(() => {
 });
 
 beforeEach(() => {
-  mockProc = makeMockProc(0);
+  setMock(0);
   // @ts-expect-error - mocking Bun.spawn
-  Bun.spawn = mock(() => mockProc);
+  Bun.spawn = mock((argv: string[]) => {
+    if (argv.includes("files")) {
+      const list = collectLedgerJournalFiles().join("\n");
+      return makeMockProc(0, list.length > 0 ? `${list}\n` : "");
+    }
+    return makeMockProc(mockExitCode, mockStdout, mockStderr);
+  });
+  // Clean and recreate ledger dir per test
+  rmSync(LEDGER, { recursive: true, force: true });
+  mkdirSync(LEDGER, { recursive: true });
 });
 
 afterEach(() => {
@@ -47,18 +86,18 @@ const run = (params: any) =>
   validateTool.execute("test", params, undefined, undefined, undefined as any) as Promise<any>;
 
 test("throws when hledger not found", async () => {
-  mockProc = makeMockProc(127);
+  setMock(127);
   await expect(run({})).rejects.toThrow("hledger not found");
 });
 
 test("returns valid result on success", async () => {
-  mockProc = makeMockProc(0);
+  setMock(0);
   const result = await run({});
   expect(result.details.ledgerIsValid).toBe(true);
 });
 
 test("throws on validation failure", async () => {
-  mockProc = makeMockProc(1, "", "hledger: Error: account not declared");
+  setMock(1, "", "hledger: Error: account not declared");
   await expect(run({})).rejects.toThrow("account not declared");
 });
 
@@ -67,4 +106,146 @@ test("re-throws unexpected errors", async () => {
     throw new TypeError("unexpected");
   });
   await expect(run({})).rejects.toThrow("unexpected");
+});
+
+// ── beautification ─────────────────────────────────────────────────
+
+describe("beautification", () => {
+  test("should sort and align each monthly file after hledger check succeeds", async () => {
+    mkdirSync(join(LEDGER, "2025"), { recursive: true });
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    // Out-of-order, misaligned in 2025/12.journal
+    writeFileSync(
+      join(LEDGER, "2025", "12.journal"),
+      [
+        "2025-12-28 * Later",
+        "    Expenses:Misc  10.00 USD",
+        "    Assets:Checking",
+        "",
+        "2025-12-01 * Earlier",
+        "    Expenses:Misc  5.00 USD",
+        "    Assets:Checking",
+      ].join("\n") + "\n",
+    );
+    // Simple file in 2026/01.journal
+    writeFileSync(
+      join(LEDGER, "2026", "01.journal"),
+      "2026-01-01 * Tx\n    Expenses:Food  5.00 USD\n    Assets:Checking\n",
+    );
+
+    await run({});
+
+    const dec = readFileSync(join(LEDGER, "2025", "12.journal"), "utf-8");
+    // Sorted: Earlier before Later
+    expect(dec.indexOf("Earlier")).toBeLessThan(dec.indexOf("Later"));
+    // Aligned to MIN_AMOUNT_COLUMN=70: Expenses:Misc (13) at indent 4 →
+    // padding = 70 - 4 - 13 = 53 spaces
+    expect(dec).toContain(`    Expenses:Misc${" ".repeat(53)}5.00 USD`);
+    expect(dec).toContain(`    Expenses:Misc${" ".repeat(53)}10.00 USD`);
+
+    const jan = readFileSync(join(LEDGER, "2026", "01.journal"), "utf-8");
+    // Expenses:Food (13) at indent 4 → padding = 70 - 4 - 13 = 53 spaces
+    expect(jan).toContain(`    Expenses:Food${" ".repeat(53)}5.00 USD`);
+  });
+
+  test("should not modify main.journal or accounts.journal", async () => {
+    const mainContent = "; main\ninclude 2026/01.journal\n";
+    const accountsContent = "account Assets:Checking\n";
+    writeFileSync(join(LEDGER, "main.journal"), mainContent);
+    writeFileSync(join(LEDGER, "accounts.journal"), accountsContent);
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    writeFileSync(
+      join(LEDGER, "2026", "01.journal"),
+      "2026-01-01 * Tx\n    Expenses:Misc    1.00 USD\n    Assets:Checking\n",
+    );
+
+    await run({});
+
+    expect(readFileSync(join(LEDGER, "main.journal"), "utf-8")).toBe(mainContent);
+    expect(readFileSync(join(LEDGER, "accounts.journal"), "utf-8")).toBe(accountsContent);
+  });
+
+  test("should skip files in non-year-named directories", async () => {
+    mkdirSync(join(LEDGER, "archive"), { recursive: true });
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    const archiveContent =
+      "2020-02-01 * Later\n    Expenses:Misc    1.00 USD\n    Assets:Checking\n\n2020-01-01 * Earlier\n    Expenses:Misc    2.00 USD\n    Assets:Checking\n";
+    writeFileSync(join(LEDGER, "archive", "01.journal"), archiveContent);
+    writeFileSync(
+      join(LEDGER, "2026", "01.journal"),
+      "2026-01-01 * New\n    Expenses:Misc    1.00 USD\n    Assets:Checking\n",
+    );
+
+    await run({});
+
+    // archive/01.journal was not touched (still has transactions in original order)
+    expect(readFileSync(join(LEDGER, "archive", "01.journal"), "utf-8")).toBe(archiveContent);
+  });
+
+  test("should skip files whose name is not two-digit month .journal", async () => {
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    const badContent =
+      "2026-02-01 * Later\n    Expenses:Misc    1.00 USD\n    Assets:Checking\n\n2026-01-01 * Earlier\n    Expenses:Misc    2.00 USD\n    Assets:Checking\n";
+    writeFileSync(join(LEDGER, "2026", "january.journal"), badContent);
+    writeFileSync(
+      join(LEDGER, "2026", "01.journal"),
+      "2026-01-02 * Tx\n    Expenses:Misc    1.00 USD\n    Assets:Checking\n",
+    );
+
+    await run({});
+
+    // january.journal was not touched (still has transactions in original order)
+    expect(readFileSync(join(LEDGER, "2026", "january.journal"), "utf-8")).toBe(badContent);
+  });
+
+  test("should leave files in their beautified form when hledger check fails", async () => {
+    // Beautify runs BEFORE hledgerCheck, so even on check failure the files
+    // on disk reflect the beautified (sorted + aligned) state.
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    const contentBefore =
+      "2026-01-28 * Later\n    Expenses:Misc  1.00 USD\n    Assets:Checking\n\n2026-01-01 * Earlier\n    Expenses:Misc  2.00 USD\n    Assets:Checking\n";
+    writeFileSync(join(LEDGER, "2026", "01.journal"), contentBefore);
+    setMock(1, "", "hledger: Error: account not declared");
+
+    await expect(run({})).rejects.toThrow("account not declared");
+
+    const after = readFileSync(join(LEDGER, "2026", "01.journal"), "utf-8");
+    // Sorted: Earlier (01) before Later (28)
+    expect(after.indexOf("Earlier")).toBeLessThan(after.indexOf("Later"));
+    // Aligned to MIN_AMOUNT_COLUMN=70: Expenses:Misc (13) at indent 4 →
+    // padding = 70 - 4 - 13 = 53 spaces
+    expect(after).toContain(`    Expenses:Misc${" ".repeat(53)}1.00 USD`);
+    expect(after).toContain(`    Expenses:Misc${" ".repeat(53)}2.00 USD`);
+  });
+
+  test("should succeed when there are no monthly files", async () => {
+    // Only non-monthly files in ledger dir
+    writeFileSync(join(LEDGER, "main.journal"), "; empty\n");
+
+    const result = await run({});
+
+    expect(result.details.ledgerIsValid).toBe(true);
+  });
+
+  test("should be idempotent: running validate twice produces identical content", async () => {
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    writeFileSync(
+      join(LEDGER, "2026", "03.journal"),
+      [
+        "2026-03-28 * Later",
+        "    Expenses:Misc  3.00 USD",
+        "    Assets:Checking",
+        "",
+        "2026-03-01 * Earlier",
+        "    Expenses:Misc  1.00 USD",
+        "    Assets:Checking",
+      ].join("\n") + "\n",
+    );
+
+    await run({});
+    const afterFirst = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    await run({});
+    const afterSecond = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    expect(afterSecond).toBe(afterFirst);
+  });
 });


### PR DESCRIPTION
Introduce a pure-TypeScript journal formatter (parse → transform → emit pipeline) that sorts transactions by date, groups postings by sign, splits and sorts tag comments, and aligns amounts on the first digit at column 70 or further right when an account is long enough to push past that floor. The formatter runs before hledgerCheck in both addTransaction and validateLedger so any layout regression is caught immediately by the validator.