### PR TITLE
fix: make release tap update idempotent + add --tap-only

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -15,12 +15,16 @@
 //   A24_TAP_REPO   git URL of the tap (default: git@github.com:machulav/homebrew-tap.git)
 //   A24_TAP_LOCAL  local checkout path (default: ../homebrew-tap)
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const DRY = process.argv.includes("--dry-run");
+// Re-run only the Homebrew tap update (e.g. to finish a release whose GitHub
+// release already published but whose tap push failed). Uses the current
+// package.json version and release/SHA256SUMS.
+const TAP_ONLY = process.argv.includes("--tap-only");
 const TAP_REPO = process.env.A24_TAP_REPO ?? "git@github.com:machulav/homebrew-tap.git";
 const TAP_LOCAL = process.env.A24_TAP_LOCAL ?? join(ROOT, "..", "homebrew-tap");
 
@@ -48,6 +52,15 @@ const TARBALLS = [
 ] as const;
 
 async function main() {
+  // Recovery path: finish a release whose tap update failed.
+  if (TAP_ONLY) {
+    const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8"));
+    console.log(`[release] --tap-only: updating Homebrew tap for v${pkg.version}`);
+    await updateBrewTap(pkg.version);
+    console.log(`[release] ✓ tap updated for v${pkg.version}`);
+    return;
+  }
+
   // 1. preflight checks
   const status = await sh(["git", "status", "--porcelain"], { capture: true, allowDry: true });
   if (status.length > 0) throw new Error(`Working tree not clean:\n${status}`);
@@ -113,12 +126,20 @@ async function updateBrewTap(version: string): Promise<void> {
     if (!shaMap.has(name)) throw new Error(`Missing SHA for ${name} in SHA256SUMS`);
   }
 
-  // ensure tap checkout exists
-  if (!existsSync(join(TAP_LOCAL, ".git"))) {
+  // ensure tap checkout exists and is a clean, up-to-date clone
+  if (existsSync(join(TAP_LOCAL, ".git"))) {
+    await sh(["git", "-C", TAP_LOCAL, "fetch", "origin"]);
+    await sh(["git", "-C", TAP_LOCAL, "pull", "--ff-only"]);
+  } else {
+    // A prior failed run can leave a non-repo dir here (e.g. just `Formula/`);
+    // git clone refuses a non-empty destination, so remove it first.
+    if (existsSync(TAP_LOCAL)) {
+      console.log(`[release] removing stale non-repo tap dir ${TAP_LOCAL}`);
+      if (!DRY) rmSync(TAP_LOCAL, { recursive: true, force: true });
+    }
     console.log(`[release] cloning tap into ${TAP_LOCAL}`);
     await sh(["git", "clone", TAP_REPO, TAP_LOCAL]);
   }
-  await sh(["git", "-C", TAP_LOCAL, "pull", "--ff-only"]);
 
   // render formula from template
   const tmpl = readFileSync(join(ROOT, "scripts", "accountant24.rb.template"), "utf-8");


### PR DESCRIPTION
## Problem

`bun run release` for v0.1.10 published the GitHub release successfully but failed at the final Homebrew-tap step:

```
fatal: destination path '.../homebrew-tap' already exists and is not an empty directory.
Command failed (128): git clone git@github.com:machulav/homebrew-tap.git .../homebrew-tap
```

`updateBrewTap` only cloned when `homebrew-tap/.git` was missing, but a prior failed run had left a `homebrew-tap/` directory (empty `Formula/`, no `.git`). `git clone` refuses a non-empty destination, so the tap update could never recover on its own — leaving `brew` stuck on the previous version while the GitHub release was already live.

## Fix

- **Idempotent tap acquisition:** if `homebrew-tap/` is a valid clone, `fetch` + `pull`; otherwise remove any stale non-repo directory and clone fresh.
- **`--tap-only` mode:** re-run just the Homebrew tap update for an already-published release — reads the current `package.json` version and `release/SHA256SUMS`, then renders/commits/pushes the formula. Skips the version bump, build, and GitHub upload (which would fail on the existing tag).

## Notes

Used to recover v0.1.10: `bun run scripts/release.ts --tap-only` brought the tap formula from 0.1.9 → 0.1.10 (SHAs verified against `release/SHA256SUMS`).