### PR TITLE
fix: run commit-msg hook via bun run commitlint

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
     "pre-commit": "biome check --write . && biome check .",
     "release": "bun run scripts/release.ts",
     "release:dry": "bun run scripts/release.ts --dry-run",
+    "commitlint": "commitlint --edit",
     "prepare": "simple-git-hooks"
   },
   "simple-git-hooks": {
-    "commit-msg": "commitlint --edit $1",
+    "commit-msg": "bun run commitlint $1",
     "pre-commit": "bun run pre-commit"
   },
   "commitlint": {


### PR DESCRIPTION
## Problem

The `simple-git-hooks` `commit-msg` hook ran bare `commitlint --edit $1`. `commitlint` is a local devDependency (`node_modules/.bin/commitlint`), so in any shell where `node_modules/.bin` isn't on `PATH` (non-interactive shells, scripted/agent commits, some CI) commits fail with:

```
.git/hooks/commit-msg: line 12: commitlint: command not found
```

## Fix

Add a `commitlint` package script (`"commitlint": "commitlint --edit"`) and invoke it from the hook as `bun run commitlint $1`. `bun run` puts `node_modules/.bin` on `PATH`, so `commitlint` resolves — without `bunx` and without a hardcoded `node_modules/.bin` path. The command stays defined in `package.json` (single source of truth).

## Verification

In a shell with `node_modules/.bin` NOT on PATH (reproducing the failure):
- regenerated `.git/hooks/commit-msg` ends with `bun run commitlint $1`
- good message → exit 0; bad message → non-zero with the expected commitlint errors
- this commit was made with a plain `git commit` (no PATH tweak); the hook ran `commitlint --edit .git/COMMIT_EDITMSG` and passed

Supersedes #14 (which used `bunx`).

> After pulling, run `bun install` (or `bunx simple-git-hooks`) once to regenerate the local hook from the updated config.