### PR TITLE
feat(desktop): dashboard

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -49,6 +49,9 @@
           "correctness": {
             "useExhaustiveDependencies": "off"
           },
+          "security": {
+            "noDangerouslySetInnerHtml": "off"
+          },
           "suspicious": {
             "noDocumentCookie": "off",
             "noDoubleEquals": "off"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "accountant24",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "accountant24",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "workspaces": [
         "packages/*"
       ],
@@ -6973,6 +6973,42 @@
       "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.11",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.11.tgz",
+      "integrity": "sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -7555,6 +7591,12 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -8010,6 +8052,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -8147,6 +8252,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
@@ -9872,6 +9983,127 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -9932,6 +10164,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -11156,7 +11394,6 @@
       "version": "1.49.0",
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
       "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
-      "dev": true,
       "license": "MIT",
       "workspaces": [
         "docs",
@@ -11281,6 +11518,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -12413,6 +12656,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -12482,6 +12735,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
@@ -15910,6 +16172,29 @@
         "react": ">=18"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -16070,6 +16355,57 @@
       },
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts/node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/remark-gfm": {
@@ -17959,6 +18295,28 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
     "node_modules/vite": {
       "version": "7.3.6",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
@@ -18460,7 +18818,7 @@
     },
     "packages/desktop": {
       "name": "@accountant24/desktop",
-      "version": "0.1.10",
+      "version": "0.0.0-dev",
       "dependencies": {
         "@aptabase/electron": "^0.3.1",
         "@assistant-ui/react": "^0.14.24",
@@ -18480,6 +18838,7 @@
         "lucide-react": "^1.21.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "recharts": "^3.8.0",
         "remark-gfm": "^4.0.1",
         "shadcn": "^4.13.0",
         "tailwind-merge": "^3.6.0",
@@ -18518,7 +18877,6 @@
     },
     "packages/pi-extension": {
       "name": "@accountant24/pi-extension",
-      "version": "0.1.9",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "0.79.8",
         "file-type": "22.0.1",

--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -5,10 +5,11 @@ import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 
 // Three-target build: main + preload run in Node (deps externalized so the pi
 // SDK and electron resolve from node_modules at runtime); renderer is the
-// existing Vite/React/Tailwind app, unchanged.
+// existing Vite/React/Tailwind app, unchanged. pi-extension is the exception:
+// its exports point at .ts source, so main bundles it instead of requiring it.
 export default defineConfig({
   main: {
-    plugins: [externalizeDepsPlugin()],
+    plugins: [externalizeDepsPlugin({ exclude: ["@accountant24/pi-extension"] })],
     build: {
       rollupOptions: { input: { index: path.resolve(import.meta.dirname, "electron/main/index.ts") } },
     },

--- a/packages/desktop/electron/main/ledger.ts
+++ b/packages/desktop/electron/main/ledger.ts
@@ -10,6 +10,7 @@
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
+import { fetchDashboardData } from "@accountant24/pi-extension/ledger/dashboard";
 import { ipcMain } from "electron";
 import { agentEnv, binDir, mainJournalPath, workspaceDir } from "./env";
 
@@ -55,7 +56,12 @@ async function ledgerMentions(): Promise<LedgerMentions> {
   return { accounts, payees, tags };
 }
 
-/** Register the ledger IPC handler (one call returns all three mention lists). */
+/** Register the ledger IPC handlers. */
 export function registerLedgerIpc(): void {
   ipcMain.handle("ledger_mentions", () => ledgerMentions());
+  // agentEnv() prepends the vendored bin dir to PATH, so pi-extension's
+  // spawn("hledger", ...) resolves the same binary the agent child uses.
+  ipcMain.handle("ledger_dashboard", () =>
+    fetchDashboardData(mainJournalPath(), { env: agentEnv(), cwd: workspaceDir() }),
+  );
 }

--- a/packages/desktop/electron/preload/index.ts
+++ b/packages/desktop/electron/preload/index.ts
@@ -32,6 +32,7 @@ const INVOKE_CHANNELS = new Set([
   "skills_set_enabled",
   "files_archive_to_workspace",
   "ledger_mentions",
+  "ledger_dashboard",
   "analytics_track",
   "update_pending",
   "update_install",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -30,6 +30,7 @@
     "lucide-react": "^1.21.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "recharts": "^3.8.0",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.13.0",
     "tailwind-merge": "^3.6.0",

--- a/packages/desktop/src/components/accountant24/dashboard/__tests__/category-bars.test.tsx
+++ b/packages/desktop/src/components/accountant24/dashboard/__tests__/category-bars.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { CategoryBars } from "../category-bars";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CategoryBars", () => {
+  it("should render a row with label and amount for each dominant-currency entry", () => {
+    render(
+      <CategoryBars
+        categories={[
+          { name: "food", amount: 500, currency: "EUR" },
+          { name: "housing", amount: 1200, currency: "EUR" },
+        ]}
+        currency="EUR"
+      />,
+    );
+    expect(screen.getByText("Food")).toBeTruthy();
+    expect(screen.getByText("500.00 EUR")).toBeTruthy();
+    expect(screen.getByText("Housing")).toBeTruthy();
+    expect(screen.getByText("1,200.00 EUR")).toBeTruthy();
+  });
+
+  it("should hide entries in other currencies", () => {
+    render(
+      <CategoryBars
+        categories={[
+          { name: "food", amount: 500, currency: "EUR" },
+          { name: "travel", amount: 900, currency: "UAH" },
+        ]}
+        currency="EUR"
+      />,
+    );
+    expect(screen.queryByText("Travel")).toBeNull();
+  });
+
+  it("should hide refund-only entries (non-positive amounts)", () => {
+    render(
+      <CategoryBars
+        categories={[
+          { name: "food", amount: 500, currency: "EUR" },
+          { name: "shopping", amount: -80, currency: "EUR" },
+        ]}
+        currency="EUR"
+      />,
+    );
+    expect(screen.queryByText("Shopping")).toBeNull();
+  });
+
+  it("should show an empty message when no rows remain", () => {
+    render(<CategoryBars categories={[]} currency="EUR" />);
+    expect(screen.getByText("No spending this month")).toBeTruthy();
+  });
+
+  it("should prettify hyphenated account names", () => {
+    render(<CategoryBars categories={[{ name: "personal-care", amount: 40, currency: "EUR" }]} currency="EUR" />);
+    expect(screen.getByText("Personal care")).toBeTruthy();
+  });
+});

--- a/packages/desktop/src/components/accountant24/dashboard/__tests__/finance-overview.test.tsx
+++ b/packages/desktop/src/components/accountant24/dashboard/__tests__/finance-overview.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DashboardData } from "../../../../rpc/types";
+
+// The hook is the faked boundary; the chart children are stubbed because
+// Recharts needs a real layout engine (ResizeObserver) that jsdom lacks.
+const useDashboardData = vi.fn<() => { data: DashboardData | null; loading: boolean }>();
+
+vi.mock("@/hooks/use-dashboard-data", () => ({ useDashboardData: () => useDashboardData() }));
+vi.mock("../stat-row", () => ({ StatRow: () => <div data-testid="stat-row" /> }));
+vi.mock("../net-worth-chart", () => ({ NetWorthChart: () => <div data-testid="net-worth-chart" /> }));
+vi.mock("../income-expense-chart", () => ({ IncomeExpenseChart: () => <div data-testid="income-expense-chart" /> }));
+vi.mock("../category-bars", () => ({ CategoryBars: () => <div data-testid="category-bars" /> }));
+
+import { FinanceOverview } from "../finance-overview";
+
+function makeData(overrides?: Partial<DashboardData>): DashboardData {
+  return {
+    netWorth: [{ amount: 5000, currency: "EUR", change: 100 }],
+    incomeThisMonth: [{ amount: 3000, currency: "EUR" }],
+    spendThisMonth: [{ amount: 1200, currency: "EUR" }],
+    topCategories: [{ name: "food", amount: 500, currency: "EUR" }],
+    netWorthSeries: [],
+    incomeExpenseSeries: [],
+    dominantCurrency: "EUR",
+    otherCurrencies: [],
+    hasTransactions: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useDashboardData.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("FinanceOverview", () => {
+  it("should render nothing while loading", () => {
+    useDashboardData.mockReturnValue({ data: null, loading: true });
+    const { container } = render(<FinanceOverview />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render nothing when the fetch failed", () => {
+    useDashboardData.mockReturnValue({ data: null, loading: false });
+    const { container } = render(<FinanceOverview />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render nothing when the data carries an error", () => {
+    useDashboardData.mockReturnValue({ data: makeData({ error: "hledger is not installed" }), loading: false });
+    const { container } = render(<FinanceOverview />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render nothing when the ledger has no transactions", () => {
+    useDashboardData.mockReturnValue({ data: makeData({ hasTransactions: false }), loading: false });
+    const { container } = render(<FinanceOverview />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render the stat row and all three charts when data is present", () => {
+    useDashboardData.mockReturnValue({ data: makeData(), loading: false });
+    render(<FinanceOverview />);
+    expect(screen.getByTestId("stat-row")).toBeTruthy();
+    expect(screen.getByTestId("net-worth-chart")).toBeTruthy();
+    expect(screen.getByTestId("income-expense-chart")).toBeTruthy();
+    expect(screen.getByTestId("category-bars")).toBeTruthy();
+  });
+});

--- a/packages/desktop/src/components/accountant24/dashboard/__tests__/stat-row.test.tsx
+++ b/packages/desktop/src/components/accountant24/dashboard/__tests__/stat-row.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { DashboardData } from "../../../../rpc/types";
+import { StatRow } from "../stat-row";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeData(overrides?: Partial<DashboardData>): DashboardData {
+  return {
+    netWorth: [{ amount: 5000, currency: "EUR", change: 800 }],
+    incomeThisMonth: [{ amount: 3000, currency: "EUR" }],
+    spendThisMonth: [{ amount: 1200, currency: "EUR" }],
+    topCategories: [],
+    netWorthSeries: [],
+    incomeExpenseSeries: [],
+    dominantCurrency: "EUR",
+    otherCurrencies: [],
+    hasTransactions: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+describe("StatRow", () => {
+  it("should show net worth, income and spend in the dominant currency", () => {
+    render(<StatRow data={makeData()} />);
+    expect(screen.getByText("5,000.00 EUR")).toBeTruthy();
+    expect(screen.getByText("3,000.00 EUR")).toBeTruthy();
+    expect(screen.getByText("1,200.00 EUR")).toBeTruthy();
+  });
+
+  it("should not show a month-over-month change line", () => {
+    render(<StatRow data={makeData()} />);
+    expect(screen.queryByText(/this month,|\+800/)).toBeNull();
+  });
+
+  it("should not show an other-currencies hint", () => {
+    render(
+      <StatRow
+        data={makeData({
+          netWorth: [
+            { amount: 5000, currency: "EUR", change: 800 },
+            { amount: 20000, currency: "UAH", change: 0 },
+          ],
+          otherCurrencies: ["UAH"],
+        })}
+      />,
+    );
+    expect(screen.queryByText(/more currenc/)).toBeNull();
+  });
+
+  it("should ignore other-currency net worth entries", () => {
+    render(
+      <StatRow
+        data={makeData({
+          netWorth: [
+            { amount: 20000, currency: "UAH", change: 0 },
+            { amount: 5000, currency: "EUR", change: 800 },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText("5,000.00 EUR")).toBeTruthy();
+    expect(screen.queryByText(/UAH/)).toBeNull();
+  });
+
+  it("should show zero income and spend when the month has no activity", () => {
+    render(<StatRow data={makeData({ incomeThisMonth: [], spendThisMonth: [] })} />);
+    expect(screen.getAllByText("0.00 EUR")).toHaveLength(2);
+  });
+});

--- a/packages/desktop/src/components/accountant24/dashboard/amounts.ts
+++ b/packages/desktop/src/components/accountant24/dashboard/amounts.ts
@@ -1,0 +1,6 @@
+import type { CurrencyAmount } from "@/rpc/types";
+
+/** The amount in `currency`, or 0 when the list has no entry for it. */
+export function amountFor(amounts: CurrencyAmount[], currency: string): number {
+  return amounts.find((a) => a.currency === currency)?.amount ?? 0;
+}

--- a/packages/desktop/src/components/accountant24/dashboard/category-bars.tsx
+++ b/packages/desktop/src/components/accountant24/dashboard/category-bars.tsx
@@ -1,0 +1,51 @@
+import type { FC } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/shadcn/card";
+import { formatAmount } from "@/lib/format-amount";
+import type { DashboardData } from "@/rpc/types";
+
+/** Ranked horizontal bars of this month's top spending accounts. Plain divs
+ *  rather than a chart: amounts are printed on each row, so no axis or tooltip
+ *  is needed at this card width. Single hue by design (one measure; identity
+ *  lives in the row labels). */
+export const CategoryBars: FC<{ categories: DashboardData["topCategories"]; currency: string }> = ({
+  categories,
+  currency,
+}) => {
+  const rows = categories.filter((c) => c.currency === currency && c.amount > 0);
+  const max = Math.max(...rows.map((r) => r.amount), 1);
+
+  return (
+    <Card className="gap-3 rounded-lg px-4 py-3 shadow-none">
+      <CardHeader className="p-0">
+        <CardTitle className="text-muted-foreground text-xs font-normal">Top spending this month</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col justify-center gap-2.5 p-0">
+        {rows.length === 0 && (
+          <div className="text-muted-foreground py-6 text-center text-xs">No spending this month</div>
+        )}
+        {rows.map((row) => (
+          <div key={row.name} className="flex items-center gap-2">
+            <span className="text-muted-foreground w-24 shrink-0 truncate text-xs" title={row.name}>
+              {displayAccountName(row.name)}
+            </span>
+            <div className="flex-1">
+              <div
+                className="h-3 rounded-r-[4px] bg-(--chart-2)"
+                style={{ width: `${Math.max((row.amount / max) * 100, 2)}%` }}
+              />
+            </div>
+            <span className="text-foreground shrink-0 text-xs tabular-nums">
+              {formatAmount(row.amount, row.currency)}
+            </span>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+};
+
+/** "personal-care" -> "Personal care" for row labels. */
+function displayAccountName(name: string): string {
+  const words = name.replace(/-/g, " ");
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}

--- a/packages/desktop/src/components/accountant24/dashboard/finance-overview.tsx
+++ b/packages/desktop/src/components/accountant24/dashboard/finance-overview.tsx
@@ -1,0 +1,27 @@
+import type { FC } from "react";
+import { useDashboardData } from "@/hooks/use-dashboard-data";
+import { CategoryBars } from "./category-bars";
+import { IncomeExpenseChart } from "./income-expense-chart";
+import { NetWorthChart } from "./net-worth-chart";
+import { StatRow } from "./stat-row";
+
+/** The main-page finance overview. Renders nothing while loading (no skeleton:
+ *  an empty ledger would show a skeleton that collapses on every app open),
+ *  on error, or when the ledger has no transactions yet; content fades in when
+ *  data arrives, and the hook's cache makes remounts instant. */
+export const FinanceOverview: FC = () => {
+  const { data, loading } = useDashboardData();
+
+  if (loading || !data || data.error !== null || !data.hasTransactions) return null;
+
+  return (
+    <div className="fade-in slide-in-from-bottom-1 animate-in fill-mode-both mb-8 flex flex-col gap-3 duration-200">
+      <StatRow data={data} />
+      <NetWorthChart series={data.netWorthSeries} currency={data.dominantCurrency} />
+      <div className="grid gap-3 sm:grid-cols-2">
+        <IncomeExpenseChart series={data.incomeExpenseSeries} currency={data.dominantCurrency} />
+        <CategoryBars categories={data.topCategories} currency={data.dominantCurrency} />
+      </div>
+    </div>
+  );
+};

--- a/packages/desktop/src/components/accountant24/dashboard/income-expense-chart.tsx
+++ b/packages/desktop/src/components/accountant24/dashboard/income-expense-chart.tsx
@@ -1,0 +1,86 @@
+import type { FC } from "react";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/shadcn/card";
+import { type ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/shadcn/chart";
+import { formatAmount, formatAmountCompact } from "@/lib/format-amount";
+import { formatMonthLong, formatMonthShort } from "@/lib/format-month";
+import type { IncomeExpensePoint } from "@/rpc/types";
+import { amountFor } from "./amounts";
+
+// Per-mode pairing, validated with the dataviz palette checker: chart-4 drops
+// below 3:1 contrast on the dark card and chart-1 on the light one, so the
+// expenses series swaps its token by mode while income keeps chart-2 (the step
+// that passes on both surfaces).
+const config = {
+  income: { label: "Income", color: "var(--chart-2)" },
+  expenses: { label: "Expenses", theme: { light: "var(--chart-4)", dark: "var(--chart-1)" } },
+} satisfies ChartConfig;
+
+export const IncomeExpenseChart: FC<{ series: IncomeExpensePoint[]; currency: string }> = ({ series, currency }) => {
+  const points = series.map((p) => ({
+    month: p.month,
+    income: amountFor(p.income, currency),
+    expenses: amountFor(p.expenses, currency),
+  }));
+
+  return (
+    <Card className="gap-3 rounded-lg px-4 py-3 shadow-none">
+      <CardHeader className="p-0">
+        <CardTitle className="text-muted-foreground text-xs font-normal">Income and expenses</CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        <ChartContainer config={config} className="aspect-[16/10] w-full">
+          <BarChart data={points} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey="month"
+              tickLine={false}
+              axisLine={false}
+              tickMargin={6}
+              interval={0}
+              tickFormatter={formatMonthShort}
+            />
+            <YAxis width={44} tickLine={false} axisLine={false} tickFormatter={formatAmountCompact} />
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  labelFormatter={(label) => formatMonthLong(String(label))}
+                  formatter={(value, name) => (
+                    <div className="flex w-full items-center gap-2 leading-none">
+                      <div
+                        className="size-2.5 shrink-0 rounded-[2px]"
+                        style={{ background: `var(--color-${String(name)})` }}
+                      />
+                      <span className="text-muted-foreground flex-1">
+                        {config[name as keyof typeof config]?.label ?? String(name)}
+                      </span>
+                      <span className="text-foreground font-medium tabular-nums">
+                        {formatAmount(Number(value), currency)}
+                      </span>
+                    </div>
+                  )}
+                />
+              }
+            />
+            <Bar dataKey="income" fill="var(--color-income)" radius={[4, 4, 0, 0]} maxBarSize={20} />
+            <Bar dataKey="expenses" fill="var(--color-expenses)" radius={[4, 4, 0, 0]} maxBarSize={20} />
+          </BarChart>
+        </ChartContainer>
+        {/* Static legend: recharts 3 orders its own legend payload differently
+            from the Bar declaration order, so it can't be trusted to read
+            left-to-right like the bars. Chip classes mirror the config above
+            (income chart-2; expenses chart-4 light / chart-1 dark). */}
+        <div className="flex items-center justify-center gap-4 pt-3 text-xs">
+          <div className="flex items-center gap-1.5">
+            <div className="size-2 shrink-0 rounded-[2px] bg-(--chart-2)" />
+            <span className="text-muted-foreground">Income</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <div className="size-2 shrink-0 rounded-[2px] bg-(--chart-4) dark:bg-(--chart-1)" />
+            <span className="text-muted-foreground">Expenses</span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/packages/desktop/src/components/accountant24/dashboard/net-worth-chart.tsx
+++ b/packages/desktop/src/components/accountant24/dashboard/net-worth-chart.tsx
@@ -1,0 +1,69 @@
+import type { FC } from "react";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/shadcn/card";
+import { type ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/shadcn/chart";
+import { formatAmount, formatAmountCompact } from "@/lib/format-amount";
+import { formatMonthLong, formatMonthShort } from "@/lib/format-month";
+import type { NetWorthPoint } from "@/rpc/types";
+import { amountFor } from "./amounts";
+
+// The design system's chart palette is monochrome (lightness steps of one
+// hue), so series identity rides on titles, legends and tooltips rather than
+// hue. chart-2 is the one step that clears 3:1 contrast on both the light and
+// dark card surfaces (checked with the dataviz palette validator).
+const config = {
+  netWorth: { label: "Net worth", color: "var(--chart-2)" },
+} satisfies ChartConfig;
+
+export const NetWorthChart: FC<{ series: NetWorthPoint[]; currency: string }> = ({ series, currency }) => {
+  const points = series.map((p) => ({ month: p.month, netWorth: amountFor(p.amounts, currency) }));
+
+  return (
+    <Card className="gap-3 rounded-lg px-4 py-3 shadow-none">
+      <CardHeader className="p-0">
+        <CardTitle className="text-muted-foreground text-xs font-normal">Net worth, last 12 months</CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        <ChartContainer config={config} className="aspect-[3/1] w-full">
+          <AreaChart data={points} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey="month"
+              tickLine={false}
+              axisLine={false}
+              tickMargin={6}
+              interval={2}
+              tickFormatter={formatMonthShort}
+            />
+            <YAxis width={44} tickLine={false} axisLine={false} tickFormatter={formatAmountCompact} />
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  hideIndicator
+                  labelFormatter={(label) => formatMonthLong(String(label))}
+                  formatter={(value) => (
+                    <div className="flex w-full items-center justify-between gap-3 leading-none">
+                      <span className="text-muted-foreground">Net worth</span>
+                      <span className="text-foreground font-medium tabular-nums">
+                        {formatAmount(Number(value), currency)}
+                      </span>
+                    </div>
+                  )}
+                />
+              }
+            />
+            <Area
+              dataKey="netWorth"
+              type="monotone"
+              stroke="var(--color-netWorth)"
+              strokeWidth={2}
+              fill="var(--color-netWorth)"
+              fillOpacity={0.08}
+              dot={false}
+            />
+          </AreaChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+};

--- a/packages/desktop/src/components/accountant24/dashboard/stat-row.tsx
+++ b/packages/desktop/src/components/accountant24/dashboard/stat-row.tsx
@@ -1,0 +1,25 @@
+import type { FC } from "react";
+import { Card } from "@/components/shadcn/card";
+import { formatAmount } from "@/lib/format-amount";
+import type { DashboardData } from "@/rpc/types";
+import { amountFor } from "./amounts";
+
+/** Net worth, income and spend for the current month, in the dominant currency. */
+export const StatRow: FC<{ data: DashboardData }> = ({ data }) => {
+  const currency = data.dominantCurrency;
+
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      <StatTile label="Net worth" value={formatAmount(amountFor(data.netWorth, currency), currency)} />
+      <StatTile label="Income this month" value={formatAmount(amountFor(data.incomeThisMonth, currency), currency)} />
+      <StatTile label="Spent this month" value={formatAmount(amountFor(data.spendThisMonth, currency), currency)} />
+    </div>
+  );
+};
+
+const StatTile: FC<{ label: string; value: string }> = ({ label, value }) => (
+  <Card className="gap-1 rounded-lg px-4 py-3 shadow-none">
+    <div className="text-muted-foreground truncate text-xs">{label}</div>
+    <div className="truncate text-lg leading-tight font-semibold tabular-nums">{value}</div>
+  </Card>
+);

--- a/packages/desktop/src/components/accountant24/thread.tsx
+++ b/packages/desktop/src/components/accountant24/thread.tsx
@@ -14,6 +14,7 @@ import { type ComponentType, createContext, type FC, memo, useContext } from "re
 import { UserMessageImage, UserMessageText } from "@/components/accountant24/attachment";
 import { ChainOfThoughtRoot, ChainOfThoughtStep } from "@/components/accountant24/chain-of-thought";
 import { Composer, EditComposer, isNewChatView } from "@/components/accountant24/composer";
+import { FinanceOverview } from "@/components/accountant24/dashboard/finance-overview";
 import { MarkdownText } from "@/components/accountant24/markdown-text";
 import { MessageError } from "@/components/accountant24/message-error";
 import { ToolFallback } from "@/components/accountant24/tool-fallback";
@@ -75,7 +76,9 @@ const ThreadRoot: FC<{ isEmpty: boolean }> = ({ isEmpty }) => {
         <div
           className={cn(
             "mx-auto flex w-full max-w-(--thread-max-width) flex-1 flex-col px-4 pt-4",
-            isEmpty && "justify-center",
+            // -safe: the finance overview can outgrow small windows; plain
+            // center would clip its top edge past the scroll viewport.
+            isEmpty && "justify-center-safe",
           )}
         >
           <AuiIf condition={isNewChatView}>
@@ -95,6 +98,10 @@ const ThreadRoot: FC<{ isEmpty: boolean }> = ({ isEmpty }) => {
             <ThreadScrollToBottom />
             <Composer />
           </ThreadPrimitive.ViewportFooter>
+
+          <AuiIf condition={isNewChatView}>
+            <FinanceOverview />
+          </AuiIf>
         </div>
       </ThreadPrimitive.Viewport>
     </ThreadPrimitive.Root>

--- a/packages/desktop/src/components/shadcn/card.tsx
+++ b/packages/desktop/src/components/shadcn/card.tsx
@@ -1,0 +1,64 @@
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Card({ className, size = "default", ...props }: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-4xl bg-card py-(--card-spacing) text-sm text-card-foreground shadow-md ring-1 ring-foreground/5 [--card-spacing:--spacing(6)] has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(4)] dark:ring-foreground/10 *:[img:first-child]:rounded-t-4xl *:[img:last-child]:rounded-b-4xl",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1.5 rounded-t-4xl px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="card-title" className={cn("font-heading text-base font-medium", className)} {...props} />;
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="card-description" className={cn("text-sm text-muted-foreground", className)} {...props} />;
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn("col-start-2 row-span-2 row-start-1 self-start justify-self-end", className)}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="card-content" className={cn("px-(--card-spacing)", className)} {...props} />;
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center rounded-b-4xl px-(--card-spacing) [.border-t]:pt-(--card-spacing)", className)}
+      {...props}
+    />
+  );
+}
+
+export { Card, CardAction, CardContent, CardDescription, CardFooter, CardHeader, CardTitle };

--- a/packages/desktop/src/components/shadcn/chart.tsx
+++ b/packages/desktop/src/components/shadcn/chart.tsx
@@ -1,0 +1,305 @@
+import * as React from "react";
+import type { TooltipValueType } from "recharts";
+import * as RechartsPrimitive from "recharts";
+
+import { cn } from "@/lib/utils";
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const;
+
+const INITIAL_DIMENSION = { width: 320, height: 200 } as const;
+type TooltipNameType = number | string;
+
+export type ChartConfig = Record<
+  string,
+  {
+    label?: React.ReactNode;
+    icon?: React.ComponentType;
+  } & ({ color?: string; theme?: never } | { color?: never; theme: Record<keyof typeof THEMES, string> })
+>;
+
+type ChartContextProps = {
+  config: ChartConfig;
+};
+
+const ChartContext = React.createContext<ChartContextProps | null>(null);
+
+function useChart() {
+  const context = React.useContext(ChartContext);
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />");
+  }
+
+  return context;
+}
+
+function ChartContainer({
+  id,
+  className,
+  children,
+  config,
+  initialDimension = INITIAL_DIMENSION,
+  ...props
+}: React.ComponentProps<"div"> & {
+  config: ChartConfig;
+  children: React.ComponentProps<typeof RechartsPrimitive.ResponsiveContainer>["children"];
+  initialDimension?: {
+    width: number;
+    height: number;
+  };
+}) {
+  const uniqueId = React.useId();
+  const chartId = `chart-${id ?? uniqueId.replace(/:/g, "")}`;
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-slot="chart"
+        data-chart={chartId}
+        className={cn(
+          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          className,
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer initialDimension={initialDimension}>
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  );
+}
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(([, config]) => config.theme ?? config.color);
+
+  if (!colorConfig.length) {
+    return null;
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color = itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ?? itemConfig.color;
+    return color ? `  --color-${key}: ${color};` : null;
+  })
+  .join("\n")}
+}
+`,
+          )
+          .join("\n"),
+      }}
+    />
+  );
+};
+
+const ChartTooltip = RechartsPrimitive.Tooltip;
+
+function ChartTooltipContent({
+  active,
+  payload,
+  className,
+  indicator = "dot",
+  hideLabel = false,
+  hideIndicator = false,
+  label,
+  labelFormatter,
+  labelClassName,
+  formatter,
+  color,
+  nameKey,
+  labelKey,
+}: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+  React.ComponentProps<"div"> & {
+    hideLabel?: boolean;
+    hideIndicator?: boolean;
+    indicator?: "line" | "dot" | "dashed";
+    nameKey?: string;
+    labelKey?: string;
+  } & Omit<RechartsPrimitive.DefaultTooltipContentProps<TooltipValueType, TooltipNameType>, "accessibilityLayer">) {
+  const { config } = useChart();
+
+  const tooltipLabel = React.useMemo(() => {
+    if (hideLabel || !payload?.length) {
+      return null;
+    }
+
+    const [item] = payload;
+    const key = `${labelKey ?? item?.dataKey ?? item?.name ?? "value"}`;
+    const itemConfig = getPayloadConfigFromPayload(config, item, key);
+    const value = !labelKey && typeof label === "string" ? (config[label]?.label ?? label) : itemConfig?.label;
+
+    if (labelFormatter) {
+      return <div className={cn("font-medium", labelClassName)}>{labelFormatter(value, payload)}</div>;
+    }
+
+    if (!value) {
+      return null;
+    }
+
+    return <div className={cn("font-medium", labelClassName)}>{value}</div>;
+  }, [label, labelFormatter, payload, hideLabel, labelClassName, config, labelKey]);
+
+  if (!active || !payload?.length) {
+    return null;
+  }
+
+  const nestLabel = payload.length === 1 && indicator !== "dot";
+
+  return (
+    <div
+      className={cn(
+        "grid min-w-32 items-start gap-1.5 rounded-xl bg-popover px-2.5 py-1.5 text-xs text-popover-foreground shadow-lg ring-1 ring-foreground/5 dark:ring-foreground/10",
+        className,
+      )}
+    >
+      {!nestLabel ? tooltipLabel : null}
+      <div className="grid gap-1.5">
+        {payload
+          .filter((item) => item.type !== "none")
+          .map((item, index) => {
+            const key = `${nameKey ?? item.name ?? item.dataKey ?? "value"}`;
+            const itemConfig = getPayloadConfigFromPayload(config, item, key);
+            const indicatorColor = color ?? item.payload?.fill ?? item.color;
+
+            return (
+              <div
+                key={index}
+                className={cn(
+                  "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+                  indicator === "dot" && "items-center",
+                )}
+              >
+                {formatter && item?.value !== undefined && item.name ? (
+                  formatter(item.value, item.name, item, index, item.payload)
+                ) : (
+                  <>
+                    {itemConfig?.icon ? (
+                      <itemConfig.icon />
+                    ) : (
+                      !hideIndicator && (
+                        <div
+                          className={cn("shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)", {
+                            "h-2.5 w-2.5": indicator === "dot",
+                            "w-1": indicator === "line",
+                            "w-0 border-[1.5px] border-dashed bg-transparent": indicator === "dashed",
+                            "my-0.5": nestLabel && indicator === "dashed",
+                          })}
+                          style={
+                            {
+                              "--color-bg": indicatorColor,
+                              "--color-border": indicatorColor,
+                            } as React.CSSProperties
+                          }
+                        />
+                      )
+                    )}
+                    <div
+                      className={cn(
+                        "flex flex-1 justify-between leading-none",
+                        nestLabel ? "items-end" : "items-center",
+                      )}
+                    >
+                      <div className="grid gap-1.5">
+                        {nestLabel ? tooltipLabel : null}
+                        <span className="text-muted-foreground">{itemConfig?.label ?? item.name}</span>
+                      </div>
+                      {item.value != null && (
+                        <span className="font-mono font-medium text-foreground tabular-nums">
+                          {typeof item.value === "number" ? item.value.toLocaleString() : String(item.value)}
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            );
+          })}
+      </div>
+    </div>
+  );
+}
+
+const ChartLegend = RechartsPrimitive.Legend;
+
+function ChartLegendContent({
+  className,
+  hideIcon = false,
+  payload,
+  verticalAlign = "bottom",
+  nameKey,
+}: React.ComponentProps<"div"> & {
+  hideIcon?: boolean;
+  nameKey?: string;
+} & RechartsPrimitive.DefaultLegendContentProps) {
+  const { config } = useChart();
+
+  if (!payload?.length) {
+    return null;
+  }
+
+  return (
+    <div className={cn("flex items-center justify-center gap-4", verticalAlign === "top" ? "pb-3" : "pt-3", className)}>
+      {payload
+        .filter((item) => item.type !== "none")
+        .map((item, index) => {
+          const key = `${nameKey ?? item.dataKey ?? "value"}`;
+          const itemConfig = getPayloadConfigFromPayload(config, item, key);
+
+          return (
+            <div
+              key={index}
+              className={cn("flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground")}
+            >
+              {itemConfig?.icon && !hideIcon ? (
+                <itemConfig.icon />
+              ) : (
+                <div
+                  className="h-2 w-2 shrink-0 rounded-[2px]"
+                  style={{
+                    backgroundColor: item.color,
+                  }}
+                />
+              )}
+              {itemConfig?.label}
+            </div>
+          );
+        })}
+    </div>
+  );
+}
+
+function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key: string) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined;
+  }
+
+  const payloadPayload =
+    "payload" in payload && typeof payload.payload === "object" && payload.payload !== null
+      ? payload.payload
+      : undefined;
+
+  let configLabelKey: string = key;
+
+  if (key in payload && typeof payload[key as keyof typeof payload] === "string") {
+    configLabelKey = payload[key as keyof typeof payload] as string;
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[key as keyof typeof payloadPayload] as string;
+  }
+
+  return configLabelKey in config ? config[configLabelKey] : config[key];
+}
+
+export { ChartContainer, ChartLegend, ChartLegendContent, ChartStyle, ChartTooltip, ChartTooltipContent };

--- a/packages/desktop/src/hooks/__tests__/use-dashboard-data.test.ts
+++ b/packages/desktop/src/hooks/__tests__/use-dashboard-data.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DashboardData } from "../../rpc/types";
+
+// The ledger IPC bridge is the faked boundary. The hook keeps a module-level
+// cache, so each test re-imports a fresh module via vi.resetModules().
+const dashboard = vi.fn<() => Promise<DashboardData>>();
+
+vi.mock("@/rpc/api", () => ({
+  ledgerApi: {
+    mentions: vi.fn(),
+    dashboard: () => dashboard(),
+  },
+}));
+
+function makeData(overrides?: Partial<DashboardData>): DashboardData {
+  return {
+    netWorth: [{ amount: 5000, currency: "EUR", change: 100 }],
+    incomeThisMonth: [{ amount: 3000, currency: "EUR" }],
+    spendThisMonth: [{ amount: 1200, currency: "EUR" }],
+    topCategories: [{ name: "food", amount: 500, currency: "EUR" }],
+    netWorthSeries: [],
+    incomeExpenseSeries: [],
+    dominantCurrency: "EUR",
+    otherCurrencies: [],
+    hasTransactions: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+/** A promise whose resolution the test controls. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function importHook() {
+  const mod = await import("../use-dashboard-data");
+  return mod.useDashboardData;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  dashboard.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useDashboardData()", () => {
+  it("should report loading with no data before the first fetch resolves", async () => {
+    dashboard.mockReturnValue(deferred<DashboardData>().promise);
+    const useDashboardData = await importHook();
+    const { result } = renderHook(() => useDashboardData());
+    expect(result.current).toEqual({ data: null, loading: true });
+  });
+
+  it("should return the fetched data and stop loading", async () => {
+    const data = makeData();
+    dashboard.mockResolvedValue(data);
+    const useDashboardData = await importHook();
+    const { result } = renderHook(() => useDashboardData());
+    await waitFor(() => expect(result.current).toEqual({ data, loading: false }));
+  });
+
+  it("should stop loading and keep data null when the fetch fails", async () => {
+    dashboard.mockRejectedValue(new Error("ipc failed"));
+    const useDashboardData = await importHook();
+    const { result } = renderHook(() => useDashboardData());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toBeNull();
+  });
+
+  it("should serve cached data instantly on remount while refetching", async () => {
+    const first = makeData();
+    dashboard.mockResolvedValue(first);
+    const useDashboardData = await importHook();
+    const mounted = renderHook(() => useDashboardData());
+    await waitFor(() => expect(mounted.result.current.data).toEqual(first));
+    mounted.unmount();
+
+    const late = deferred<DashboardData>();
+    dashboard.mockReturnValue(late.promise);
+    const remounted = renderHook(() => useDashboardData());
+    expect(remounted.result.current).toEqual({ data: first, loading: false });
+
+    const second = makeData({ netWorth: [{ amount: 6000, currency: "EUR", change: 1000 }] });
+    await act(async () => {
+      late.resolve(second);
+      await late.promise;
+    });
+    expect(remounted.result.current.data).toEqual(second);
+  });
+
+  it("should keep cached data when a background refetch fails", async () => {
+    const first = makeData();
+    dashboard.mockResolvedValue(first);
+    const useDashboardData = await importHook();
+    const mounted = renderHook(() => useDashboardData());
+    await waitFor(() => expect(mounted.result.current.data).toEqual(first));
+    mounted.unmount();
+
+    dashboard.mockRejectedValue(new Error("ipc failed"));
+    const remounted = renderHook(() => useDashboardData());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(remounted.result.current).toEqual({ data: first, loading: false });
+  });
+
+  it("should ignore a resolution that arrives after unmount", async () => {
+    const late = deferred<DashboardData>();
+    dashboard.mockReturnValue(late.promise);
+    const useDashboardData = await importHook();
+    const { unmount } = renderHook(() => useDashboardData());
+    unmount();
+    await expect(
+      act(async () => {
+        late.resolve(makeData());
+        await late.promise;
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/desktop/src/hooks/use-dashboard-data.ts
+++ b/packages/desktop/src/hooks/use-dashboard-data.ts
@@ -1,0 +1,38 @@
+// Stale-while-revalidate fetch of the main-page finance overview. The overview
+// only exists in the empty-thread view: it unmounts when a chat starts (the
+// only way ledger data changes) and remounts on "New chat", so fetch-on-mount
+// keeps it fresh. A module-level cache renders the previous result instantly on
+// remount while a background refetch replaces it.
+
+import { useEffect, useState } from "react";
+import { ledgerApi } from "../rpc/api";
+import type { DashboardData } from "../rpc/types";
+
+let cache: DashboardData | null = null;
+
+export function useDashboardData(): { data: DashboardData | null; loading: boolean } {
+  const [data, setData] = useState<DashboardData | null>(cache);
+  const [loading, setLoading] = useState(cache === null);
+
+  useEffect(() => {
+    let disposed = false;
+    ledgerApi
+      .dashboard()
+      .then((fresh) => {
+        cache = fresh;
+        if (!disposed) {
+          setData(fresh);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        // Keep any cached data; with no cache the overview stays hidden.
+        if (!disposed) setLoading(false);
+      });
+    return () => {
+      disposed = true;
+    };
+  }, []);
+
+  return { data, loading };
+}

--- a/packages/desktop/src/index.css
+++ b/packages/desktop/src/index.css
@@ -41,11 +41,16 @@
   --border: oklch(0.925 0.005 214.3);
   --input: oklch(0.925 0.005 214.3);
   --ring: oklch(0.723 0.014 214.4);
-  --chart-1: oklch(0.872 0.007 219.6);
-  --chart-2: oklch(0.56 0.021 213.5);
-  --chart-3: oklch(0.45 0.017 213.2);
-  --chart-4: oklch(0.378 0.015 216);
-  --chart-5: oklch(0.275 0.011 216.9);
+  /* Chart palette (replaces the preset's monochrome ramp): brand-teal-led
+     categorical set, per-mode steps, slot order chosen for CVD separation.
+     Validated with the dataviz palette checker against the card surfaces
+     (light #ffffff, dark #161b1d): lightness band, chroma floor, adjacent-pair
+     CVD deltaE, >=3:1 contrast. Revalidate if you change values or order. */
+  --chart-1: oklch(0.56 0.105 183);
+  --chart-2: oklch(0.62 0.15 45);
+  --chart-3: oklch(0.55 0.14 258);
+  --chart-4: oklch(0.58 0.15 356);
+  --chart-5: oklch(0.5 0.17 290);
   --sidebar: oklch(0.987 0.002 197.1);
   --sidebar-foreground: oklch(0.148 0.004 228.8);
   --sidebar-primary: oklch(0.6 0.118 184.704);
@@ -75,11 +80,11 @@
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.56 0.021 213.5);
-  --chart-1: oklch(0.872 0.007 219.6);
-  --chart-2: oklch(0.56 0.021 213.5);
-  --chart-3: oklch(0.45 0.017 213.2);
-  --chart-4: oklch(0.378 0.015 216);
-  --chart-5: oklch(0.275 0.011 216.9);
+  --chart-1: oklch(0.66 0.115 183);
+  --chart-2: oklch(0.66 0.14 45);
+  --chart-3: oklch(0.62 0.13 258);
+  --chart-4: oklch(0.64 0.14 356);
+  --chart-5: oklch(0.65 0.12 290);
   --sidebar: oklch(0.218 0.008 223.9);
   --sidebar-foreground: oklch(0.987 0.002 197.1);
   --sidebar-primary: oklch(0.704 0.14 182.503);

--- a/packages/desktop/src/lib/__tests__/format-amount.test.ts
+++ b/packages/desktop/src/lib/__tests__/format-amount.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { formatAmount, formatAmountCompact } from "../format-amount";
+
+describe("formatAmount()", () => {
+  it("should return '1,234.56 EUR' when amount=1234.56, currency=EUR", () => {
+    expect(formatAmount(1234.56, "EUR")).toBe("1,234.56 EUR");
+  });
+
+  it("should return '-50.00 USD' when amount=-50, currency=USD", () => {
+    expect(formatAmount(-50, "USD")).toBe("-50.00 USD");
+  });
+
+  it("should return '0.00 EUR' when amount=0, currency=EUR", () => {
+    expect(formatAmount(0, "EUR")).toBe("0.00 EUR");
+  });
+
+  it("should round to two fraction digits", () => {
+    expect(formatAmount(1234.567, "EUR")).toBe("1,234.57 EUR");
+  });
+
+  it("should omit the suffix when currency is empty", () => {
+    expect(formatAmount(5, "")).toBe("5.00");
+  });
+
+  it("should keep symbol commodities as a plain suffix", () => {
+    expect(formatAmount(100, "$")).toBe("100.00 $");
+  });
+});
+
+describe("formatAmountCompact()", () => {
+  it("should return '0' when amount=0", () => {
+    expect(formatAmountCompact(0)).toBe("0");
+  });
+
+  it("should round sub-thousand values to whole numbers", () => {
+    expect(formatAmountCompact(999.4)).toBe("999");
+  });
+
+  it("should return '1k' when amount=1000", () => {
+    expect(formatAmountCompact(1000)).toBe("1k");
+  });
+
+  it("should return '1.2k' when amount=1234", () => {
+    expect(formatAmountCompact(1234)).toBe("1.2k");
+  });
+
+  it("should return '45k' when amount=45000", () => {
+    expect(formatAmountCompact(45000)).toBe("45k");
+  });
+
+  it("should return '-1.2k' when amount=-1234", () => {
+    expect(formatAmountCompact(-1234)).toBe("-1.2k");
+  });
+
+  it("should return '1.5M' when amount=1500000", () => {
+    expect(formatAmountCompact(1_500_000)).toBe("1.5M");
+  });
+
+  it("should return '1M' when amount=1000000", () => {
+    expect(formatAmountCompact(1_000_000)).toBe("1M");
+  });
+});

--- a/packages/desktop/src/lib/__tests__/format-month.test.ts
+++ b/packages/desktop/src/lib/__tests__/format-month.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { formatMonthLong, formatMonthShort } from "../format-month";
+
+describe("formatMonthShort()", () => {
+  it("should return 'Aug' when month=2025-08", () => {
+    expect(formatMonthShort("2025-08")).toBe("Aug");
+  });
+
+  it("should return 'Jan' when month=2026-01", () => {
+    expect(formatMonthShort("2026-01")).toBe("Jan");
+  });
+
+  it("should return the input unchanged when it is not a YYYY-MM label", () => {
+    expect(formatMonthShort("total")).toBe("total");
+  });
+});
+
+describe("formatMonthLong()", () => {
+  it("should return 'Aug 2025' when month=2025-08", () => {
+    expect(formatMonthLong("2025-08")).toBe("Aug 2025");
+  });
+
+  it("should return the input unchanged when it is not a YYYY-MM label", () => {
+    expect(formatMonthLong("")).toBe("");
+  });
+});

--- a/packages/desktop/src/lib/format-amount.ts
+++ b/packages/desktop/src/lib/format-amount.ts
@@ -1,0 +1,27 @@
+// Amount formatting for the finance overview. Commodities are arbitrary
+// journal strings ("EUR", "UAH", "$", quoted tickers), so Intl's currency
+// style is unusable; format the number and append the commodity as-is.
+
+const numberFormat = new Intl.NumberFormat("en-US", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+/** "1,234.56 EUR"; no suffix when the commodity is empty. */
+export function formatAmount(amount: number, currency: string): string {
+  const num = numberFormat.format(amount);
+  return currency ? `${num} ${currency}` : num;
+}
+
+/** Short form for chart axis ticks: "45k", "1.5M", "-1.2k", "999". */
+export function formatAmountCompact(amount: number): string {
+  const sign = amount < 0 ? "-" : "";
+  const abs = Math.abs(amount);
+  if (abs >= 1_000_000) return `${sign}${trimTrailingZero((abs / 1_000_000).toFixed(1))}M`;
+  if (abs >= 1_000) return `${sign}${trimTrailingZero((abs / 1_000).toFixed(1))}k`;
+  return `${sign}${Math.round(abs)}`;
+}
+
+function trimTrailingZero(s: string): string {
+  return s.replace(/\.0$/, "");
+}

--- a/packages/desktop/src/lib/format-month.ts
+++ b/packages/desktop/src/lib/format-month.ts
@@ -1,0 +1,20 @@
+// "YYYY-MM" month labels from the dashboard series, formatted for chart axes
+// and tooltips.
+
+/** "2025-08" -> "Aug" (axis ticks). */
+export function formatMonthShort(month: string): string {
+  const d = parseMonth(month);
+  return d ? d.toLocaleString("en-US", { month: "short" }) : month;
+}
+
+/** "2025-08" -> "Aug 2025" (tooltip headers). */
+export function formatMonthLong(month: string): string {
+  const d = parseMonth(month);
+  return d ? d.toLocaleString("en-US", { month: "short", year: "numeric" }) : month;
+}
+
+function parseMonth(month: string): Date | null {
+  const m = month.match(/^(\d{4})-(\d{2})$/);
+  if (!m) return null;
+  return new Date(Number(m[1]), Number(m[2]) - 1, 1);
+}

--- a/packages/desktop/src/rpc/api.ts
+++ b/packages/desktop/src/rpc/api.ts
@@ -12,6 +12,7 @@ import type {
   AuthModels,
   AuthProviders,
   AuthStatus,
+  DashboardData,
   LedgerMentions,
   OllamaInfo,
   SessionSummary,
@@ -116,6 +117,8 @@ export const settingsApi = {
 export const ledgerApi = {
   /** Fetch accounts/payees/tags for the @-mention picker. */
   mentions: () => api.invoke<LedgerMentions>("ledger_mentions"),
+  /** Fetch the main-page finance overview (stats + chart series). */
+  dashboard: () => api.invoke<DashboardData>("ledger_dashboard"),
 };
 
 export const skillsApi = {

--- a/packages/desktop/src/rpc/types.ts
+++ b/packages/desktop/src/rpc/types.ts
@@ -1,5 +1,16 @@
 // Subset of the pi RPC protocol and the auth-helper protocol that the UI uses.
 
+// ---- Ledger dashboard (main-page finance overview) -----------------------
+
+// Type-only re-export from the workspace package; erased at build, so the
+// renderer bundle stays free of pi-extension code.
+export type {
+  CurrencyAmount,
+  DashboardData,
+  IncomeExpensePoint,
+  NetWorthPoint,
+} from "@accountant24/pi-extension/ledger/dashboard";
+
 // ---- Ledger mentions (@-mention picker data) ----------------------------
 
 /** Entity names available to the chat composer's @-mention popover, sourced

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -14,7 +14,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./entry": "./src/entry.ts",
-    "./tool-labels": "./src/tool-labels.ts"
+    "./tool-labels": "./src/tool-labels.ts",
+    "./ledger/dashboard": "./src/ledger/dashboard.ts"
   },
   "dependencies": {
     "@earendil-works/pi-coding-agent": "0.79.8",

--- a/packages/pi-extension/src/ledger/__tests__/briefing.test.ts
+++ b/packages/pi-extension/src/ledger/__tests__/briefing.test.ts
@@ -360,6 +360,27 @@ describe("fetchBriefingData()", () => {
       expect(cat.name).not.toContain("Expenses:");
     }
   });
+
+  test("should strip lowercase expenses: prefix from category names", async () => {
+    const cats = `"account","balance"\n"expenses:food","500.00 EUR"\n"expenses:transport","300.00 EUR"\n"Total:","800.00 EUR"`;
+    setAllQueries(null, null, null, null, cats);
+    const data = await fetchBriefingData("/fake/main.journal");
+    expect(data.topCategories).toEqual([
+      { name: "food", amount: 500, currency: "EUR" },
+      { name: "transport", amount: 300, currency: "EUR" },
+    ]);
+  });
+
+  test("should forward env and cwd opts to spawnText for every query", async () => {
+    setAllQueries(null, null, null, null, null);
+    const env = { PATH: "/vendored/bin" };
+    await fetchBriefingData("/fake/main.journal", { env, cwd: "/workspace" });
+    const calls = vi.mocked(spawnText).mock.calls;
+    expect(calls).toHaveLength(5);
+    for (const call of calls) {
+      expect(call[1]).toMatchObject({ env, cwd: "/workspace" });
+    }
+  });
 });
 
 // ── Integration: future-dated transactions ─────────────────────────

--- a/packages/pi-extension/src/ledger/__tests__/dashboard.test.ts
+++ b/packages/pi-extension/src/ledger/__tests__/dashboard.test.ts
@@ -1,0 +1,352 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { spawnText } from "../../spawn";
+
+vi.mock("../../spawn");
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach } from "vitest";
+import {
+  fetchDashboardData,
+  INCOME_EXPENSE_MONTHS,
+  NET_WORTH_MONTHS,
+  parseMultiPeriodBalCSV,
+  pickDominantCurrency,
+} from "../dashboard";
+
+// Mock at I/O boundary (spawnText) so the real tryRunHledger/runHledger execute.
+
+/** "YYYY-MM" label `offset` months before the current month. */
+function label(offset: number): string {
+  const now = new Date();
+  const d = new Date(now.getFullYear(), now.getMonth() - offset, 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+type QueryResponses = {
+  nwNow?: string | null;
+  nwPrev?: string | null;
+  expenses?: string | null;
+  income?: string | null;
+  categories?: string | null;
+  nwSeries?: string | null;
+  ieSeries?: string | null;
+};
+
+/** Dispatch mocked hledger output by inspecting the command line, so tests
+ *  don't depend on internal call ordering. null/omitted → exitCode 1. */
+function setQueries(responses: QueryResponses) {
+  vi.mocked(spawnText).mockImplementation(async (cmd) => {
+    const args = cmd.join(" ");
+    const pick = (): string | null | undefined => {
+      if (args.includes("--monthly")) {
+        return args.includes("--historical") ? responses.nwSeries : responses.ieSeries;
+      }
+      if (args.includes("Assets")) return args.includes("tomorrow") ? responses.nwNow : responses.nwPrev;
+      if (args.includes("--depth 2")) return responses.categories;
+      if (args.includes("Expenses")) return responses.expenses;
+      return responses.income;
+    };
+    const r = pick();
+    if (r == null) return { exitCode: 1, stdout: "", stderr: "error" };
+    return { exitCode: 0, stdout: r, stderr: "" };
+  });
+}
+
+describe("parseMultiPeriodBalCSV()", () => {
+  test("should extract month labels from the header", () => {
+    const csv = `"account","2025-08","2025-09"\n"assets:checking","EUR 100.00","EUR 150.00"\n"Total:","EUR 100.00","EUR 150.00"`;
+    const parsed = parseMultiPeriodBalCSV(csv);
+    expect(parsed.months).toEqual(["2025-08", "2025-09"]);
+  });
+
+  test("should parse account rows with one cell per month", () => {
+    const csv = `"account","2025-08","2025-09"\n"assets:checking","EUR 100.00","EUR 150.00"\n"Total:","EUR 100.00","EUR 150.00"`;
+    const parsed = parseMultiPeriodBalCSV(csv);
+    expect(parsed.rows).toEqual([
+      {
+        account: "assets:checking",
+        cells: [[{ amount: 100, currency: "EUR" }], [{ amount: 150, currency: "EUR" }]],
+      },
+    ]);
+  });
+
+  test("should drop literal zero cells", () => {
+    const csv = `"account","2025-08","2025-09"\n"assets:checking","0","EUR 150.00"`;
+    const parsed = parseMultiPeriodBalCSV(csv);
+    expect(parsed.rows[0].cells).toEqual([[], [{ amount: 150, currency: "EUR" }]]);
+  });
+
+  test("should split multi-currency cells", () => {
+    const csv = `"account","2025-08"\n"assets:checking","EUR 1,917.61, 5.00 USD"`;
+    const parsed = parseMultiPeriodBalCSV(csv);
+    expect(parsed.rows[0].cells[0]).toEqual([
+      { amount: 1917.61, currency: "EUR" },
+      { amount: 5, currency: "USD" },
+    ]);
+  });
+
+  test("should degrade quoted-ticker cells to empty without crashing", () => {
+    const csv = `"account","2025-08"\n"assets:broker","""SXR8"" 2.37"`;
+    const parsed = parseMultiPeriodBalCSV(csv);
+    expect(parsed.rows[0].cells[0]).toEqual([]);
+  });
+
+  test("should skip the Total: row", () => {
+    const csv = `"account","2025-08"\n"assets:checking","EUR 100.00"\n"Total:","EUR 100.00"`;
+    expect(parseMultiPeriodBalCSV(csv).rows).toHaveLength(1);
+  });
+
+  test("should return empty result for empty CSV", () => {
+    expect(parseMultiPeriodBalCSV("")).toEqual({ months: [], rows: [] });
+  });
+
+  test("should return no rows for header-only CSV", () => {
+    expect(parseMultiPeriodBalCSV(`"account","balance"`)).toEqual({ months: ["balance"], rows: [] });
+  });
+});
+
+describe("pickDominantCurrency()", () => {
+  const point = (month: string, income: Array<[number, string]>, expenses: Array<[number, string]>) => ({
+    month,
+    income: income.map(([amount, currency]) => ({ amount, currency })),
+    expenses: expenses.map(([amount, currency]) => ({ amount, currency })),
+  });
+
+  test("should pick the most active currency even when another has larger amounts", () => {
+    const series = [
+      point("2026-01", [[100, "EUR"]], [[50, "EUR"]]),
+      point("2026-02", [], [[60, "EUR"]]),
+      point("2026-03", [[999999, "USD"]], []),
+    ];
+    const netWorth = [{ amount: 500000, currency: "USD", change: 0 }];
+    expect(pickDominantCurrency(series, netWorth)).toEqual({ dominant: "EUR", others: ["USD"] });
+  });
+
+  test("should break activity ties by larger absolute net worth", () => {
+    const series = [point("2026-01", [[100, "EUR"]], [[100, "USD"]])];
+    const netWorth = [
+      { amount: -9000, currency: "USD", change: 0 },
+      { amount: 1000, currency: "EUR", change: 0 },
+    ];
+    expect(pickDominantCurrency(series, netWorth)).toEqual({ dominant: "USD", others: ["EUR"] });
+  });
+
+  test("should rank net-worth-only currencies by absolute amount when there is no activity", () => {
+    const netWorth = [
+      { amount: 100, currency: "UAH", change: 0 },
+      { amount: 90, currency: "BTC", change: 0 },
+    ];
+    expect(pickDominantCurrency([], netWorth)).toEqual({ dominant: "UAH", others: ["BTC"] });
+  });
+
+  test("should return empty when there are no currencies", () => {
+    expect(pickDominantCurrency([], [])).toEqual({ dominant: "", others: [] });
+  });
+});
+
+describe("fetchDashboardData()", () => {
+  const NW_NOW = `"account","balance"\n"assets:checking","EUR 5000.00"\n"Total:","EUR 5000.00"`;
+  const EXPENSES = `"account","balance"\n"expenses","EUR 1200.00"\n"Total:","EUR 1200.00"`;
+  const INCOME = `"account","balance"\n"income","EUR -3000.00"\n"Total:","EUR -3000.00"`;
+
+  beforeEach(() => {
+    setQueries({});
+  });
+
+  test("should scaffold full-length series even when all queries fail", async () => {
+    const data = await fetchDashboardData("/fake/main.journal");
+    expect(data.netWorthSeries).toHaveLength(NET_WORTH_MONTHS);
+    expect(data.incomeExpenseSeries).toHaveLength(INCOME_EXPENSE_MONTHS);
+    expect(data.hasTransactions).toBe(false);
+    expect(data.dominantCurrency).toBe("");
+    expect(data.error).toBeNull();
+  });
+
+  test("should order series labels oldest to newest ending at the current month", async () => {
+    const data = await fetchDashboardData("/fake/main.journal");
+    expect(data.netWorthSeries[0].month).toBe(label(NET_WORTH_MONTHS - 1));
+    expect(data.netWorthSeries[NET_WORTH_MONTHS - 1].month).toBe(label(0));
+    expect(data.incomeExpenseSeries[0].month).toBe(label(INCOME_EXPENSE_MONTHS - 1));
+    expect(data.incomeExpenseSeries[INCOME_EXPENSE_MONTHS - 1].month).toBe(label(0));
+  });
+
+  test("should place historical net worth by month label and zero-fill the rest", async () => {
+    const nwSeries = `"account","${label(2)}"\n"assets:checking","EUR 100.00"\n"Total:","EUR 100.00"`;
+    setQueries({ nwSeries });
+    const data = await fetchDashboardData("/fake/main.journal");
+    const filled = data.netWorthSeries.find((p) => p.month === label(2));
+    expect(filled?.amounts).toEqual([{ amount: 100, currency: "EUR" }]);
+    for (const p of data.netWorthSeries) {
+      if (p.month !== label(2)) expect(p.amounts).toEqual([]);
+    }
+  });
+
+  test("should sum asset and liability rows per month per currency", async () => {
+    const nwSeries = `"account","${label(1)}"\n"assets:checking","EUR 100.00"\n"liabilities:card","EUR -30.00"\n"Total:","EUR 70.00"`;
+    setQueries({ nwSeries });
+    const data = await fetchDashboardData("/fake/main.journal");
+    const point = data.netWorthSeries.find((p) => p.month === label(1));
+    expect(point?.amounts).toEqual([{ amount: 70, currency: "EUR" }]);
+  });
+
+  test("should use the exact-range briefing value for the current net worth point", async () => {
+    const nwSeries = `"account","${label(1)}"\n"assets:checking","EUR 100.00"\n"Total:","EUR 100.00"`;
+    setQueries({ nwNow: NW_NOW, nwSeries });
+    const data = await fetchDashboardData("/fake/main.journal");
+    const current = data.netWorthSeries[NET_WORTH_MONTHS - 1];
+    expect(current.month).toBe(label(0));
+    expect(current.amounts).toEqual([{ amount: 5000, currency: "EUR" }]);
+  });
+
+  test("should negate income (not abs) and keep expenses as-is in past months", async () => {
+    const ieSeries = `"account","${label(1)}"\n"income","EUR -3000.00"\n"expenses","EUR 2000.00"\n"Total:","EUR -1000.00"`;
+    setQueries({ ieSeries });
+    const data = await fetchDashboardData("/fake/main.journal");
+    const point = data.incomeExpenseSeries.find((p) => p.month === label(1));
+    expect(point?.income).toEqual([{ amount: 3000, currency: "EUR" }]);
+    expect(point?.expenses).toEqual([{ amount: 2000, currency: "EUR" }]);
+  });
+
+  test("should show a refund-heavy past month as negative income", async () => {
+    const ieSeries = `"account","${label(1)}"\n"income","EUR 250.00"\n"Total:","EUR 250.00"`;
+    setQueries({ ieSeries });
+    const data = await fetchDashboardData("/fake/main.journal");
+    const point = data.incomeExpenseSeries.find((p) => p.month === label(1));
+    expect(point?.income).toEqual([{ amount: -250, currency: "EUR" }]);
+  });
+
+  test("should use briefing values for the current income/expense point", async () => {
+    setQueries({ nwNow: NW_NOW, expenses: EXPENSES, income: INCOME });
+    const data = await fetchDashboardData("/fake/main.journal");
+    const current = data.incomeExpenseSeries[INCOME_EXPENSE_MONTHS - 1];
+    expect(current.income).toEqual([{ amount: 3000, currency: "EUR" }]);
+    expect(current.expenses).toEqual([{ amount: 1200, currency: "EUR" }]);
+  });
+
+  test("should pass through briefing stat figures", async () => {
+    setQueries({ nwNow: NW_NOW, expenses: EXPENSES, income: INCOME });
+    const data = await fetchDashboardData("/fake/main.journal");
+    expect(data.netWorth).toEqual([{ amount: 5000, currency: "EUR", change: 5000 }]);
+    expect(data.spendThisMonth).toEqual([{ amount: 1200, currency: "EUR" }]);
+    expect(data.incomeThisMonth).toEqual([{ amount: 3000, currency: "EUR" }]);
+  });
+
+  test("should compute dominant and other currencies from series activity", async () => {
+    const ieSeries = `"account","${label(2)}","${label(1)}"\n"income","EUR -3000.00","EUR -3000.00, -10.00 USD"\n"expenses","EUR 2000.00","EUR 1500.00"\n"Total:","EUR -1000.00","EUR -1500.00, -10.00 USD"`;
+    setQueries({ ieSeries });
+    const data = await fetchDashboardData("/fake/main.journal");
+    expect(data.dominantCurrency).toBe("EUR");
+    expect(data.otherCurrencies).toEqual(["USD"]);
+  });
+
+  test("should set hasTransactions when only series data exists", async () => {
+    const nwSeries = `"account","${label(3)}"\n"assets:checking","EUR 100.00"\n"Total:","EUR 100.00"`;
+    setQueries({ nwSeries });
+    const data = await fetchDashboardData("/fake/main.journal");
+    expect(data.hasTransactions).toBe(true);
+  });
+
+  test("should report hasTransactions=false for header-and-total-only outputs", async () => {
+    const emptyNw = `"account","${label(1)}"\n"Total:","0"`;
+    const emptyIe = `"account","${label(1)}"\n"Total:","0"`;
+    setQueries({ nwSeries: emptyNw, ieSeries: emptyIe });
+    const data = await fetchDashboardData("/fake/main.journal");
+    expect(data.hasTransactions).toBe(false);
+  });
+
+  test("should set error and empty series when hledger is not installed", async () => {
+    vi.mocked(spawnText).mockResolvedValue({ exitCode: 127, stdout: "", stderr: "not found" });
+    const data = await fetchDashboardData("/fake/main.journal");
+    expect(data.error).toContain("hledger is not installed");
+    expect(data.netWorthSeries).toEqual([]);
+    expect(data.incomeExpenseSeries).toEqual([]);
+    expect(data.hasTransactions).toBe(false);
+  });
+
+  test("should forward env and cwd opts to every spawnText call", async () => {
+    setQueries({});
+    const env = { PATH: "/vendored/bin" };
+    await fetchDashboardData("/fake/main.journal", { env, cwd: "/workspace" });
+    const calls = vi.mocked(spawnText).mock.calls;
+    expect(calls).toHaveLength(7);
+    for (const call of calls) {
+      expect(call[1]).toMatchObject({ env, cwd: "/workspace" });
+    }
+  });
+});
+
+// ── Integration: future-dated transactions ─────────────────────────
+// Uses real hledger to pin the whole `-e <monthStart>` + exact-range design:
+// a future-dated transaction must not appear in any series point.
+
+describe("fetchDashboardData() future transactions", () => {
+  let tmp: string;
+  let journalPath: string;
+
+  beforeEach(() => {
+    vi.mocked(spawnText).mockImplementation(async (cmd, opts) => {
+      const r = spawnSync(cmd[0], cmd.slice(1), { cwd: opts?.cwd, encoding: "utf8" });
+      if (r.error) throw r.error;
+      return { exitCode: r.status ?? 0, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+    });
+
+    tmp = mkdtempSync(join(tmpdir(), "dashboard-future-"));
+    journalPath = join(tmp, "main.journal");
+
+    const now = new Date();
+    const fmt = (d: Date) =>
+      `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    const today = fmt(now);
+    const lastMonth = fmt(new Date(now.getFullYear(), now.getMonth() - 1, 15));
+    const future = fmt(new Date(now.getFullYear(), now.getMonth() + 1, 15));
+
+    writeFileSync(
+      journalPath,
+      [
+        `${lastMonth} * Old Payee`,
+        `    expenses:food    50.00 EUR`,
+        `    assets:checking`,
+        ``,
+        `${today} * Current Payee`,
+        `    expenses:food    100.00 EUR`,
+        `    assets:checking`,
+        ``,
+        `${future} * Future Payee`,
+        `    expenses:education    200.00 EUR`,
+        `    assets:checking`,
+      ].join("\n"),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("should exclude the future transaction from every net worth point", async () => {
+    const data = await fetchDashboardData(journalPath);
+    const current = data.netWorthSeries[NET_WORTH_MONTHS - 1];
+    expect(current.amounts).toEqual([{ amount: -150, currency: "EUR" }]);
+    const lastMonthPoint = data.netWorthSeries[NET_WORTH_MONTHS - 2];
+    expect(lastMonthPoint.amounts).toEqual([{ amount: -50, currency: "EUR" }]);
+  });
+
+  test("should exclude the future transaction from every income/expense point", async () => {
+    const data = await fetchDashboardData(journalPath);
+    const current = data.incomeExpenseSeries[INCOME_EXPENSE_MONTHS - 1];
+    expect(current.expenses).toEqual([{ amount: 100, currency: "EUR" }]);
+    const lastMonthPoint = data.incomeExpenseSeries[INCOME_EXPENSE_MONTHS - 2];
+    expect(lastMonthPoint.expenses).toEqual([{ amount: 50, currency: "EUR" }]);
+    const total = data.incomeExpenseSeries.reduce((sum, p) => sum + p.expenses.reduce((s, e) => s + e.amount, 0), 0);
+    expect(total).toBe(150);
+  });
+
+  test("should report EUR as dominant with no others", async () => {
+    const data = await fetchDashboardData(journalPath);
+    expect(data.dominantCurrency).toBe("EUR");
+    expect(data.otherCurrencies).toEqual([]);
+    expect(data.hasTransactions).toBe(true);
+  });
+});

--- a/packages/pi-extension/src/ledger/briefing.ts
+++ b/packages/pi-extension/src/ledger/briefing.ts
@@ -1,4 +1,4 @@
-import { tryRunHledger } from "./hledger";
+import { type HledgerRunOpts, tryRunHledger } from "./hledger";
 
 export interface BriefingData {
   netWorth: Array<{ amount: number; currency: string; change: number }>;
@@ -126,7 +126,7 @@ function emptyData(): BriefingData {
 
 const TOP_CATEGORIES_LIMIT = 5;
 
-export async function fetchBriefingData(journalPath: string): Promise<BriefingData> {
+export async function fetchBriefingData(journalPath: string, opts?: HledgerRunOpts): Promise<BriefingData> {
   const { beginDate } = getMonthBounds();
   const f = ["-f", journalPath];
 
@@ -138,11 +138,11 @@ export async function fetchBriefingData(journalPath: string): Promise<BriefingDa
 
   try {
     [netWorthNow, netWorthPrev, expenses, income, categories] = await Promise.all([
-      tryRunHledger(["bal", ...f, "Assets", "Liabilities", "--flat", "-e", "tomorrow", "-O", "csv"]),
-      tryRunHledger(["bal", ...f, "Assets", "Liabilities", "--flat", "-e", beginDate, "-O", "csv"]),
-      tryRunHledger(["bal", ...f, "Expenses", "-b", beginDate, "-e", "tomorrow", "--depth", "1", "-O", "csv"]),
-      tryRunHledger(["bal", ...f, "Income", "-b", beginDate, "-e", "tomorrow", "--depth", "1", "-O", "csv"]),
-      tryRunHledger(["bal", ...f, "Expenses", "-b", beginDate, "-e", "tomorrow", "--depth", "2", "-O", "csv"]),
+      tryRunHledger(["bal", ...f, "Assets", "Liabilities", "--flat", "-e", "tomorrow", "-O", "csv"], opts),
+      tryRunHledger(["bal", ...f, "Assets", "Liabilities", "--flat", "-e", beginDate, "-O", "csv"], opts),
+      tryRunHledger(["bal", ...f, "Expenses", "-b", beginDate, "-e", "tomorrow", "--depth", "1", "-O", "csv"], opts),
+      tryRunHledger(["bal", ...f, "Income", "-b", beginDate, "-e", "tomorrow", "--depth", "1", "-O", "csv"], opts),
+      tryRunHledger(["bal", ...f, "Expenses", "-b", beginDate, "-e", "tomorrow", "--depth", "2", "-O", "csv"], opts),
     ]);
   } catch {
     // tryRunHledger only re-throws HledgerNotFoundError; all other errors return null
@@ -209,7 +209,7 @@ export async function fetchBriefingData(journalPath: string): Promise<BriefingDa
     const rows = parseBalRows(categories);
     data.topCategories = rows
       .map((r) => ({
-        name: r.name.replace(/^Expenses:/, ""),
+        name: r.name.replace(/^expenses:/i, ""),
         amount: r.amount,
         currency: r.currency,
       }))

--- a/packages/pi-extension/src/ledger/dashboard.ts
+++ b/packages/pi-extension/src/ledger/dashboard.ts
@@ -1,0 +1,223 @@
+// Dashboard data for the desktop app's main-page finance overview. Composes
+// fetchBriefingData (current-month figures) with two multi-period hledger
+// reports (historical series). `--monthly` expands the report period to whole
+// months, so the multi-period queries end at the first of the current month
+// (interval-aligned, no future-transaction leakage) and the current-month data
+// points come from briefing's exact-range queries instead.
+
+import { type BriefingData, fetchBriefingData, parseAmounts, parseCSVLine } from "./briefing";
+import { type HledgerRunOpts, tryRunHledger } from "./hledger";
+
+export interface CurrencyAmount {
+  amount: number;
+  currency: string;
+}
+
+export interface NetWorthPoint {
+  month: string; // "2025-08"
+  amounts: CurrencyAmount[];
+}
+
+export interface IncomeExpensePoint {
+  month: string;
+  income: CurrencyAmount[];
+  expenses: CurrencyAmount[];
+}
+
+export interface DashboardData {
+  netWorth: BriefingData["netWorth"];
+  incomeThisMonth: BriefingData["incomeThisMonth"];
+  spendThisMonth: BriefingData["spendThisMonth"];
+  topCategories: BriefingData["topCategories"];
+  netWorthSeries: NetWorthPoint[]; // NET_WORTH_MONTHS entries, oldest first, last = now
+  incomeExpenseSeries: IncomeExpensePoint[]; // INCOME_EXPENSE_MONTHS entries, last = current month
+  dominantCurrency: string; // "" when the ledger has no data
+  otherCurrencies: string[];
+  hasTransactions: boolean;
+  error: string | null;
+}
+
+export const NET_WORTH_MONTHS = 12;
+export const INCOME_EXPENSE_MONTHS = 6;
+
+export interface MultiPeriodRow {
+  account: string;
+  cells: CurrencyAmount[][]; // one cell per month column
+}
+
+/** Parse a multi-period `bal --monthly -O csv` report: header holds the month
+ *  labels ("account","2025-08",...), zero cells are literal "0", multi-commodity
+ *  cells are ", "-separated, and the last row is "Total:". */
+export function parseMultiPeriodBalCSV(csv: string): { months: string[]; rows: MultiPeriodRow[] } {
+  const lines = csv.split("\n").filter((l) => l.trim());
+  if (lines.length === 0) return { months: [], rows: [] };
+  const months = parseCSVLine(lines[0])
+    .slice(1)
+    .map((m) => m.trim());
+  const rows: MultiPeriodRow[] = [];
+  for (const line of lines.slice(1)) {
+    const fields = parseCSVLine(line);
+    const key = fields[0].toLowerCase().replace(/:$/, "");
+    if (!fields[0] || key === "account" || key === "total") continue;
+    rows.push({
+      account: fields[0],
+      cells: months.map((_, i) =>
+        parseAmounts(fields[i + 1] ?? "0").filter((a) => a.currency !== "" || a.amount !== 0),
+      ),
+    });
+  }
+  return { months, rows };
+}
+
+/** Most-active currency: most non-zero income/expense cells across the series
+ *  (magnitude alone would mis-rank low-value currencies); ties broken by larger
+ *  absolute net worth. Returns "" when the ledger has no currencies at all. */
+export function pickDominantCurrency(
+  incomeExpenseSeries: IncomeExpensePoint[],
+  netWorth: BriefingData["netWorth"],
+): { dominant: string; others: string[] } {
+  const activity = new Map<string, number>();
+  for (const point of incomeExpenseSeries) {
+    for (const cell of [...point.income, ...point.expenses]) {
+      if (cell.amount !== 0 && cell.currency) {
+        activity.set(cell.currency, (activity.get(cell.currency) ?? 0) + 1);
+      }
+    }
+  }
+  const netWorthAbs = new Map(netWorth.map((n) => [n.currency, Math.abs(n.amount)]));
+  const candidates = new Set([...activity.keys(), ...netWorthAbs.keys()]);
+  candidates.delete("");
+  const ranked = [...candidates].sort((a, b) => {
+    const byActivity = (activity.get(b) ?? 0) - (activity.get(a) ?? 0);
+    if (byActivity !== 0) return byActivity;
+    return (netWorthAbs.get(b) ?? 0) - (netWorthAbs.get(a) ?? 0);
+  });
+  return { dominant: ranked[0] ?? "", others: ranked.slice(1) };
+}
+
+export async function fetchDashboardData(journalPath: string, opts?: HledgerRunOpts): Promise<DashboardData> {
+  const f = ["-f", journalPath];
+  const now = new Date();
+  const netWorthLabels = monthLabels(now, NET_WORTH_MONTHS);
+  const incomeExpenseLabels = monthLabels(now, INCOME_EXPENSE_MONTHS);
+  const currentMonthStart = `${netWorthLabels[netWorthLabels.length - 1]}-01`;
+
+  let briefing: BriefingData;
+  let netWorthCsv: string | null;
+  let incomeExpenseCsv: string | null;
+  try {
+    [briefing, netWorthCsv, incomeExpenseCsv] = await Promise.all([
+      fetchBriefingData(journalPath, opts),
+      tryRunHledger(
+        // biome-ignore format: the command reads better on one line
+        ["bal", ...f, "Assets", "Liabilities", "--flat", "--monthly", "--historical", "-b", `${netWorthLabels[0]}-01`, "-e", currentMonthStart, "-O", "csv"],
+        opts,
+      ),
+      tryRunHledger(
+        // biome-ignore format: the command reads better on one line
+        ["bal", ...f, "Income", "Expenses", "--monthly", "--depth", "1", "-b", `${incomeExpenseLabels[0]}-01`, "-e", currentMonthStart, "-O", "csv"],
+        opts,
+      ),
+    ]);
+  } catch {
+    // tryRunHledger only re-throws HledgerNotFoundError
+    return { ...emptyDashboard(), error: "hledger is not installed. Install it from https://hledger.org/install" };
+  }
+  if (briefing.error) return { ...emptyDashboard(), error: briefing.error };
+
+  const netWorthParsed = parseMultiPeriodBalCSV(netWorthCsv ?? "");
+  const netWorthByMonth = sumByMonth(netWorthParsed);
+  const netWorthSeries: NetWorthPoint[] = netWorthLabels.map((month, i) =>
+    i === netWorthLabels.length - 1
+      ? { month, amounts: briefing.netWorth.map(({ amount, currency }) => ({ amount, currency })) }
+      : { month, amounts: toCurrencyAmounts(netWorthByMonth.get(month)) },
+  );
+
+  const incomeExpenseParsed = parseMultiPeriodBalCSV(incomeExpenseCsv ?? "");
+  const incomeByMonth = sumByMonth(incomeExpenseParsed, (account) => /^income/i.test(account));
+  const expensesByMonth = sumByMonth(incomeExpenseParsed, (account) => /^expenses/i.test(account));
+  const incomeExpenseSeries: IncomeExpensePoint[] = incomeExpenseLabels.map((month, i) =>
+    i === incomeExpenseLabels.length - 1
+      ? { month, income: [...briefing.incomeThisMonth], expenses: [...briefing.spendThisMonth] }
+      : {
+          month,
+          // income balances are negative in hledger; negate (not abs) so a
+          // refund-heavy month shows honestly
+          income: toCurrencyAmounts(incomeByMonth.get(month), { negate: true }),
+          expenses: toCurrencyAmounts(expensesByMonth.get(month)),
+        },
+  );
+
+  const { dominant, others } = pickDominantCurrency(incomeExpenseSeries, briefing.netWorth);
+  const hasSeriesData =
+    netWorthSeries.some((p) => p.amounts.some((a) => a.amount !== 0)) ||
+    incomeExpenseSeries.some((p) => [...p.income, ...p.expenses].some((a) => a.amount !== 0));
+
+  return {
+    netWorth: briefing.netWorth,
+    incomeThisMonth: briefing.incomeThisMonth,
+    spendThisMonth: briefing.spendThisMonth,
+    topCategories: briefing.topCategories,
+    netWorthSeries,
+    incomeExpenseSeries,
+    dominantCurrency: dominant,
+    otherCurrencies: others,
+    hasTransactions: briefing.netWorth.length > 0 || briefing.topCategories.length > 0 || hasSeriesData,
+    error: null,
+  };
+}
+
+// ── Internals ───────────────────────────────────────────────────────
+
+/** Last `count` month labels ("YYYY-MM"), oldest first, ending at now's month. */
+function monthLabels(now: Date, count: number): string[] {
+  const labels: string[] = [];
+  for (let i = count - 1; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    labels.push(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`);
+  }
+  return labels;
+}
+
+/** Per month label: currency → sum across matching account rows. */
+function sumByMonth(
+  parsed: { months: string[]; rows: MultiPeriodRow[] },
+  accountFilter?: (account: string) => boolean,
+): Map<string, Map<string, number>> {
+  const byMonth = new Map<string, Map<string, number>>();
+  parsed.months.forEach((month, i) => {
+    const byCurrency = new Map<string, number>();
+    for (const row of parsed.rows) {
+      if (accountFilter && !accountFilter(row.account)) continue;
+      for (const cell of row.cells[i]) {
+        if (!cell.currency && cell.amount === 0) continue;
+        byCurrency.set(cell.currency, (byCurrency.get(cell.currency) ?? 0) + cell.amount);
+      }
+    }
+    byMonth.set(month, byCurrency);
+  });
+  return byMonth;
+}
+
+function toCurrencyAmounts(byCurrency: Map<string, number> | undefined, opts?: { negate?: boolean }): CurrencyAmount[] {
+  if (!byCurrency) return [];
+  return [...byCurrency.entries()]
+    .filter(([, amount]) => amount !== 0)
+    .map(([currency, amount]) => ({ amount: opts?.negate ? -amount : amount, currency }))
+    .sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount));
+}
+
+function emptyDashboard(): DashboardData {
+  return {
+    netWorth: [],
+    incomeThisMonth: [],
+    spendThisMonth: [],
+    topCategories: [],
+    netWorthSeries: [],
+    incomeExpenseSeries: [],
+    dominantCurrency: "",
+    otherCurrencies: [],
+    hasTransactions: false,
+    error: null,
+  };
+}

--- a/packages/pi-extension/src/ledger/hledger.ts
+++ b/packages/pi-extension/src/ledger/hledger.ts
@@ -23,17 +23,16 @@ export class HledgerCommandError extends Error {
 
 // ── Commands ────────────────────────────────────────────────────────
 
-export async function runHledger(args: string[], opts?: { cwd?: string; signal?: AbortSignal }): Promise<string> {
+export type HledgerRunOpts = { cwd?: string; env?: NodeJS.ProcessEnv; signal?: AbortSignal };
+
+export async function runHledger(args: string[], opts?: HledgerRunOpts): Promise<string> {
   const { exitCode, stdout, stderr } = await spawn(["hledger", ...args], opts);
   if (exitCode === 127) throw new HledgerNotFoundError();
   if (exitCode !== 0) throw new HledgerCommandError(stdout, stderr);
   return stdout;
 }
 
-export async function tryRunHledger(
-  args: string[],
-  opts?: { cwd?: string; signal?: AbortSignal },
-): Promise<string | null> {
+export async function tryRunHledger(args: string[], opts?: HledgerRunOpts): Promise<string | null> {
   try {
     return await runHledger(args, opts);
   } catch (e) {
@@ -42,7 +41,7 @@ export async function tryRunHledger(
   }
 }
 
-export async function hledgerCheck(journalPath: string, opts?: { cwd?: string; signal?: AbortSignal }): Promise<void> {
+export async function hledgerCheck(journalPath: string, opts?: HledgerRunOpts): Promise<void> {
   await runHledger(["check", "--strict", "-f", journalPath], opts);
 }
 
@@ -50,7 +49,7 @@ export async function hledgerCheck(journalPath: string, opts?: { cwd?: string; s
 
 async function spawn(
   cmd: string[],
-  opts?: { cwd?: string; signal?: AbortSignal },
+  opts?: HledgerRunOpts,
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   try {
     return await spawnText(cmd, opts);

--- a/packages/pi-extension/src/ledger/index.ts
+++ b/packages/pi-extension/src/ledger/index.ts
@@ -1,5 +1,6 @@
 export { listAccounts } from "./accounts";
 export { type BriefingData, fetchBriefingData } from "./briefing";
+export { type DashboardData, fetchDashboardData } from "./dashboard";
 export { HledgerCommandError, HledgerNotFoundError, hledgerCheck, runHledger, tryRunHledger } from "./hledger";
 export { resolveSafePath } from "./paths";
 export { listPayees } from "./payees";

--- a/packages/pi-extension/src/spawn.ts
+++ b/packages/pi-extension/src/spawn.ts
@@ -7,9 +7,12 @@ import { spawn } from "node:child_process";
 
 export type SpawnResult = { exitCode: number; stdout: string; stderr: string };
 
-export function spawnText(cmd: string[], opts?: { cwd?: string; signal?: AbortSignal }): Promise<SpawnResult> {
+export function spawnText(
+  cmd: string[],
+  opts?: { cwd?: string; env?: NodeJS.ProcessEnv; signal?: AbortSignal },
+): Promise<SpawnResult> {
   return new Promise<SpawnResult>((resolve, reject) => {
-    const proc = spawn(cmd[0], cmd.slice(1), { cwd: opts?.cwd });
+    const proc = spawn(cmd[0], cmd.slice(1), { cwd: opts?.cwd, env: opts?.env });
     let stdout = "";
     let stderr = "";
     proc.stdout?.on("data", (d) => {


### PR DESCRIPTION
## Summary

- Add a dashboard to the main page of the desktop app, built from shadcn `card` and `chart` components, with a new `dashboard/` component group under `components/accountant24/`.
- Add a `useDashboardData` hook plus a new RPC endpoint (main process `ledger.ts`, preload, `rpc/api.ts`, `rpc/types.ts`) to feed the dashboard.
- Add a `dashboard` ledger report to `pi-extension` that aggregates hledger data for the charts.
- Add `formatAmount` and `formatMonth` helpers with tests.
- Allow `noDangerouslySetInnerHtml` in biome config for the chart components.

## Test plan

- [ ] `npm test` passes (new tests for dashboard data, dashboard report, and formatters)
- [ ] Dashboard renders on the main page with real ledger data
- [ ] Charts follow the OS light/dark theme