### PR TITLE
fix: resolve commitlint via bunx in commit-msg git hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "simple-git-hooks"
   },
   "simple-git-hooks": {
-    "commit-msg": "commitlint --edit $1",
+    "commit-msg": "bunx commitlint --edit $1",
     "pre-commit": "bun run pre-commit"
   },
   "commitlint": {


### PR DESCRIPTION
## Problem

The `simple-git-hooks` `commit-msg` hook ran bare `commitlint --edit $1`. `commitlint` is a local devDependency (`node_modules/.bin/commitlint`), so in any shell where `node_modules/.bin` isn't on `PATH` (non-interactive shells, scripted/agent commits, some CI) the commit fails with:

```
.git/hooks/commit-msg: line 12: commitlint: command not found
```

## Fix

Change the hook command to `bunx commitlint --edit $1`, which resolves the local `@commitlint/cli` regardless of `PATH`, then regenerate the hooks.

## Verification

In a shell with `node_modules/.bin` NOT on PATH (reproducing the failure):
- bare `commitlint` → not found; `bunx commitlint --version` → `@commitlint/cli@20.5.0`
- regenerated `.git/hooks/commit-msg` ends with `bunx commitlint --edit $1`
- good message → exit 0; bad message → exit 1 with the expected lint errors
- this very commit was made with a plain `git commit` (no PATH tweak) and the hook passed

> Note: after pulling, run `bun install` (or `bunx simple-git-hooks`) once to regenerate the local hook from the updated config.