### PR TITLE
feat: simplify the starter accounts and add naming rules

### DIFF
--- a/packages/pi-extension/src/scaffold/__tests__/scaffold.test.ts
+++ b/packages/pi-extension/src/scaffold/__tests__/scaffold.test.ts
@@ -83,11 +83,36 @@ describe("ensureScaffolded()", () => {
   test("should write accounts.journal with all five account types", async () => {
     await ensureScaffolded();
     const content = readFileSync(join(BASE, "ledger", "accounts.journal"), "utf-8");
-    expect(content).toContain("account assets:");
-    expect(content).toContain("account liabilities:");
-    expect(content).toContain("account equity:");
-    expect(content).toContain("account income:");
-    expect(content).toContain("account expenses:");
+    expect(content).toContain("account Assets:");
+    expect(content).toContain("account Liabilities:");
+    expect(content).toContain("account Equity:");
+    expect(content).toContain("account Income:");
+    expect(content).toContain("account Expenses:");
+  });
+
+  test("should write accounts.journal with capitalized account names only", async () => {
+    await ensureScaffolded();
+    const content = readFileSync(join(BASE, "ledger", "accounts.journal"), "utf-8");
+    const names = content.match(/^account (\S+)/gm) ?? [];
+    expect(names.length).toBeGreaterThan(0);
+    for (const name of names) {
+      expect(name).toMatch(/^account [A-Z]/);
+    }
+  });
+
+  test("should keep expense accounts one level deep (high-level categories only)", async () => {
+    await ensureScaffolded();
+    const content = readFileSync(join(BASE, "ledger", "accounts.journal"), "utf-8");
+    const expenseLines = content.split("\n").filter((l) => l.startsWith("account Expenses:"));
+    expect(expenseLines.length).toBeGreaterThan(0);
+    for (const line of expenseLines) {
+      // Strip the inline comment, then require exactly one colon (Expenses:Category)
+      const name = line
+        .replace(/^account /, "")
+        .split(";")[0]
+        .trim();
+      expect(name.match(/:/g)).toHaveLength(1);
+    }
   });
 
   test("should write .gitignore with auth exclusion", async () => {

--- a/packages/pi-extension/src/scaffold/__tests__/scaffold.test.ts
+++ b/packages/pi-extension/src/scaffold/__tests__/scaffold.test.ts
@@ -76,7 +76,7 @@ describe("ensureScaffolded()", () => {
   test("should write accounts.journal with semicolon comments", async () => {
     await ensureScaffolded();
     const content = readFileSync(join(BASE, "ledger", "accounts.journal"), "utf-8");
-    expect(content).toContain("; Default chart of accounts");
+    expect(content).toContain("; Chart of accounts");
     expect(content).not.toMatch(/^#/m);
   });
 

--- a/packages/pi-extension/src/scaffold/template/ledger/accounts.journal
+++ b/packages/pi-extension/src/scaffold/template/ledger/accounts.journal
@@ -11,131 +11,57 @@
 ; ASSETS — things you own (bank accounts, cash, investments)
 ; ====================================================================
 
-account assets:cash
+account Assets:Cash
 
 ; ====================================================================
 ; LIABILITIES — things you owe (credit cards, loans, mortgages)
 ; ====================================================================
 
-account liabilities:credit-card
-account liabilities:mortgage
-account liabilities:car-loan
-account liabilities:student-loan
-account liabilities:loan
+account Liabilities:Credit Card
+account Liabilities:Mortgage
+account Liabilities:Car Loan
+account Liabilities:Student Loan
+account Liabilities:Loan
 
 ; ====================================================================
 ; EQUITY — owner's investment, balances assets and liabilities
 ; ====================================================================
 
-account equity:opening-balances
+account Equity:Opening Balances
 
 ; ====================================================================
 ; INCOME — inflows of money (salary, business, interest)
 ; ====================================================================
 
-account income:salary
-account income:business
-account income:investment
-account income:interest
-account income:rental
-account income:gifts-received
-account income:government-benefits
-account income:tax-refund
-account income:other
+account Income:Salary
+account Income:Business
+account Income:Investment
+account Income:Interest
+account Income:Rental
+account Income:Gifts Received
+account Income:Government Benefits
+account Income:Tax Refund
+account Income:Other
 
 ; ====================================================================
 ; EXPENSES — outflows of money (rent, groceries, subscriptions)
 ; ====================================================================
 
-account expenses:housing:rent
-account expenses:housing:insurance
-account expenses:housing:maintenance-and-repairs
-account expenses:housing:other
-
-account expenses:utilities:electricity
-account expenses:utilities:gas
-account expenses:utilities:water
-account expenses:utilities:internet
-account expenses:utilities:phone
-account expenses:utilities:sewage-and-waste
-account expenses:utilities:other
-
-account expenses:food:groceries
-account expenses:food:dining-out
-account expenses:food:delivery
-account expenses:food:coffee-shops
-account expenses:food:other
-
-account expenses:transport:fuel
-account expenses:transport:public-transit
-account expenses:transport:taxi-and-rideshare
-account expenses:transport:carsharing
-account expenses:transport:parking
-account expenses:transport:car-insurance
-account expenses:transport:car-maintenance
-account expenses:transport:bike-and-scooter
-account expenses:transport:other
-
-account expenses:shopping:clothing-and-accessories
-account expenses:shopping:electronics
-account expenses:shopping:home-goods-and-furniture
-account expenses:shopping:other
-
-account expenses:entertainment:events-and-activities
-account expenses:entertainment:video-games
-account expenses:entertainment:hobbies
-account expenses:entertainment:other
-
-account expenses:travel:transportation
-account expenses:travel:accommodation
-account expenses:travel:food
-account expenses:travel:other
-
-account expenses:health:insurance
-account expenses:health:doctor-and-hospital
-account expenses:health:pharmacy-and-medications
-account expenses:health:other
-
-account expenses:personal-care:hair-and-beauty
-account expenses:personal-care:gym-and-fitness
-account expenses:personal-care:other
-
-account expenses:education:tuition-and-courses
-account expenses:education:books
-account expenses:education:other
-
-account expenses:children:childcare
-account expenses:children:activities
-account expenses:children:other
-
-account expenses:pets:food-and-supplies
-account expenses:pets:vet-and-health
-account expenses:pets:other
-
-account expenses:financial:bank-fees
-account expenses:financial:credit-card-interest
-account expenses:financial:mortgage-interest
-account expenses:financial:car-loan-interest
-account expenses:financial:student-loan-interest
-account expenses:financial:loan-interest
-account expenses:financial:other
-
-account expenses:taxes:income-tax
-account expenses:taxes:property-tax
-account expenses:taxes:other
-
-account expenses:professional-services:legal
-account expenses:professional-services:tax-and-accounting
-account expenses:professional-services:consulting
-account expenses:professional-services:other
-
-account expenses:gifts-and-donations:gifts
-account expenses:gifts-and-donations:charity
-account expenses:gifts-and-donations:other
-
-account expenses:subscriptions:streaming
-account expenses:subscriptions:software-and-apps
-account expenses:subscriptions:memberships
-account expenses:subscriptions:other
-
-account expenses:uncategorized
+account Expenses:Housing                ; rent, home insurance, maintenance and repairs
+account Expenses:Utilities              ; electricity, gas, water, internet, phone, sewage and waste
+account Expenses:Food                   ; groceries, dining out, delivery, coffee shops
+account Expenses:Transport              ; fuel, public transit, taxi, parking, car insurance and maintenance
+account Expenses:Shopping               ; clothing, electronics, home goods and furniture
+account Expenses:Entertainment          ; events, activities, video games, hobbies
+account Expenses:Travel                 ; transportation, accommodation, food while traveling
+account Expenses:Health                 ; health insurance, doctors, hospitals, pharmacy, medications
+account Expenses:Personal Care          ; hair, beauty, gym and fitness
+account Expenses:Education              ; tuition, courses, books
+account Expenses:Children               ; childcare, kids' activities
+account Expenses:Pets                   ; pet food, supplies, vet
+account Expenses:Financial              ; bank fees, credit card and loan interest
+account Expenses:Taxes                  ; income tax, property tax
+account Expenses:Professional Services  ; legal, tax and accounting, consulting
+account Expenses:Gifts & Donations      ; gifts, charity
+account Expenses:Subscriptions          ; streaming, software and apps, memberships
+account Expenses:Uncategorized          ; transactions pending categorization

--- a/packages/pi-extension/src/scaffold/template/ledger/accounts.journal
+++ b/packages/pi-extension/src/scaffold/template/ledger/accounts.journal
@@ -1,47 +1,38 @@
-; Default chart of accounts for accountant24
+; Chart of accounts — every account used in the ledger must be declared here.
 ;
 ; Account types:
-;   ASSETS       — things you own (bank accounts, cash, investments)
+;   ASSETS       — things you own (cash, bank accounts, investments, property)
 ;   LIABILITIES  — things you owe (credit cards, loans, mortgages)
-;   EQUITY       — owner's investment, balances assets and liabilities
-;   INCOME       — inflows of money (salary, business, interest)
+;   EQUITY       — technical balancing entries, not real money flows (opening balances, currency conversion)
+;   INCOME       — inflows of money (salary, business, investments)
 ;   EXPENSES     — outflows of money (rent, groceries, subscriptions)
 
 ; ====================================================================
-; ASSETS — things you own (bank accounts, cash, investments)
+; ASSETS — things you own (cash, bank accounts, investments, property)
 ; ====================================================================
 
-account Assets:Cash
+account Assets:Cash  ; physical cash
 
 ; ====================================================================
 ; LIABILITIES — things you owe (credit cards, loans, mortgages)
 ; ====================================================================
 
-account Liabilities:Credit Card
-account Liabilities:Mortgage
-account Liabilities:Car Loan
-account Liabilities:Student Loan
-account Liabilities:Loan
+account Liabilities:Loan  ; personal loans
 
 ; ====================================================================
-; EQUITY — owner's investment, balances assets and liabilities
+; EQUITY — technical balancing entries, not real money flows (opening balances, currency conversion)
 ; ====================================================================
 
-account Equity:Opening Balances
+account Equity:Opening Balances  ; counterpart for initial account balances
 
 ; ====================================================================
-; INCOME — inflows of money (salary, business, interest)
+; INCOME — inflows of money (salary, business, investments)
 ; ====================================================================
 
-account Income:Salary
-account Income:Business
-account Income:Investment
-account Income:Interest
-account Income:Rental
-account Income:Gifts Received
-account Income:Government Benefits
-account Income:Tax Refund
-account Income:Other
+account Income:Salary      ; wages, bonuses, employer benefits
+account Income:Business    ; self-employment, freelance, side gigs
+account Income:Investment  ; dividends, capital gains, interest
+account Income:Other       ; gifts, tax refunds, government benefits
 
 ; ====================================================================
 ; EXPENSES — outflows of money (rent, groceries, subscriptions)
@@ -58,10 +49,8 @@ account Expenses:Health                 ; health insurance, doctors, hospitals, 
 account Expenses:Personal Care          ; hair, beauty, gym and fitness
 account Expenses:Education              ; tuition, courses, books
 account Expenses:Children               ; childcare, kids' activities
-account Expenses:Pets                   ; pet food, supplies, vet
-account Expenses:Financial              ; bank fees, credit card and loan interest
+account Expenses:Financial              ; bank fees, interest, legal and accounting services
 account Expenses:Taxes                  ; income tax, property tax
-account Expenses:Professional Services  ; legal, tax and accounting, consulting
 account Expenses:Gifts & Donations      ; gifts, charity
 account Expenses:Subscriptions          ; streaming, software and apps, memberships
 account Expenses:Uncategorized          ; transactions pending categorization

--- a/packages/pi-extension/src/system-prompt/system.md
+++ b/packages/pi-extension/src/system-prompt/system.md
@@ -53,6 +53,8 @@ These rules are absolute. Do not violate them.
 - Normalize payee spelling against known payees (case-insensitively).
 - Category: the user's explicit category wins; otherwise use ledger history for that payee; ask when ambiguous or absent.
 - Account: the user's explicit account overrides memory defaults; otherwise use the default; ask if none.
+- Accounts for real-world things (bank accounts, credit cards, brokers, property) get the real name as the leaf under their class, e.g. `Assets:Bank:N26`, `Liabilities:Credit Card:Amex`, `Assets:Investments:IBKR`. Create one the first time it appears — ask for the name if missing rather than booking to a generic account.
+- Refunds reverse the account of the original payment (a returned purchase reduces its expense account); book to income only when the original payment was never in the ledger (e.g. a tax refund on withheld salary tax).
 - When the user omits the currency, use the memory default.
 - When the user attaches a non-image file (PDF, CSV, …), the message carries an `[[attachment]]{"name":…,"path":…}` marker. The file is already saved in the workspace at `path` (e.g., `files/2026/04/20260417160112.pdf`); pass that path to `extract_text` or other tools — never use absolute paths with `extract_text`. (Images are attached directly as content; they are archived too but need no path.)
 - On import (bank statements, receipts), preserve the original bank payee using the `original_payee_name` tag, store the bank description with the `original_description` tag, and link the source document with the `related_file` tag (path relative to workspace).

--- a/packages/pi-extension/src/tools/add-transactions.ts
+++ b/packages/pi-extension/src/tools/add-transactions.ts
@@ -4,7 +4,7 @@ import { type AddTransactionsResult, addTransactions } from "../ledger";
 import { TOOL_LABELS } from "../tool-labels";
 
 const Posting = Type.Object({
-  account: Type.String({ description: "Account name, e.g. Expenses:Food:Groceries" }),
+  account: Type.String({ description: "Account name, e.g. Expenses:Food" }),
   amount: Type.Number({ description: "Amount — use negative for outflows (e.g. -45), positive for inflows" }),
   currency: Type.String({ description: "Currency code, e.g. USD, EUR" }),
 });

--- a/packages/pi-extension/src/tools/query.ts
+++ b/packages/pi-extension/src/tools/query.ts
@@ -46,9 +46,7 @@ const Params = Type.Object({
       { description: "Period grouping for multi-period reports" },
     ),
   ),
-  depth: Type.Optional(
-    Type.Number({ description: "Account depth limit (2 = Expenses:Food, not Expenses:Food:Groceries)" }),
-  ),
+  depth: Type.Optional(Type.Number({ description: "Account depth limit (2 = Assets:Bank, not Assets:Bank:Checking)" })),
   invert: Type.Optional(Type.Boolean({ description: "Flip signs — show expenses as positive (--invert)" })),
   output_format: Type.Optional(
     Type.Union([Type.Literal("txt"), Type.Literal("csv"), Type.Literal("json"), Type.Literal("tsv")], {


### PR DESCRIPTION
## Summary

Implements A24-7 — make the default chart of accounts simple, readable, and chat-friendly.

- **Flatten expense accounts to high-level categories**: the three-level sub-accounts are gone; each spending category is one account (`Expenses:Housing`, `Expenses:Food`, …, `Expenses:Uncategorized` — 16 total, down from 66), each with an inline `;` hint listing what it covers so the agent keeps its categorization cues.
- **Rename all accounts for chat readability**: capitalized segments with spaces instead of hyphens, e.g. `income:salary` → `Income:Salary`, `expenses:personal-care` → `Expenses:Personal Care` — matching the style briefing queries and tool descriptions already use.
- **Keep only universal starter accounts**: dropped the ones better created on demand — credit cards, mortgage and specific loans, rental income, pets, professional services. Income is now 4 accounts (`Salary`, `Business`, `Investment`, `Other`), liabilities just `Loan`.
- **Teach the agent how to grow the chart**: new system prompt heuristics — accounts for real-world things (banks, credit cards, brokers, property) get their real name as the leaf (`Assets:Bank:N26`, `Liabilities:Credit Card:Amex`) and are created on first use instead of booked to generic buckets; refunds reverse the account of the original payment rather than counting as income.
- **Plain-language descriptions everywhere**: every account type and account carries a human-readable hint (e.g. EQUITY is "technical balancing entries, not real money flows"), and tool examples are aligned with the flattened chart.

The template only applies to fresh scaffolds — an existing `accounts.journal` is never overwritten.

## Test plan

- `npx vitest run` — full monorepo suite passes (1090 tests)
- `hledger check accounts` passes on the new template; strict-mode transactions against spaced names (`Expenses:Personal Care`, `Expenses:Gifts & Donations`) validate and report correctly