### PR TITLE
feat: keep chats working while you switch between them

### DIFF
--- a/packages/desktop/electron/main/__tests__/agent.test.ts
+++ b/packages/desktop/electron/main/__tests__/agent.test.ts
@@ -1,10 +1,11 @@
 import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// agent.ts owns the pi child process: spawn args/env, the stdout JSONL→IPC
-// bridge, the stderr tail, and crash-vs-intentional exit reporting. The child
-// process, fs, Electron IPC, and env paths are the faked I/O boundaries; the
-// bridging logic itself runs for real.
+// agent.ts owns the pi child processes — one per session: spawn args/env, the
+// per-session stdout JSONL→IPC bridge (events tagged with sessionPath), the
+// stderr tail, crash-vs-intentional exit reporting, and the idle reaper. The
+// child process, fs, Electron IPC, and env paths are the faked I/O boundaries;
+// the bridging logic itself runs for real.
 type Handler = (event: unknown, payload?: unknown) => unknown;
 
 /** A fake pi child: real EventEmitters for the process and its stdio streams. */
@@ -62,11 +63,16 @@ vi.mock("../skills-store", () => ({
 
 const win = { isDestroyed: () => false, webContents: { send: h.sendToWindow } };
 
-let killAgent: () => void;
+const A = "/ws/sessions/a.jsonl";
+const B = "/ws/sessions/b.jsonl";
+
+let killSessionAgent: (sessionPath: string) => void;
+let killAllAgents: () => void;
 
 async function setup(getWin: () => unknown = () => win) {
   const mod = await import("../agent");
-  killAgent = mod.killAgent;
+  killSessionAgent = mod.killSessionAgent;
+  killAllAgents = mod.killAllAgents;
   mod.registerAgentIpc(getWin as never);
 }
 
@@ -75,6 +81,9 @@ const invoke = (channel: string, payload?: unknown) => {
   if (!handler) throw new Error(`no handler for ${channel}`);
   return handler(null, payload);
 };
+
+const send = (sessionPath: string, command: unknown = { type: "get_state" }) =>
+  invoke("agent_send", { sessionPath, command });
 
 /** The nth spawned fake child (0-based). */
 const proc = (n = 0) => h.procs[n] as FakeProc;
@@ -98,13 +107,14 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
-describe("agent_start", () => {
-  it("should spawn pi in rpc mode with the system prompt, enabled skills, and bundled extension", async () => {
+describe("agent_send", () => {
+  it("should spawn pi in rpc mode with the system prompt, enabled skills, the session file, and bundled extension", async () => {
     await setup();
-    invoke("agent_start");
+    send(A);
 
     expect(h.mkdirSync).toHaveBeenCalledWith("/ws", { recursive: true });
     expect(h.spawnCalls).toHaveLength(1);
@@ -125,6 +135,8 @@ describe("agent_start", () => {
       "/ws/skills/pdf",
       "--session-dir",
       "/ws/sessions",
+      "--session",
+      A,
       "-e",
       "/res/ext.js",
     ]);
@@ -132,101 +144,154 @@ describe("agent_start", () => {
     expect(opts.env).toMatchObject({ PATH: "/vendored/bin", ELECTRON_RUN_AS_NODE: "1" });
   });
 
-  it("should not spawn a second child while one is running", async () => {
-    await setup();
-    invoke("agent_start");
-    invoke("agent_start");
-    expect(h.spawnCalls).toHaveLength(1);
-  });
-
-  it("should spawn again when started after a crash", async () => {
-    await setup();
-    invoke("agent_start");
-    proc().emit("exit", 1, null);
-    invoke("agent_start");
-    expect(h.spawnCalls).toHaveLength(2);
-  });
-});
-
-describe("stdout JSONL bridge", () => {
-  it("should forward one agent-event per complete line", async () => {
-    await setup();
-    invoke("agent_start");
-    proc().stdout.emit("data", '{"type":"a"}\n{"type":"b"}\n');
-    expect(sent("agent-event")).toEqual(['{"type":"a"}', '{"type":"b"}']);
-  });
-
-  it("should buffer a partial line until its newline arrives in a later chunk", async () => {
-    await setup();
-    invoke("agent_start");
-    proc().stdout.emit("data", '{"type":');
-    expect(sent("agent-event")).toEqual([]);
-
-    proc().stdout.emit("data", '"a"}\n');
-    expect(sent("agent-event")).toEqual(['{"type":"a"}']);
-  });
-
-  it("should strip a trailing carriage return from a line", async () => {
-    await setup();
-    invoke("agent_start");
-    proc().stdout.emit("data", '{"type":"a"}\r\n');
-    expect(sent("agent-event")).toEqual(['{"type":"a"}']);
-  });
-
-  it("should skip empty lines", async () => {
-    await setup();
-    invoke("agent_start");
-    proc().stdout.emit("data", '\n\n{"type":"a"}\n\n');
-    expect(sent("agent-event")).toEqual(['{"type":"a"}']);
-  });
-
-  it("should not throw when no window is available", async () => {
-    await setup(() => null);
-    invoke("agent_start");
-    expect(() => proc().stdout.emit("data", '{"type":"a"}\n')).not.toThrow();
-  });
-});
-
-describe("agent_send", () => {
   it("should write the command as one JSON line to the child's stdin", async () => {
     await setup();
-    invoke("agent_start");
-    invoke("agent_send", { type: "prompt", message: "hi" });
+    send(A, { type: "prompt", message: "hi" });
     expect(proc().stdin.write).toHaveBeenCalledWith('{"type":"prompt","message":"hi"}\n');
   });
 
-  it("should throw when the agent is not running", async () => {
+  it("should reuse the running child on a second send to the same session", async () => {
     await setup();
-    expect(() => invoke("agent_send", { type: "prompt" })).toThrow("agent not running");
+    send(A);
+    send(A, { type: "prompt", message: "again" });
+    expect(h.spawnCalls).toHaveLength(1);
+    expect(proc().stdin.write).toHaveBeenCalledTimes(2);
+  });
+
+  it("should spawn one child per session and route each send to its own child", async () => {
+    await setup();
+    send(A, { type: "prompt", message: "for A" });
+    send(B, { type: "prompt", message: "for B" });
+
+    expect(h.spawnCalls).toHaveLength(2);
+    expect(h.spawnCalls[0].args).toContain(A);
+    expect(h.spawnCalls[1].args).toContain(B);
+    expect(proc(0).stdin.write).toHaveBeenCalledWith('{"type":"prompt","message":"for A"}\n');
+    expect(proc(1).stdin.write).toHaveBeenCalledWith('{"type":"prompt","message":"for B"}\n');
+  });
+
+  it("should spawn a replacement on the next send after a crash", async () => {
+    await setup();
+    send(A);
+    proc().emit("exit", 1, null);
+    send(A);
+    expect(h.spawnCalls).toHaveLength(2);
+  });
+
+  it("should reject a session path outside the sessions directory", async () => {
+    await setup();
+    expect(() => send("/etc/passwd")).toThrow("session path outside the sessions directory");
+    expect(h.spawnCalls).toHaveLength(0);
+  });
+
+  it("should reject a path that merely shares the sessions dir prefix", async () => {
+    await setup();
+    expect(() => send("/ws/sessions-backup/a.jsonl")).toThrow("session path outside the sessions directory");
+  });
+
+  it("should reject a missing session path", async () => {
+    await setup();
+    expect(() => invoke("agent_send", { command: { type: "get_state" } })).toThrow("session path is required");
   });
 
   it("should reject an undefined command instead of writing the literal text", async () => {
     await setup();
-    invoke("agent_start");
-    expect(() => invoke("agent_send", undefined)).toThrow("invalid agent command");
-    expect(proc().stdin.write).not.toHaveBeenCalled();
+    expect(() => invoke("agent_send", { sessionPath: A })).toThrow("invalid agent command");
+    expect(h.spawnCalls).toHaveLength(0);
   });
 
   it("should reject a null command", async () => {
     await setup();
-    invoke("agent_start");
-    expect(() => invoke("agent_send", null)).toThrow("invalid agent command");
+    expect(() => invoke("agent_send", { sessionPath: A, command: null })).toThrow("invalid agent command");
+  });
+});
+
+describe("agent_create_session", () => {
+  it("should mint a fresh .jsonl path inside the sessions dir without spawning", async () => {
+    await setup();
+    const path = invoke("agent_create_session") as string;
+    expect(path).toMatch(/^\/ws\/sessions\/.+\.jsonl$/);
+    expect(h.mkdirSync).toHaveBeenCalledWith("/ws/sessions", { recursive: true });
+    expect(h.spawnCalls).toHaveLength(0);
+  });
+
+  it("should mint a distinct path per call", async () => {
+    await setup();
+    const first = invoke("agent_create_session");
+    const second = invoke("agent_create_session");
+    expect(first).not.toEqual(second);
+  });
+});
+
+describe("stdout JSONL bridge", () => {
+  it("should forward one agent-event per complete line, tagged with the session", async () => {
+    await setup();
+    send(A);
+    proc().stdout.emit("data", '{"type":"a"}\n{"type":"b"}\n');
+    expect(sent("agent-event")).toEqual([
+      { sessionPath: A, line: '{"type":"a"}' },
+      { sessionPath: A, line: '{"type":"b"}' },
+    ]);
+  });
+
+  it("should tag each session's events with its own path when two children stream", async () => {
+    await setup();
+    send(A);
+    send(B);
+    proc(0).stdout.emit("data", '{"type":"a"}\n');
+    proc(1).stdout.emit("data", '{"type":"b"}\n');
+    expect(sent("agent-event")).toEqual([
+      { sessionPath: A, line: '{"type":"a"}' },
+      { sessionPath: B, line: '{"type":"b"}' },
+    ]);
+  });
+
+  it("should buffer a partial line until its newline arrives in a later chunk", async () => {
+    await setup();
+    send(A);
+    proc().stdout.emit("data", '{"type":');
+    expect(sent("agent-event")).toEqual([]);
+
+    proc().stdout.emit("data", '"a"}\n');
+    expect(sent("agent-event")).toEqual([{ sessionPath: A, line: '{"type":"a"}' }]);
+  });
+
+  it("should strip a trailing carriage return from a line", async () => {
+    await setup();
+    send(A);
+    proc().stdout.emit("data", '{"type":"a"}\r\n');
+    expect(sent("agent-event")).toEqual([{ sessionPath: A, line: '{"type":"a"}' }]);
+  });
+
+  it("should skip empty lines", async () => {
+    await setup();
+    send(A);
+    proc().stdout.emit("data", '\n\n{"type":"a"}\n\n');
+    expect(sent("agent-event")).toEqual([{ sessionPath: A, line: '{"type":"a"}' }]);
+  });
+
+  it("should not throw when no window is available", async () => {
+    await setup(() => null);
+    send(A);
+    expect(() => proc().stdout.emit("data", '{"type":"a"}\n')).not.toThrow();
   });
 });
 
 describe("crash reporting", () => {
-  it("should report an unexpected exit with code, signal, and the stderr tail", async () => {
+  it("should report an unexpected exit with the session, code, signal, and the stderr tail", async () => {
     await setup();
-    invoke("agent_start");
+    send(A);
     proc().stderr.emit("data", "boom line 1\nboom line 2\n");
     proc().emit("exit", 1, null);
 
-    expect(sent("agent-terminated")).toEqual([{ code: 1, signal: null, stderr: "boom line 1\nboom line 2" }]);
+    expect(sent("agent-terminated")).toEqual([
+      { sessionPath: A, code: 1, signal: null, stderr: "boom line 1\nboom line 2" },
+    ]);
   });
 
   it("should keep only the last 4000 characters of stderr", async () => {
     await setup();
-    invoke("agent_start");
+    send(A);
     proc().stderr.emit("data", "x".repeat(5000));
     proc().stderr.emit("data", "END");
     proc().emit("exit", 1, null);
@@ -236,90 +301,183 @@ describe("crash reporting", () => {
     expect(report.stderr.endsWith("END")).toBe(true);
   });
 
-  it("should forward a spawn error as agent-error", async () => {
+  it("should forward a spawn error as agent-error with the session", async () => {
     await setup();
-    invoke("agent_start");
+    send(A);
     proc().emit("error", new Error("spawn ENOENT"));
-    expect(sent("agent-error")).toEqual(["spawn ENOENT"]);
+    expect(sent("agent-error")).toEqual([{ sessionPath: A, message: "spawn ENOENT" }]);
   });
 
   it("should record a crash for analytics with kind only", async () => {
     await setup();
-    invoke("agent_start");
+    send(A);
     proc().emit("exit", 1, null);
     expect(h.trackAgentFailed).toHaveBeenCalledWith("crash");
   });
 
   it("should record a spawn error for analytics with kind only", async () => {
     await setup();
-    invoke("agent_start");
+    send(A);
     proc().emit("error", new Error("spawn ENOENT"));
     expect(h.trackAgentFailed).toHaveBeenCalledWith("spawn");
   });
 
-  it("should not record an intentional stop as an error", async () => {
+  it("should not touch the other session's child when one crashes", async () => {
     await setup();
-    invoke("agent_start");
-    invoke("agent_stop");
-    proc().emit("exit", null, "SIGTERM");
-    expect(h.trackAgentFailed).not.toHaveBeenCalled();
+    send(A);
+    send(B);
+    proc(0).emit("exit", 1, null);
+
+    expect(proc(1).kill).not.toHaveBeenCalled();
+    send(B); // still routed to the live child, no respawn
+    expect(h.spawnCalls).toHaveLength(2);
   });
 });
 
 describe("intentional stops", () => {
-  it("should kill the child and not report its exit when stopped", async () => {
+  it("should kill only the given session's child on killSessionAgent", async () => {
     await setup();
-    invoke("agent_start");
-    invoke("agent_stop");
-    expect(proc().kill).toHaveBeenCalled();
+    send(A);
+    send(B);
+    killSessionAgent(A);
 
+    expect(proc(0).kill).toHaveBeenCalled();
+    expect(proc(1).kill).not.toHaveBeenCalled();
+    proc(0).emit("exit", null, "SIGTERM");
+    expect(sent("agent-terminated")).toEqual([]);
+    expect(h.trackAgentFailed).not.toHaveBeenCalled();
+  });
+
+  it("should kill every child on killAllAgents", async () => {
+    await setup();
+    send(A);
+    send(B);
+    killAllAgents();
+    expect(proc(0).kill).toHaveBeenCalled();
+    expect(proc(1).kill).toHaveBeenCalled();
+  });
+
+  it("should kill every child on agent_restart and respawn lazily on the next send", async () => {
+    await setup();
+    send(A);
+    send(B);
+    invoke("agent_restart");
+    expect(proc(0).kill).toHaveBeenCalled();
+    expect(proc(1).kill).toHaveBeenCalled();
+
+    proc(0).emit("exit", null, "SIGTERM");
+    proc(1).emit("exit", null, "SIGTERM");
+    expect(sent("agent-terminated")).toEqual([]);
+
+    send(A);
+    expect(h.spawnCalls).toHaveLength(3);
+  });
+
+  it("should still report a real crash of a replacement child after a restart", async () => {
+    await setup();
+    send(A);
+    invoke("agent_restart");
+    proc(0).emit("exit", null, "SIGTERM"); // the intentional kill
+    send(A);
+    proc(1).emit("exit", 2, null); // the live replacement crashing
+    expect(sent("agent-terminated")).toEqual([{ sessionPath: A, code: 2, signal: null, stderr: "" }]);
+  });
+
+  it("should do nothing when killSessionAgent is called with no child running", async () => {
+    await setup();
+    expect(() => killSessionAgent(A)).not.toThrow();
+  });
+
+  it("should do nothing when killAllAgents is called with no children", async () => {
+    await setup();
+    expect(() => killAllAgents()).not.toThrow();
+  });
+
+  it("should allow a fresh send after an intentional stop", async () => {
+    await setup();
+    send(A);
+    killSessionAgent(A);
+    proc(0).emit("exit", null, "SIGTERM");
+
+    send(A);
+    expect(h.spawnCalls).toHaveLength(2);
+  });
+});
+
+describe("idle reaper", () => {
+  it("should kill an idle child after the idle TTL without reporting a crash", async () => {
+    vi.useFakeTimers();
+    await setup();
+    send(A);
+
+    vi.advanceTimersByTime(16 * 60_000);
+    expect(proc().kill).toHaveBeenCalled();
     proc().emit("exit", null, "SIGTERM");
     expect(sent("agent-terminated")).toEqual([]);
   });
 
-  it("should spawn a replacement on restart and not report the old child's exit", async () => {
+  it("should never reap a child with a run in flight, however long it runs", async () => {
+    vi.useFakeTimers();
     await setup();
-    invoke("agent_start");
-    invoke("agent_restart");
-    expect(h.spawnCalls).toHaveLength(2);
+    send(A, { type: "prompt", message: "go" });
+    proc().stdout.emit("data", '{"type":"agent_start"}\n');
 
-    proc(0).emit("exit", null, "SIGTERM");
-    expect(sent("agent-terminated")).toEqual([]);
+    vi.advanceTimersByTime(60 * 60_000);
+    expect(proc().kill).not.toHaveBeenCalled();
   });
 
-  it("should not report either old child when two restarts overlap before their exits", async () => {
+  it("should reap a child once its run ended and the TTL passed", async () => {
+    vi.useFakeTimers();
     await setup();
-    invoke("agent_start");
-    invoke("agent_restart"); // kills proc 0, spawns proc 1
-    invoke("agent_restart"); // kills proc 1, spawns proc 2
+    send(A, { type: "prompt", message: "go" });
+    proc().stdout.emit("data", '{"type":"agent_start"}\n');
+    vi.advanceTimersByTime(30 * 60_000);
+    proc().stdout.emit("data", '{"type":"agent_end"}\n');
 
-    // Both killed children exit only now — neither is a crash.
-    proc(0).emit("exit", null, "SIGTERM");
-    proc(1).emit("exit", null, "SIGTERM");
-    expect(sent("agent-terminated")).toEqual([]);
+    vi.advanceTimersByTime(16 * 60_000);
+    expect(proc().kill).toHaveBeenCalled();
   });
 
-  it("should still report a real crash of the current child after a restart", async () => {
+  it("should keep a child alive while sends keep arriving within the TTL", async () => {
+    vi.useFakeTimers();
     await setup();
-    invoke("agent_start");
-    invoke("agent_restart");
-    proc(0).emit("exit", null, "SIGTERM"); // the intentional kill
-    proc(1).emit("exit", 2, null); // the live child crashing
-    expect(sent("agent-terminated")).toEqual([{ code: 2, signal: null, stderr: "" }]);
+    send(A);
+    for (let i = 0; i < 4; i += 1) {
+      vi.advanceTimersByTime(10 * 60_000);
+      send(A);
+    }
+    expect(proc().kill).not.toHaveBeenCalled();
   });
 
-  it("should do nothing when killAgent is called with no child running", async () => {
+  it("should evict the least-recently-active idle child when the cap is reached", async () => {
+    vi.useFakeTimers();
     await setup();
-    expect(() => killAgent()).not.toThrow();
+    // Fill the cap (8) with idle children, oldest activity first.
+    for (let i = 0; i < 8; i += 1) {
+      send(`/ws/sessions/s${i}.jsonl`);
+      vi.advanceTimersByTime(1000);
+    }
+    expect(h.spawnCalls).toHaveLength(8);
+
+    send("/ws/sessions/s8.jsonl");
+    expect(h.spawnCalls).toHaveLength(9);
+    expect(proc(0).kill).toHaveBeenCalled(); // s0: least recently active
+    expect(proc(1).kill).not.toHaveBeenCalled();
   });
 
-  it("should allow a fresh start after an intentional stop", async () => {
+  it("should not evict a running child for the cap, even when it is the oldest", async () => {
+    vi.useFakeTimers();
     await setup();
-    invoke("agent_start");
-    invoke("agent_stop");
-    proc(0).emit("exit", null, "SIGTERM");
+    send("/ws/sessions/s0.jsonl", { type: "prompt", message: "go" });
+    proc(0).stdout.emit("data", '{"type":"agent_start"}\n');
+    vi.advanceTimersByTime(1000);
+    for (let i = 1; i < 8; i += 1) {
+      send(`/ws/sessions/s${i}.jsonl`);
+      vi.advanceTimersByTime(1000);
+    }
 
-    invoke("agent_start");
-    expect(h.spawnCalls).toHaveLength(2);
+    send("/ws/sessions/s8.jsonl");
+    expect(proc(0).kill).not.toHaveBeenCalled(); // running — spared
+    expect(proc(1).kill).toHaveBeenCalled(); // oldest idle instead
   });
 });

--- a/packages/desktop/electron/main/__tests__/pi.test.ts
+++ b/packages/desktop/electron/main/__tests__/pi.test.ts
@@ -27,6 +27,7 @@ const h = vi.hoisted(() => ({
   },
   sessionList: vi.fn<(...args: unknown[]) => Promise<unknown[]>>(async () => []),
   trackProviderConnected: vi.fn(),
+  killSessionAgent: vi.fn(),
   fs: {
     existsSync: vi.fn(() => false),
     readFileSync: vi.fn(),
@@ -44,6 +45,7 @@ vi.mock("electron", () => ({
   shell: { openExternal: h.openExternal },
 }));
 vi.mock("../env", () => ({ workspaceDir: () => "/ws", sessionsDir: () => "/ws/sessions" }));
+vi.mock("../agent", () => ({ killSessionAgent: h.killSessionAgent }));
 vi.mock("../analytics", () => ({ trackProviderConnected: h.trackProviderConnected }));
 vi.mock("@earendil-works/pi-coding-agent", () => ({
   AuthStorage: { create: () => h.authStorage },
@@ -572,10 +574,21 @@ describe("sessions_delete", () => {
     expect(h.fs.rmSync).toHaveBeenCalledWith("/ws/sessions/a.jsonl", { force: true });
   });
 
+  it("should kill the session's agent child before removing the file", async () => {
+    await setup();
+    invoke("sessions_delete", { path: "/ws/sessions/a.jsonl" });
+    expect(h.killSessionAgent).toHaveBeenCalledWith("/ws/sessions/a.jsonl");
+    // Kill first, then remove — a live child could re-persist the file.
+    const killOrder = h.killSessionAgent.mock.invocationCallOrder[0];
+    const rmOrder = h.fs.rmSync.mock.invocationCallOrder[0];
+    expect(killOrder).toBeLessThan(rmOrder);
+  });
+
   it("should refuse a sibling directory that shares the sessions prefix", async () => {
     await setup();
     expect(invoke("sessions_delete", { path: "/ws/sessions-backup/x.jsonl" })).toEqual(refusal);
     expect(h.fs.rmSync).not.toHaveBeenCalled();
+    expect(h.killSessionAgent).not.toHaveBeenCalled();
   });
 
   it("should refuse a traversal that resolves outside the sessions directory", async () => {

--- a/packages/desktop/electron/main/agent.ts
+++ b/packages/desktop/electron/main/agent.ts
@@ -1,14 +1,29 @@
-// The pi agent child process. Mirrors the old src-tauri/src/agent.rs: spawn
-// `pi --mode rpc -e <extension>` and bridge its JSONL stdio.
+// The pi agent child processes — ONE PER SESSION, so a run in chat A keeps
+// going while the user works in chat B (pi's RPC mode is single-active-session
+// per process; switch_session would abort the in-flight run).
 //
-//   stdout line  -> "agent-event"     (one RPC event/response per line)
-//   "agent_send" -> one JSON command written to stdin (+ "\n")
+// Each child is `pi --mode rpc --session <sessionPath>` bridging JSONL stdio:
+//
+//   stdout line  -> "agent-event" { sessionPath, line }
+//   "agent_send" { sessionPath, command } -> one JSON command to that child's
+//                                            stdin (+ "\n"), spawning on demand
+//
+// `--session <path>` opens an existing session file OR starts a fresh session
+// at a not-yet-existing path (pi dist/main.js resolveSessionPath treats any
+// path-like arg as type:"path"; SessionManager.open keeps the explicit path and
+// only flushes the file once an assistant message exists — verified for the
+// vendored 0.79.x). That lets the app mint session paths up front
+// (agent_create_session) and use the same spawn code for new chats, reopened
+// chats, and respawns after idle-reap/crash — history, model, and thinking
+// level all restore from the session file.
 //
 // Option B: instead of a compiled pi binary, we run pi's cli.js with Electron's
 // own Node (ELECTRON_RUN_AS_NODE), resolved from node_modules.
 
 import { type ChildProcess, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { mkdirSync } from "node:fs";
+import { resolve } from "node:path";
 import { type BrowserWindow, ipcMain } from "electron";
 import { trackAgentFailed } from "./analytics";
 import {
@@ -22,15 +37,49 @@ import {
   systemPromptPath,
   workspaceDir,
 } from "./env";
+import { resolveSessionPath } from "./sessionPaths";
 import { buildSkillArgs } from "./skills-store";
 
-let child: ChildProcess | null = null;
-// Children we deliberately killed (restart / app quit), so their `exit` isn't
-// reported to the renderer as a crash. A set, not a single slot: two rapid
-// restarts can have several killed children still awaiting their exit event.
+interface AgentChild {
+  proc: ChildProcess;
+  /** A run is in flight (between agent_start and agent_end) — never reap. */
+  running: boolean;
+  /** Last stdin write or stdout line, for the idle reaper. */
+  lastActivity: number;
+}
+
+/** Live children, keyed by their session file's absolute path. */
+const children = new Map<string, AgentChild>();
+// Children we deliberately killed (reap / restart / delete / app quit), so
+// their `exit` isn't reported to the renderer as a crash. A set, not a single
+// slot: several killed children can still be awaiting their exit event.
 const intentionalKills = new Set<ChildProcess>();
 
-function spawnAgent(getWin: () => BrowserWindow | null): void {
+/** Kill idle children after this long without stdio activity. */
+const IDLE_TTL_MS = 15 * 60_000;
+/** Soft cap on live children; above it, spawning evicts the LRU idle child. */
+const MAX_CHILDREN = 8;
+const REAP_INTERVAL_MS = 60_000;
+
+/** Reject session paths outside the sessions dir — the path becomes a spawn
+ *  argument. */
+function assertSessionPath(sessionPath: unknown): string {
+  if (typeof sessionPath !== "string" || sessionPath.length === 0) {
+    throw new Error("session path is required");
+  }
+  const target = resolveSessionPath(sessionPath);
+  if (!target) throw new Error("session path outside the sessions directory");
+  return target;
+}
+
+/** Mint a fresh session file path (no spawn — the first send does that). */
+function createSessionPath(): string {
+  mkdirSync(sessionsDir(), { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return resolve(sessionsDir(), `${stamp}_${randomUUID()}.jsonl`);
+}
+
+function spawnAgent(sessionPath: string, getWin: () => BrowserWindow | null): AgentChild {
   const workspace = workspaceDir();
   // current_dir requires the dir to exist at spawn time (the extension scaffolds
   // its contents later, on session_start).
@@ -63,6 +112,9 @@ function spawnAgent(getWin: () => BrowserWindow | null): void {
       ...buildSkillArgs(skillsDir()),
       "--session-dir",
       sessionsDir(),
+      // This child's one-and-only session (see header).
+      "--session",
+      sessionPath,
       "-e",
       extensionPath(),
     ],
@@ -72,8 +124,9 @@ function spawnAgent(getWin: () => BrowserWindow | null): void {
       stdio: ["pipe", "pipe", "pipe"],
     },
   );
-  child = proc;
-  console.log(`[agent] spawned (pid ${proc.pid})`);
+  const child: AgentChild = { proc, running: false, lastActivity: Date.now() };
+  children.set(sessionPath, child);
+  console.log(`[agent] spawned (pid ${proc.pid}) for ${sessionPath}`);
 
   const emit = (channel: string, payload: unknown) => {
     const win = getWin();
@@ -89,7 +142,24 @@ function spawnAgent(getWin: () => BrowserWindow | null): void {
     while ((nl = buf.indexOf("\n")) !== -1) {
       const line = buf.slice(0, nl).replace(/\r$/, "");
       buf = buf.slice(nl + 1);
-      if (line.length > 0) emit("agent-event", line);
+      if (line.length === 0) continue;
+      child.lastActivity = Date.now();
+      // Run-state sniff for the reaper: a substring pre-check keeps the parse
+      // off streaming-delta lines, and the parse confirms the type (a delta
+      // whose text merely mentions the marker parses to a different type).
+      // Content-based on purpose — a byte-length gate would silently stop
+      // matching if pi ever added fields to these events, and the reaper
+      // would then kill children mid-run.
+      if (line.includes('"agent_start"') || line.includes('"agent_end"')) {
+        try {
+          const type = (JSON.parse(line) as { type?: string }).type;
+          if (type === "agent_start") child.running = true;
+          else if (type === "agent_end") child.running = false;
+        } catch {
+          // not JSON / partial — the renderer's parser deals with it
+        }
+      }
+      emit("agent-event", { sessionPath, line });
     }
   });
   // Keep a rolling tail of stderr so a crash can report a diagnostic instead of
@@ -100,50 +170,91 @@ function spawnAgent(getWin: () => BrowserWindow | null): void {
     stderrTail = (stderrTail + chunk).slice(-4000);
   });
   proc.on("exit", (code, signal) => {
-    if (child === proc) child = null;
-    // Kills we initiated (restart / app quit) aren't crashes — don't surface them.
+    if (children.get(sessionPath)?.proc === proc) children.delete(sessionPath);
+    // Kills we initiated (reap / restart / delete / app quit) aren't crashes —
+    // don't surface them.
     if (intentionalKills.delete(proc)) {
-      console.log("[agent] stopped (intentional)");
+      console.log(`[agent] stopped (intentional) for ${sessionPath}`);
       return;
     }
-    console.error(`[agent] crashed: code=${code} signal=${signal}`);
+    console.error(`[agent] crashed: code=${code} signal=${signal} session=${sessionPath}`);
     if (stderrTail.trim()) console.error(`[agent] stderr tail:\n${stderrTail.trim()}`);
     trackAgentFailed("crash");
-    emit("agent-terminated", { code, signal, stderr: stderrTail.trim() });
+    emit("agent-terminated", { sessionPath, code, signal, stderr: stderrTail.trim() });
   });
   proc.on("error", (err) => {
     console.error(`[agent] spawn error: ${err.message}`);
     trackAgentFailed("spawn");
-    emit("agent-error", err.message);
+    emit("agent-error", { sessionPath, message: err.message });
   });
+  return child;
 }
 
-/** Kill the agent child (app exit / explicit stop). */
-export function killAgent(): void {
-  if (child) {
-    intentionalKills.add(child);
-    child.kill();
-    child = null;
+function killChild(sessionPath: string, child: AgentChild): void {
+  intentionalKills.add(child.proc);
+  child.proc.kill();
+  children.delete(sessionPath);
+}
+
+/** Kill one session's agent child, if it has one (session delete / stop). */
+export function killSessionAgent(sessionPath: string): void {
+  const target = resolve(sessionPath);
+  const child = children.get(target);
+  if (child) killChild(target, child);
+}
+
+/** Kill every agent child (app exit / restart after provider/skills changes). */
+export function killAllAgents(): void {
+  for (const [sessionPath, child] of children) killChild(sessionPath, child);
+}
+
+/** Kill idle children past the TTL. Never touches a child with a run in flight. */
+function reapIdle(): void {
+  const now = Date.now();
+  for (const [sessionPath, child] of children) {
+    if (!child.running && now - child.lastActivity > IDLE_TTL_MS) {
+      console.log(`[agent] reaping idle child for ${sessionPath}`);
+      killChild(sessionPath, child);
+    }
   }
 }
 
-/** Register agent IPC. Idempotent spawn guards against StrictMode double-mount. */
+/** Above the cap, evict the least-recently-active idle child to make room. */
+function evictForCap(): void {
+  while (children.size >= MAX_CHILDREN) {
+    let lru: [string, AgentChild] | undefined;
+    for (const entry of children) {
+      if (entry[1].running) continue;
+      if (!lru || entry[1].lastActivity < lru[1].lastActivity) lru = entry;
+    }
+    if (!lru) return; // everything is running — let the spawn go over the cap
+    console.log(`[agent] evicting idle child for ${lru[0]}`);
+    killChild(lru[0], lru[1]);
+  }
+}
+
+/** Register agent IPC + the idle reaper. */
 export function registerAgentIpc(getWin: () => BrowserWindow | null): void {
-  ipcMain.handle("agent_start", () => {
-    if (!child) spawnAgent(getWin);
-  });
-  ipcMain.handle("agent_send", (_e, command: unknown) => {
-    if (!child?.stdin) throw new Error("agent not running");
+  ipcMain.handle("agent_send", (_e, payload: unknown) => {
+    const { sessionPath, command } = (payload ?? {}) as { sessionPath?: unknown; command?: unknown };
+    const target = assertSessionPath(sessionPath);
     // JSON.stringify(undefined) is undefined, which would write the literal
     // text "undefined" and corrupt the JSONL stream — commands must be objects.
     if (typeof command !== "object" || command === null) throw new Error("invalid agent command");
-    child.stdin.write(`${JSON.stringify(command)}\n`);
+    let child = children.get(target);
+    if (!child) {
+      evictForCap();
+      child = spawnAgent(target, getWin);
+    }
+    child.lastActivity = Date.now();
+    // stdin always exists: the spawn pipes all three stdio streams.
+    child.proc.stdin?.write(`${JSON.stringify(command)}\n`);
   });
-  ipcMain.handle("agent_stop", () => killAgent());
-  // Respawn the child so it re-reads auth.json + models.json — used after the app
-  // adds/removes a provider, since the agent caches both in memory at startup.
-  ipcMain.handle("agent_restart", () => {
-    killAgent();
-    spawnAgent(getWin);
-  });
+  ipcMain.handle("agent_create_session", () => createSessionPath());
+  // Kill every child so the next send respawns with fresh auth.json +
+  // models.json — used after the app adds/removes a provider, since the agent
+  // caches both in memory at startup. Respawn is lazy (each send carries its
+  // session path), so nothing to restart eagerly.
+  ipcMain.handle("agent_restart", () => killAllAgents());
+  setInterval(reapIdle, REAP_INTERVAL_MS).unref();
 }

--- a/packages/desktop/electron/main/index.ts
+++ b/packages/desktop/electron/main/index.ts
@@ -3,7 +3,7 @@
 
 import { join } from "node:path";
 import { app, BrowserWindow, ipcMain, nativeImage } from "electron";
-import { killAgent, registerAgentIpc } from "./agent";
+import { killAllAgents, registerAgentIpc } from "./agent";
 import { initAnalytics, registerAnalyticsIpc, trackAnalyticsToggle, trackLaunch, trackQuit } from "./analytics";
 import { registerFilesIpc } from "./files";
 import { registerLedgerIpc } from "./ledger";
@@ -68,11 +68,11 @@ app.whenReady().then(() => {
 });
 
 app.on("window-all-closed", () => {
-  killAgent();
+  killAllAgents();
   if (process.platform !== "darwin") app.quit();
 });
 
 app.on("before-quit", () => {
   trackQuit();
-  killAgent();
+  killAllAgents();
 });

--- a/packages/desktop/electron/main/pi.ts
+++ b/packages/desktop/electron/main/pi.ts
@@ -8,11 +8,13 @@
 // same files the agent child reads (PI_CODING_AGENT_DIR points there).
 
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { join, resolve, sep } from "node:path";
+import { join } from "node:path";
 import { AuthStorage, ModelRegistry, SessionManager } from "@earendil-works/pi-coding-agent";
 import { type BrowserWindow, ipcMain, shell } from "electron";
+import { killSessionAgent } from "./agent";
 import { trackProviderConnected } from "./analytics";
 import { sessionsDir, workspaceDir } from "./env";
+import { resolveSessionPath } from "./sessionPaths";
 
 type LoginCallbacks = Parameters<AuthStorage["login"]>[1];
 
@@ -292,13 +294,13 @@ async function sessionsList() {
 
 function sessionsDelete(path: string) {
   if (!path) return { type: "error", message: "session path is required" };
-  const dir = resolve(sessionsDir());
-  const target = resolve(path);
-  // Strictly inside the sessions dir: the separator suffix stops both siblings
-  // that merely share the prefix (…/sessions-backup) and the dir itself.
-  if (!target.startsWith(dir + sep)) {
+  const target = resolveSessionPath(path);
+  if (!target) {
     return { type: "error", message: "refusing to delete a path outside the sessions directory" };
   }
+  // A live child would keep running (and eventually re-persist the file) —
+  // deleting a running session intentionally aborts it.
+  killSessionAgent(target);
   rmSync(target, { force: true });
   return { type: "done", path };
 }

--- a/packages/desktop/electron/main/sessionPaths.ts
+++ b/packages/desktop/electron/main/sessionPaths.ts
@@ -1,0 +1,15 @@
+// The session-file path guard shared by the agent child manager (the path
+// becomes a spawn argument) and the sessions IPC (an rmSync target). One
+// security-relevant containment check, one place to harden.
+
+import { resolve, sep } from "node:path";
+import { sessionsDir } from "./env";
+
+/** Resolve a session path strictly inside the sessions dir, or null when it
+ *  falls outside. The separator suffix stops both siblings that merely share
+ *  the prefix (…/sessions-backup) and the dir itself. */
+export function resolveSessionPath(sessionPath: string): string | null {
+  const dir = resolve(sessionsDir());
+  const target = resolve(sessionPath);
+  return target.startsWith(dir + sep) ? target : null;
+}

--- a/packages/desktop/electron/preload/index.ts
+++ b/packages/desktop/electron/preload/index.ts
@@ -6,9 +6,8 @@ import { contextBridge, type IpcRendererEvent, ipcRenderer } from "electron";
 
 const INVOKE_CHANNELS = new Set([
   "app_version",
-  "agent_start",
+  "agent_create_session",
   "agent_send",
-  "agent_stop",
   "agent_restart",
   "auth_status",
   "auth_providers",

--- a/packages/desktop/src/components/accountant24/__tests__/chat-layout.test.tsx
+++ b/packages/desktop/src/components/accountant24/__tests__/chat-layout.test.tsx
@@ -7,10 +7,18 @@ import { installJsdomPolyfills } from "@/test/jsdomPolyfills";
 // Shared, mutable test state. `vi.hoisted` runs before the vi.mock factories
 // (which are hoisted to the top of the module), so the mocks can close over it.
 const h = vi.hoisted(() => ({
-  // Fake pi runtime surface ChatLayout drives.
+  // Fake pi runtime surface ChatLayout drives. MAIN is the viewed thread;
+  // BG is a background thread.
+  MAIN: "/ws/sessions/main.jsonl",
+  BG: "/ws/sessions/background.jsonl",
   rename: vi.fn<(title: string) => Promise<void>>(),
+  bgRename: vi.fn<(title: string) => Promise<void>>(),
+  bgTitle: null as string | null,
   switchToNewThread: vi.fn(),
-  thread: { title: null as string | null, messages: [] as { role: string; content: unknown[] }[] },
+  thread: { title: null as string | null },
+  // Per-session transcripts the fake client's getThread serves.
+  transcripts: {} as Record<string, unknown[]>,
+  getThread: vi.fn<(id: string) => Promise<{ messages: unknown[] }>>(),
   // Live agent-event subscribers (agentBridge.addEventListener registrations).
   agentListeners: new Set<(e: { type: string }) => void>(),
   // updateApi state the update banner reads.
@@ -19,13 +27,18 @@ const h = vi.hoisted(() => ({
 }));
 
 // A single stable runtime object so ChatLayout's title effect subscribes once.
-// getState reads `h.thread` live, so tests can seed messages/title per case.
+// getState reads `h` live, so tests can seed titles per case.
 const fakeRuntime = {
   threads: {
     switchToNewThread: h.switchToNewThread,
-    mainItem: { getState: () => ({ title: h.thread.title }), rename: h.rename },
+    mainItem: { getState: () => ({ title: h.thread.title, isMain: true, id: h.MAIN }), rename: h.rename },
+    getItemById: (id: string) => {
+      if (id === h.MAIN)
+        return { getState: () => ({ title: h.thread.title, isMain: true, id: h.MAIN }), rename: h.rename };
+      if (id === h.BG) return { getState: () => ({ title: h.bgTitle, isMain: false, id: h.BG }), rename: h.bgRename };
+      throw new Error("Thread not found");
+    },
   },
-  thread: { getState: () => ({ messages: h.thread.messages }) },
 };
 
 // AssistantRuntimeProvider is a pure context wrapper here; the real one demands a
@@ -39,8 +52,9 @@ vi.mock("@assistant-ui/react-pi", () => ({
   usePiRuntime: () => fakeRuntime,
 }));
 
+// The client's only role here is serving transcripts for auto-titling.
 vi.mock("@/runtime/electronPiClient", () => ({
-  createElectronPiClient: () => ({ __client: true }),
+  createElectronPiClient: () => ({ getThread: h.getThread }),
 }));
 
 vi.mock("@/runtime/fileAttachmentAdapter", () => ({
@@ -129,10 +143,15 @@ beforeAll(() => {
 beforeEach(() => {
   h.rename.mockReset();
   h.rename.mockResolvedValue(undefined);
+  h.bgRename.mockReset();
+  h.bgRename.mockResolvedValue(undefined);
+  h.bgTitle = null;
   h.switchToNewThread.mockReset();
   h.install.mockReset();
   h.thread.title = null;
-  h.thread.messages = [];
+  h.transcripts = {};
+  h.getThread.mockReset();
+  h.getThread.mockImplementation(async (id: string) => ({ messages: h.transcripts[id] ?? [] }));
   h.update.pendingValue = null;
   h.update.downloadedCb = null;
   h.agentListeners.clear();
@@ -140,12 +159,16 @@ beforeEach(() => {
 
 afterEach(() => cleanup());
 
-/** Push an agent event to every live subscriber, flushing React work. */
-const emit = (type: string) => {
+/** Push an agent event (tagged with its session) to every live subscriber,
+ *  flushing React work. */
+const emit = (type: string, sessionPath: string = h.MAIN) => {
   act(() => {
-    for (const fn of [...h.agentListeners]) fn({ type });
+    for (const fn of [...h.agentListeners]) fn({ type, sessionPath } as never);
   });
 };
+
+/** Let the titling path's async transcript fetch settle. */
+const flushTitling = () => act(async () => {});
 
 const userMessage = (text: string) => ({ role: "user", content: [{ type: "text", text }] });
 
@@ -228,61 +251,153 @@ describe("ChatLayout update banner", () => {
 });
 
 describe("ChatLayout auto-titling of new chats", () => {
-  it("should title an untitled chat from the first user message when a run ends", () => {
+  it("should title an untitled chat from the transcript's first user message when a run ends", async () => {
     h.thread.title = null;
-    h.thread.messages = [userMessage("what is my balance")];
+    h.transcripts[h.MAIN] = [userMessage("what is my balance")];
     render(<ChatLayout />);
 
     emit("agent_start");
     emit("agent_end");
+    await flushTitling();
 
     expect(h.rename).toHaveBeenCalledTimes(1);
     expect(h.rename).toHaveBeenCalledWith("what is my balance");
   });
 
-  it("should truncate a long first message to 60 characters with an ellipsis", () => {
+  it("should truncate a long first message to 60 characters with an ellipsis", async () => {
     // Spec: deriveChatTitle caps titles at 60 chars + "…".
     const long = "a".repeat(61);
     const expected = `${"a".repeat(60)}…`;
     h.thread.title = null;
-    h.thread.messages = [userMessage(long)];
+    h.transcripts[h.MAIN] = [userMessage(long)];
     render(<ChatLayout />);
 
     emit("agent_start");
     emit("agent_end");
+    await flushTitling();
 
     expect(h.rename).toHaveBeenCalledWith(expected);
   });
 
-  it("should not retitle a chat that already has a title", () => {
+  it("should not retitle (nor fetch the transcript of) a chat that already has a title", async () => {
     h.thread.title = "Groceries budget";
-    h.thread.messages = [userMessage("what is my balance")];
+    h.transcripts[h.MAIN] = [userMessage("what is my balance")];
     render(<ChatLayout />);
 
     emit("agent_start");
     emit("agent_end");
+    await flushTitling();
 
     expect(h.rename).not.toHaveBeenCalled();
+    expect(h.getThread).not.toHaveBeenCalled();
   });
 
-  it("should not rename when there is nothing to title from (no user message)", () => {
+  it("should not rename when there is nothing to title from (no user message)", async () => {
     h.thread.title = null;
-    h.thread.messages = [];
+    h.transcripts[h.MAIN] = [];
     render(<ChatLayout />);
 
     emit("agent_start");
     emit("agent_end");
+    await flushTitling();
 
     expect(h.rename).not.toHaveBeenCalled();
   });
 
-  it("should not rename on a bare agent_start with no run completion", () => {
+  it("should not rename on a bare agent_start with no run completion", async () => {
     h.thread.title = null;
-    h.thread.messages = [userMessage("what is my balance")];
+    h.transcripts[h.MAIN] = [userMessage("what is my balance")];
     render(<ChatLayout />);
 
     emit("agent_start");
+    await flushTitling();
 
     expect(h.rename).not.toHaveBeenCalled();
+  });
+
+  it("should not rename when the chat was titled while the transcript fetch was in flight", async () => {
+    h.thread.title = null;
+    h.transcripts[h.MAIN] = [userMessage("what is my balance")];
+    let release: (value: { messages: unknown[] }) => void = () => {};
+    h.getThread.mockImplementationOnce(() => new Promise((r) => (release = r)));
+    render(<ChatLayout />);
+
+    emit("agent_start");
+    emit("agent_end");
+    h.thread.title = "Renamed by hand"; // lands before the fetch resolves
+    release({ messages: h.transcripts[h.MAIN] });
+    await flushTitling();
+
+    expect(h.rename).not.toHaveBeenCalled();
+  });
+});
+
+describe("ChatLayout auto-titling of background chats", () => {
+  it("should title the background chat (not the viewed one) when its run ends", async () => {
+    // The viewed thread has its own untitled state — a background completion
+    // must not touch it.
+    h.thread.title = null;
+    h.transcripts[h.MAIN] = [userMessage("main thread question")];
+    h.transcripts[h.BG] = [userMessage("categorize last month")];
+    render(<ChatLayout />);
+
+    emit("agent_start", h.BG);
+    emit("agent_end", h.BG);
+    await flushTitling();
+
+    expect(h.bgRename).toHaveBeenCalledTimes(1);
+    expect(h.bgRename).toHaveBeenCalledWith("categorize last month");
+    expect(h.rename).not.toHaveBeenCalled();
+  });
+
+  it("should title from the transcript's FIRST user message, not a later one", async () => {
+    h.transcripts[h.BG] = [
+      userMessage("first question"),
+      { role: "assistant", content: [{ type: "text", text: "answer" }] },
+      userMessage("second question"),
+    ];
+    render(<ChatLayout />);
+
+    emit("agent_start", h.BG);
+    emit("agent_end", h.BG);
+    await flushTitling();
+
+    expect(h.bgRename).toHaveBeenCalledWith("first question");
+  });
+
+  it("should not retitle a background chat that already has a title", async () => {
+    h.bgTitle = "Named already";
+    h.transcripts[h.BG] = [userMessage("categorize last month")];
+    render(<ChatLayout />);
+
+    emit("agent_start", h.BG);
+    emit("agent_end", h.BG);
+    await flushTitling();
+
+    expect(h.bgRename).not.toHaveBeenCalled();
+    expect(h.getThread).not.toHaveBeenCalled();
+  });
+
+  it("should not crash when a run ends for a session unknown to the thread list", async () => {
+    render(<ChatLayout />);
+
+    emit("agent_start", "/ws/sessions/unknown.jsonl");
+    emit("agent_end", "/ws/sessions/unknown.jsonl");
+    await flushTitling();
+
+    expect(h.rename).not.toHaveBeenCalled();
+    expect(h.bgRename).not.toHaveBeenCalled();
+    expect(h.getThread).not.toHaveBeenCalled();
+  });
+
+  it("should not rename when the transcript fetch fails", async () => {
+    h.getThread.mockRejectedValueOnce(new Error("child crashed"));
+    render(<ChatLayout />);
+
+    emit("agent_start", h.BG);
+    emit("agent_end", h.BG);
+    await flushTitling();
+
+    expect(h.bgRename).not.toHaveBeenCalled();
   });
 });

--- a/packages/desktop/src/components/accountant24/chat-layout.tsx
+++ b/packages/desktop/src/components/accountant24/chat-layout.tsx
@@ -52,9 +52,11 @@ export function ChatLayout() {
   // The "*" adapter must be last (it handles all remaining types).
   // Image filenames are lost once pi projects them to bare `image` parts, so the
   // adapter reports each sent image's name here. `pending` collects the current
-  // send; `run` is the snapshot taken at agent_start so a run is titled only from
-  // its own images (not images left over from an earlier, already-titled chat).
-  const imageNames = useRef<{ pending: string[]; run: string[] }>({ pending: [], run: [] });
+  // send; `run` maps each session to the snapshot taken at its agent_start so a
+  // run is titled only from its own images (not images left over from an
+  // earlier, already-titled chat) — keyed per session because runs on several
+  // chats can be in flight at once.
+  const imageNames = useRef<{ pending: string[]; run: Map<string, string[]> }>({ pending: [], run: new Map() });
   const attachments = useMemo(
     () =>
       new CompositeAttachmentAdapter([
@@ -79,33 +81,53 @@ export function ChatLayout() {
   // When a still-untitled chat finishes its first run, title it from the first
   // user message via the thread item's own rename — an optimistic, single-thread
   // update (no list refetch) that also persists the name. Titled chats are
-  // skipped, so this never clobbers a manual rename or fires twice.
+  // skipped, so this never clobbers a manual rename or fires twice. Everything
+  // is keyed by the event's sessionPath (= threadId), so a run finishing in a
+  // background chat titles THAT chat, not the one being viewed.
   useEffect(() => {
     return agentBridge.addEventListener((e) => {
-      // Claim this run's images before agent_end so a later message can't retitle.
+      // Claim this run's images before agent_end so a later message can't
+      // retitle. The pending images belong to this session: they were attached
+      // in the composer whose send started this very run.
       if (e.type === "agent_start") {
-        imageNames.current.run = imageNames.current.pending;
+        imageNames.current.run.set(e.sessionPath, imageNames.current.pending);
         imageNames.current.pending = [];
         return;
       }
       if (e.type !== "agent_end") return;
-      const sentImages = imageNames.current.run;
-      imageNames.current.run = [];
-      const item = runtime.threads.mainItem;
+      const sentImages = imageNames.current.run.get(e.sessionPath) ?? [];
+      imageNames.current.run.delete(e.sessionPath);
+      let item: ReturnType<typeof runtime.threads.getItemById>;
+      try {
+        item = runtime.threads.getItemById(e.sessionPath);
+      } catch {
+        return; // session unknown to the thread list — nothing to title
+      }
       if (item.getState().title) return;
-      const firstUser = runtime.thread.getState().messages.find((m) => m.role === "user");
-      const texts = (firstUser?.content ?? [])
-        .filter((p): p is { type: "text"; text: string } => p.type === "text")
-        .map((p) => p.text);
-      // Title from the first user message: its text (markers stripped, mentions
-      // as plain labels), or the attached file/image names for an attachment-only
-      // message. `sentImages` are the names the adapter reported for this run,
-      // since images are gone from the transcript.
-      const title = deriveChatTitle({ texts, imageNames: sentImages });
-      if (!title) return;
-      void item.rename(title);
+      // Fetch the first user message from the session's transcript — works the
+      // same for the viewed and background chats, and arrives already
+      // normalized (skill blocks collapsed) by the client's snapshot path.
+      // One extra RPC, paid only on the first run of a still-untitled chat.
+      void client
+        .getThread(e.sessionPath)
+        .then((snapshot) => {
+          if (item.getState().title) return; // a rename landed meanwhile
+          const messages = snapshot.messages as Array<{ role?: string; content?: unknown }>;
+          const firstUser = messages.find((m) => m.role === "user");
+          const content = Array.isArray(firstUser?.content)
+            ? (firstUser.content as { type?: string; text?: string }[])
+            : [];
+          const texts = content.filter((p) => p.type === "text" && typeof p.text === "string").map((p) => p.text ?? "");
+          // Title from the first user message: its text (markers stripped,
+          // mentions as plain labels), or the attached file/image names for an
+          // attachment-only message. `sentImages` are the names the adapter
+          // reported for this run, since images are gone from the transcript.
+          const title = deriveChatTitle({ texts, imageNames: sentImages });
+          if (title) void item.rename(title);
+        })
+        .catch(() => undefined);
     });
-  }, [runtime]);
+  }, [runtime, client]);
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>

--- a/packages/desktop/src/rpc/__tests__/api.test.ts
+++ b/packages/desktop/src/rpc/__tests__/api.test.ts
@@ -35,35 +35,25 @@ function onlyPayload(channel: string): unknown {
 }
 
 describe("agentApi", () => {
-  describe("start()", () => {
-    it("should invoke the 'agent_start' channel with no payload and resolve its value", async () => {
-      bridge.setHandler("agent_start", () => "started");
+  describe("createSession()", () => {
+    it("should invoke the 'agent_create_session' channel and resolve the minted path", async () => {
+      bridge.setHandler("agent_create_session", () => "/ws/sessions/new.jsonl");
 
-      const result = await agentApi.start();
+      const result = await agentApi.createSession();
 
-      expect(result).toBe("started");
-      expect(bridge.callsFor("agent_start")).toEqual([undefined]);
+      expect(result).toBe("/ws/sessions/new.jsonl");
+      expect(bridge.callsFor("agent_create_session")).toEqual([undefined]);
     });
   });
 
   describe("send()", () => {
-    it("should invoke 'agent_send' with the command object as payload", async () => {
+    it("should invoke 'agent_send' with the session path and the command object", async () => {
       const command = { type: "user", text: "hi" };
       bridge.setHandler("agent_send", () => undefined);
 
-      await agentApi.send(command);
+      await agentApi.send("/ws/sessions/a.jsonl", command);
 
-      expect(onlyPayload("agent_send")).toEqual(command);
-    });
-  });
-
-  describe("stop()", () => {
-    it("should invoke the 'agent_stop' channel with no payload", async () => {
-      bridge.setHandler("agent_stop", () => undefined);
-
-      await agentApi.stop();
-
-      expect(bridge.callsFor("agent_stop")).toEqual([undefined]);
+      expect(onlyPayload("agent_send")).toEqual({ sessionPath: "/ws/sessions/a.jsonl", command });
     });
   });
 
@@ -107,21 +97,26 @@ describe("agentApi", () => {
   });
 
   describe("onEvent()", () => {
-    it("should parse a JSONL payload into an object and pass it to the callback", async () => {
+    it("should parse the JSONL line and merge the session path into the event", async () => {
       const cb = vi.fn();
       await agentApi.onEvent(cb);
 
-      bridge.emit("agent-event", JSON.stringify({ type: "text", value: "hello" }));
+      bridge.emit("agent-event", {
+        sessionPath: "/ws/sessions/a.jsonl",
+        line: JSON.stringify({ type: "text", value: "hello" }),
+      });
 
       expect(cb).toHaveBeenCalledTimes(1);
-      expect(cb).toHaveBeenCalledWith({ type: "text", value: "hello" });
+      expect(cb).toHaveBeenCalledWith({ type: "text", value: "hello", sessionPath: "/ws/sessions/a.jsonl" });
     });
 
-    it("should not throw and not call the callback when the payload is malformed JSON", async () => {
+    it("should not throw and not call the callback when the line is malformed JSON", async () => {
       const cb = vi.fn();
       await agentApi.onEvent(cb);
 
-      expect(() => bridge.emit("agent-event", "{not valid json")).not.toThrow();
+      expect(() =>
+        bridge.emit("agent-event", { sessionPath: "/ws/sessions/a.jsonl", line: "{not valid json" }),
+      ).not.toThrow();
       expect(cb).not.toHaveBeenCalled();
     });
 
@@ -136,10 +131,10 @@ describe("agentApi", () => {
   });
 
   describe("onTerminated()", () => {
-    it("should pass the exit-info payload through to the callback", async () => {
+    it("should pass the exit-info payload (with its session) through to the callback", async () => {
       const cb = vi.fn();
       await agentApi.onTerminated(cb);
-      const exit = { code: 1, signal: null, stderr: "boom" };
+      const exit = { sessionPath: "/ws/sessions/a.jsonl", code: 1, signal: null, stderr: "boom" };
 
       bridge.emit("agent-terminated", exit);
 
@@ -148,13 +143,13 @@ describe("agentApi", () => {
   });
 
   describe("onError()", () => {
-    it("should pass the error message payload through to the callback", async () => {
+    it("should pass the error payload (with its session) through to the callback", async () => {
       const cb = vi.fn();
       await agentApi.onError(cb);
 
-      bridge.emit("agent-error", "spawn failed");
+      bridge.emit("agent-error", { sessionPath: "/ws/sessions/a.jsonl", message: "spawn failed" });
 
-      expect(cb).toHaveBeenCalledWith("spawn failed");
+      expect(cb).toHaveBeenCalledWith({ sessionPath: "/ws/sessions/a.jsonl", message: "spawn failed" });
     });
   });
 });

--- a/packages/desktop/src/rpc/api.ts
+++ b/packages/desktop/src/rpc/api.ts
@@ -6,7 +6,6 @@
 // parse here (one place).
 
 import type {
-  AgentEvent,
   AppSettings,
   AuthEvent,
   AuthModels,
@@ -14,6 +13,7 @@ import type {
   AuthStatus,
   LedgerMentions,
   OllamaInfo,
+  SessionAgentEvent,
   SessionSummary,
   SkillAddRequest,
   SkillAddResult,
@@ -34,13 +34,16 @@ const MODELS_CHANGED = "a24:models-changed";
 
 /** Payload for an unexpected agent exit (crash), carrying a stderr tail for
  *  diagnostics. Deliberate stops (restart / app quit) are not reported. */
-export type AgentExit = { code: number | null; signal: string | null; stderr: string };
+export type AgentExit = { sessionPath: string; code: number | null; signal: string | null; stderr: string };
 
 export const agentApi = {
-  start: () => api.invoke<void>("agent_start"),
-  send: (command: object) => api.invoke<void>("agent_send", command),
-  stop: () => api.invoke<void>("agent_stop"),
-  /** Respawn the agent so it re-reads auth.json + models.json, then notify the UI. */
+  /** Mint a fresh session file path for a new chat (no process is spawned —
+   *  the first send to it does that). */
+  createSession: () => api.invoke<string>("agent_create_session"),
+  /** Send one RPC command to the given session's child, spawning it on demand. */
+  send: (sessionPath: string, command: object) => api.invoke<void>("agent_send", { sessionPath, command }),
+  /** Kill all children so the next send respawns them with fresh auth.json +
+   *  models.json, then notify the UI. */
   async restart(): Promise<void> {
     await api.invoke<void>("agent_restart");
     window.dispatchEvent(new Event(MODELS_CHANGED));
@@ -50,18 +53,25 @@ export const agentApi = {
     window.addEventListener(MODELS_CHANGED, cb);
     return () => window.removeEventListener(MODELS_CHANGED, cb);
   },
-  onEvent: async (cb: (event: AgentEvent) => void): Promise<() => void> =>
+  onEvent: async (cb: (event: SessionAgentEvent) => void): Promise<() => void> =>
     api.on("agent-event", (payload) => {
+      const { sessionPath, line } = payload as { sessionPath: string; line: string };
+      let event: SessionAgentEvent;
       try {
-        cb(JSON.parse(payload as string) as AgentEvent);
+        // Mutate the freshly parsed object (nothing else references it) —
+        // this runs per streaming token, so skip the spread copy.
+        event = JSON.parse(line) as SessionAgentEvent;
+        event.sessionPath = sessionPath;
       } catch {
-        dlog(`PARSE FAIL: ${String(payload).slice(0, 140)}`);
+        dlog(`PARSE FAIL: ${String(line).slice(0, 140)}`);
+        return;
       }
+      cb(event);
     }),
   onTerminated: async (cb: (info: AgentExit) => void): Promise<() => void> =>
     api.on("agent-terminated", (payload) => cb(payload as AgentExit)),
-  onError: async (cb: (message: string) => void): Promise<() => void> =>
-    api.on("agent-error", (payload) => cb(payload as string)),
+  onError: async (cb: (info: { sessionPath: string; message: string }) => void): Promise<() => void> =>
+    api.on("agent-error", (payload) => cb(payload as { sessionPath: string; message: string })),
 };
 
 export const appApi = {

--- a/packages/desktop/src/rpc/types.ts
+++ b/packages/desktop/src/rpc/types.ts
@@ -182,6 +182,11 @@ export type AgentEvent =
     }
   | { type: "response"; id?: string; command: string; success: boolean; data?: unknown; error?: string };
 
+/** An agent event tagged with the session it came from. The pi wire event is
+ *  anonymous; main tags each line with its child's session path so the
+ *  renderer can route concurrent sessions' streams. */
+export type SessionAgentEvent = AgentEvent & { sessionPath: string };
+
 // ---- Sessions (from the sessions helper) --------------------------------
 
 export interface SessionSummary {

--- a/packages/desktop/src/runtime/__tests__/agentBridge.test.ts
+++ b/packages/desktop/src/runtime/__tests__/agentBridge.test.ts
@@ -1,26 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// The pi sidecar's IPC boundary. agentBridge talks to the child only through
+// The pi sidecars' IPC boundary. agentBridge talks to the children only through
 // this module, so it's the single seam we fake. `h` holds the fake's captured
-// listeners + a record of what the bridge sent, so tests can drive the stream
-// (emit responses/stream events) and observe outgoing commands.
+// listeners + a record of what the bridge sent (with its target session), so
+// tests can drive the stream (emit responses/stream events) and observe
+// outgoing commands.
 const h = vi.hoisted(() => ({
   eventListeners: new Set<(e: unknown) => void>(),
   terminatedListeners: new Set<(info: unknown) => void>(),
-  errorListeners: new Set<(m: string) => void>(),
-  sent: [] as unknown[],
-  startCount: { n: 0 },
+  errorListeners: new Set<(info: unknown) => void>(),
+  sent: [] as { sessionPath: string; command: unknown }[],
 }));
 
 vi.mock("../../rpc/api", () => ({
   agentApi: {
-    start: vi.fn(async () => {
-      h.startCount.n++;
+    send: vi.fn(async (sessionPath: string, command: object) => {
+      h.sent.push({ sessionPath, command });
     }),
-    send: vi.fn(async (command: object) => {
-      h.sent.push(command);
-    }),
-    stop: vi.fn(async () => {}),
     onEvent: vi.fn(async (cb: (e: unknown) => void) => {
       h.eventListeners.add(cb);
       return () => {
@@ -33,7 +29,7 @@ vi.mock("../../rpc/api", () => ({
         h.terminatedListeners.delete(cb);
       };
     }),
-    onError: vi.fn(async (cb: (m: string) => void) => {
+    onError: vi.fn(async (cb: (info: unknown) => void) => {
       h.errorListeners.add(cb);
       return () => {
         h.errorListeners.delete(cb);
@@ -42,14 +38,17 @@ vi.mock("../../rpc/api", () => ({
   },
 }));
 
+const A = "/ws/sessions/a.jsonl";
+const B = "/ws/sessions/b.jsonl";
+
 // The bridge is a module singleton, so each test re-imports it fresh after a
-// module reset to avoid leaking `wired`/`startPromise`/pending state.
+// module reset to avoid leaking wire/pending state.
 async function loadBridge() {
   const mod = await import("../agentBridge");
   return mod.agentBridge;
 }
 
-/** Let the bridge's async ensureStarted → wire → send microtasks drain. */
+/** Let the bridge's async wire → send microtasks drain. */
 const flush = () => new Promise<void>((r) => setTimeout(r, 0));
 
 const emit = (e: unknown) => {
@@ -58,23 +57,23 @@ const emit = (e: unknown) => {
 /** The correlation id request() attached to the sent command of the given type
  *  (pi echoes it back on the response — the fake mirrors that contract). */
 const sentId = (type: string): string | undefined =>
-  (h.sent.find((c) => (c as { type?: string }).type === type) as { id?: string } | undefined)?.id;
+  (h.sent.find((c) => (c.command as { type?: string }).type === type)?.command as { id?: string } | undefined)?.id;
 /** Emit the response to the previously-sent command of the given type. */
 const respondTo = (type: string, over: Record<string, unknown>) =>
   emit({ type: "response", id: sentId(type), command: type, ...over });
 const emitTerminated = (info: unknown) => {
   for (const cb of [...h.terminatedListeners]) cb(info);
 };
-const emitError = (m: string) => {
-  for (const cb of [...h.errorListeners]) cb(m);
+const emitError = (sessionPath: string, message: string) => {
+  for (const cb of [...h.errorListeners]) cb({ sessionPath, message });
 };
+const commands = () => h.sent.map((c) => c.command);
 
 beforeEach(() => {
   h.eventListeners.clear();
   h.terminatedListeners.clear();
   h.errorListeners.clear();
   h.sent.length = 0;
-  h.startCount.n = 0;
   vi.resetModules();
 });
 
@@ -83,41 +82,41 @@ afterEach(() => {
 });
 
 describe("agentBridge", () => {
-  describe("sidecar lifecycle", () => {
-    it("should start the sidecar and forward the command when send() is called", async () => {
+  describe("send()", () => {
+    it("should forward the command with its target session", async () => {
       const bridge = await loadBridge();
-      await bridge.send({ type: "ping" });
-      expect(h.startCount.n).toBe(1);
-      expect(h.sent).toContainEqual({ type: "ping" });
+      await bridge.send(A, { type: "ping" });
+      expect(h.sent).toEqual([{ sessionPath: A, command: { type: "ping" } }]);
     });
 
-    it("should start the sidecar only once when send() is called repeatedly", async () => {
+    it("should route each command to its own session", async () => {
       const bridge = await loadBridge();
-      await bridge.send({ n: 1 });
-      await bridge.send({ n: 2 });
-      expect(h.startCount.n).toBe(1);
+      await bridge.send(A, { n: 1 });
+      await bridge.send(B, { n: 2 });
+      expect(h.sent).toEqual([
+        { sessionPath: A, command: { n: 1 } },
+        { sessionPath: B, command: { n: 2 } },
+      ]);
     });
 
-    it("should respawn the sidecar when send() is called after a crash", async () => {
+    it("should attach the stream listeners exactly once across many sends", async () => {
       const bridge = await loadBridge();
-      await bridge.send({});
+      await bridge.send(A, {});
+      await bridge.send(B, {});
       await flush();
-      expect(h.startCount.n).toBe(1);
-
-      emitTerminated({ code: 1, signal: null, stderr: "" });
-
-      await bridge.send({});
-      await flush();
-      expect(h.startCount.n).toBe(2);
+      expect(h.eventListeners.size).toBe(1);
+      expect(h.terminatedListeners.size).toBe(1);
+      expect(h.errorListeners.size).toBe(1);
     });
   });
 
   describe("request()", () => {
     it("should resolve with the response data when a response with the matching id arrives", async () => {
       const bridge = await loadBridge();
-      const p = bridge.request({ type: "get_state" }, "get_state");
+      const p = bridge.request(A, { type: "get_state" }, "get_state");
       await flush();
-      expect(h.sent).toContainEqual(expect.objectContaining({ type: "get_state" }));
+      expect(h.sent[0].sessionPath).toBe(A);
+      expect(commands()).toContainEqual(expect.objectContaining({ type: "get_state" }));
 
       respondTo("get_state", { success: true, data: { model: "m1" } });
       await expect(p).resolves.toEqual({ model: "m1" });
@@ -125,12 +124,12 @@ describe("agentBridge", () => {
 
     it("should attach a unique correlation id when sending each command", async () => {
       const bridge = await loadBridge();
-      const p1 = bridge.request({ type: "get_state" }, "get_state");
-      const p2 = bridge.request({ type: "get_messages" }, "get_messages");
+      const p1 = bridge.request(A, { type: "get_state" }, "get_state");
+      const p2 = bridge.request(A, { type: "get_messages" }, "get_messages");
       [p1, p2].map((p) => p.catch(() => {}));
       await flush();
 
-      const ids = h.sent.map((c) => (c as { id?: string }).id);
+      const ids = commands().map((c) => (c as { id?: string }).id);
       expect(ids[0]).toBeTruthy();
       expect(ids[1]).toBeTruthy();
       expect(ids[0]).not.toBe(ids[1]);
@@ -138,7 +137,7 @@ describe("agentBridge", () => {
 
     it("should reject with the response error when success is false", async () => {
       const bridge = await loadBridge();
-      const p = bridge.request({ type: "do_x" }, "do_x");
+      const p = bridge.request(A, { type: "do_x" }, "do_x");
       await flush();
       respondTo("do_x", { success: false, error: "boom" });
       await expect(p).rejects.toThrow("boom");
@@ -146,7 +145,7 @@ describe("agentBridge", () => {
 
     it("should reject with a default message when a failed response carries no error", async () => {
       const bridge = await loadBridge();
-      const p = bridge.request({ type: "do_x" }, "do_x");
+      const p = bridge.request(A, { type: "do_x" }, "do_x");
       await flush();
       respondTo("do_x", { success: false });
       await expect(p).rejects.toThrow("do_x failed");
@@ -154,7 +153,7 @@ describe("agentBridge", () => {
 
     it("should stay pending when a response carries a different id", async () => {
       const bridge = await loadBridge();
-      const p = bridge.request({ type: "get_state" }, "get_state");
+      const p = bridge.request(A, { type: "get_state" }, "get_state");
       await flush();
 
       let state = "pending";
@@ -178,11 +177,11 @@ describe("agentBridge", () => {
 
     it("should resolve each request with its own data when two same-command requests overlap", async () => {
       const bridge = await loadBridge();
-      const p1 = bridge.request({ type: "get_state" }, "get_state");
-      const p2 = bridge.request({ type: "get_state" }, "get_state");
+      const p1 = bridge.request(A, { type: "get_state" }, "get_state");
+      const p2 = bridge.request(A, { type: "get_state" }, "get_state");
       await flush();
 
-      const [c1, c2] = h.sent.filter((c) => (c as { type?: string }).type === "get_state") as { id?: string }[];
+      const [c1, c2] = commands().filter((c) => (c as { type?: string }).type === "get_state") as { id?: string }[];
       // Answer the second request FIRST — out-of-order delivery must not
       // cross-wire the results.
       emit({ type: "response", id: c2.id, command: "get_state", success: true, data: "B" });
@@ -192,88 +191,121 @@ describe("agentBridge", () => {
       await expect(p2).resolves.toBe("B");
     });
 
+    it("should resolve each request with its own data when two SESSIONS' same-command requests overlap", async () => {
+      const bridge = await loadBridge();
+      const pA = bridge.request(A, { type: "get_state" }, "get_state");
+      const pB = bridge.request(B, { type: "get_state" }, "get_state");
+      await flush();
+
+      const idA = (h.sent.find((c) => c.sessionPath === A)?.command as { id?: string }).id;
+      const idB = (h.sent.find((c) => c.sessionPath === B)?.command as { id?: string }).id;
+      // Children's responses interleave on the one multiplexed stream — the
+      // per-request UUID keeps them apart, B's answer arriving first.
+      emit({ type: "response", id: idB, command: "get_state", success: true, data: "for B" });
+      emit({ type: "response", id: idA, command: "get_state", success: true, data: "for A" });
+
+      await expect(pA).resolves.toBe("for A");
+      await expect(pB).resolves.toBe("for B");
+    });
+
     it("should resolve only once when two matching responses arrive", async () => {
       const bridge = await loadBridge();
-      const p = bridge.request({ type: "get_state" }, "get_state");
+      const p = bridge.request(A, { type: "get_state" }, "get_state");
       await flush();
       respondTo("get_state", { success: true, data: 1 });
       respondTo("get_state", { success: true, data: 2 });
       await expect(p).resolves.toBe(1);
     });
 
-    it("should remove its per-request event listener when the request settles", async () => {
+    it("should not add IPC listeners for in-flight requests (responses ride the one wired stream)", async () => {
       const bridge = await loadBridge();
-      await bridge.send({});
+      await bridge.send(A, {});
       await flush();
       const base = h.eventListeners.size; // the single process-lifetime wire listener
 
-      const p = bridge.request({ type: "get_state" }, "get_state");
+      const p1 = bridge.request(A, { type: "get_state" }, "get_state");
+      const p2 = bridge.request(B, { type: "get_messages" }, "get_messages");
       await flush();
-      expect(h.eventListeners.size).toBe(base + 1);
+      expect(h.eventListeners.size).toBe(base);
 
       respondTo("get_state", { success: true, data: 0 });
-      await p;
-      expect(h.eventListeners.size).toBe(base);
+      respondTo("get_messages", { success: true, data: 0 });
+      await Promise.all([p1, p2]);
     });
   });
 
   describe("request() failure paths", () => {
-    it("should reject an in-flight request when the sidecar crashes", async () => {
+    it("should reject an in-flight request when its session's child crashes", async () => {
       const bridge = await loadBridge();
-      const p = bridge.request({}, "get_state");
+      const p = bridge.request(A, {}, "get_state");
       await flush();
 
-      emitTerminated({ code: 1, signal: null, stderr: "kaboom" });
+      emitTerminated({ sessionPath: A, code: 1, signal: null, stderr: "kaboom" });
       await expect(p).rejects.toThrow(/agent stopped/i);
     });
 
-    it("should reject every in-flight request when the sidecar crashes", async () => {
+    it("should reject every in-flight request of the crashed session", async () => {
       const bridge = await loadBridge();
-      const p1 = bridge.request({}, "cmd1");
-      const p2 = bridge.request({}, "cmd2");
+      const p1 = bridge.request(A, {}, "cmd1");
+      const p2 = bridge.request(A, {}, "cmd2");
       await flush();
 
-      emitTerminated({ code: null, signal: "SIGKILL", stderr: "" });
+      emitTerminated({ sessionPath: A, code: null, signal: "SIGKILL", stderr: "" });
       await expect(p1).rejects.toThrow();
       await expect(p2).rejects.toThrow();
     });
 
-    it("should reject an in-flight request when a spawn error occurs", async () => {
+    it("should keep another session's in-flight request pending when one session crashes", async () => {
       const bridge = await loadBridge();
-      const p = bridge.request({}, "get_state");
+      const pA = bridge.request(A, { type: "get_state" }, "get_state");
+      const pB = bridge.request(B, { type: "get_messages" }, "get_messages");
       await flush();
 
-      emitError("spawn ENOENT");
-      await expect(p).rejects.toThrow("spawn ENOENT");
+      let stateB = "pending";
+      pB.then(
+        () => {
+          stateB = "resolved";
+        },
+        () => {
+          stateB = "rejected";
+        },
+      );
+
+      emitTerminated({ sessionPath: A, code: 1, signal: null, stderr: "" });
+      await expect(pA).rejects.toThrow();
+      await flush();
+      expect(stateB).toBe("pending");
+
+      // B's child is untouched and still answers.
+      respondTo("get_messages", { success: true, data: { messages: [] } });
+      await expect(pB).resolves.toEqual({ messages: [] });
     });
 
-    it("should remove the per-request listener when a crash rejects it", async () => {
+    it("should reject an in-flight request when its session has a spawn error", async () => {
       const bridge = await loadBridge();
-      const p = bridge.request({}, "get_state");
+      const p = bridge.request(A, {}, "get_state");
       await flush();
-      const withRequest = h.eventListeners.size;
 
-      emitTerminated({ code: 1, signal: null, stderr: "" });
-      await expect(p).rejects.toThrow();
-      expect(h.eventListeners.size).toBe(withRequest - 1);
+      emitError(A, "spawn ENOENT");
+      await expect(p).rejects.toThrow("spawn ENOENT");
     });
 
     it("should keep an already-resolved request's outcome when a later crash occurs", async () => {
       const bridge = await loadBridge();
-      const p = bridge.request({ type: "get_state" }, "get_state");
+      const p = bridge.request(A, { type: "get_state" }, "get_state");
       await flush();
       respondTo("get_state", { success: true, data: 42 });
       await expect(p).resolves.toBe(42);
 
       // A crash after the request already settled must be a no-op for it.
-      emitTerminated({ code: 1, signal: null, stderr: "" });
+      emitTerminated({ sessionPath: A, code: 1, signal: null, stderr: "" });
       await expect(p).resolves.toBe(42);
     });
 
     it("should reject the request when no response arrives within 30s", async () => {
       vi.useFakeTimers();
       const bridge = await loadBridge();
-      const p = bridge.request({}, "slow");
+      const p = bridge.request(A, {}, "slow");
       p.catch(() => {});
 
       await vi.advanceTimersByTimeAsync(30_000);
@@ -283,7 +315,7 @@ describe("agentBridge", () => {
     it("should stay pending at 29999ms and reject at 30000ms when no response arrives", async () => {
       vi.useFakeTimers();
       const bridge = await loadBridge();
-      const p = bridge.request({}, "slow");
+      const p = bridge.request(A, {}, "slow");
       let state = "pending";
       p.then(
         () => {
@@ -304,7 +336,7 @@ describe("agentBridge", () => {
     it("should not reject after 30s when a response already arrived", async () => {
       vi.useFakeTimers();
       const bridge = await loadBridge();
-      const p = bridge.request({ type: "x" }, "x");
+      const p = bridge.request(A, { type: "x" }, "x");
       await vi.advanceTimersByTimeAsync(0);
 
       respondTo("x", { success: true, data: 7 });
@@ -321,21 +353,30 @@ describe("agentBridge", () => {
       const bridge = await loadBridge();
       const seen: unknown[] = [];
       bridge.addEventListener((e) => seen.push(e));
-      await bridge.send({});
       await flush();
 
-      emit({ type: "turn_start" });
-      expect(seen).toEqual([{ type: "turn_start" }]);
+      emit({ type: "turn_start", sessionPath: A });
+      expect(seen).toEqual([{ type: "turn_start", sessionPath: A }]);
+    });
+
+    it("should deliver every session's events to subscribers, tagged with their session", async () => {
+      const bridge = await loadBridge();
+      const seen: { sessionPath?: string }[] = [];
+      bridge.addEventListener((e) => seen.push(e));
+      await flush();
+
+      emit({ type: "agent_start", sessionPath: A });
+      emit({ type: "agent_start", sessionPath: B });
+      expect(seen.map((e) => e.sessionPath)).toEqual([A, B]);
     });
 
     it("should not forward response events to stream subscribers", async () => {
       const bridge = await loadBridge();
       const seen: unknown[] = [];
       bridge.addEventListener((e) => seen.push(e));
-      await bridge.send({});
       await flush();
 
-      emit({ type: "response", command: "x", success: true, data: 1 });
+      emit({ type: "response", command: "x", success: true, data: 1, sessionPath: A });
       expect(seen).toHaveLength(0);
     });
 
@@ -343,108 +384,107 @@ describe("agentBridge", () => {
       const bridge = await loadBridge();
       const seen: unknown[] = [];
       const off = bridge.addEventListener((e) => seen.push(e));
-      await bridge.send({});
       await flush();
 
       off();
-      emit({ type: "turn_start" });
+      emit({ type: "turn_start", sessionPath: A });
       expect(seen).toHaveLength(0);
     });
   });
 
   describe("extension_ui_request auto-confirm", () => {
-    it("should auto-confirm and not forward to subscribers when a confirm request arrives", async () => {
+    it("should auto-confirm to the originating session and not forward to subscribers", async () => {
       const bridge = await loadBridge();
       const seen: unknown[] = [];
       bridge.addEventListener((e) => seen.push(e));
-      await bridge.send({});
       await flush();
 
-      emit({ type: "extension_ui_request", id: "q1", method: "confirm" });
-      expect(h.sent).toContainEqual({ type: "extension_ui_response", id: "q1", confirmed: true });
+      emit({ type: "extension_ui_request", id: "q1", method: "confirm", sessionPath: B });
+      expect(h.sent).toContainEqual({
+        sessionPath: B,
+        command: { type: "extension_ui_response", id: "q1", confirmed: true },
+      });
       expect(seen).toHaveLength(0);
     });
 
     it("should answer with an empty value when an input request arrives", async () => {
       const bridge = await loadBridge();
-      await bridge.send({});
+      bridge.addEventListener(() => {});
       await flush();
 
-      emit({ type: "extension_ui_request", id: "q2", method: "input" });
-      expect(h.sent).toContainEqual({ type: "extension_ui_response", id: "q2", confirmed: true, value: "" });
+      emit({ type: "extension_ui_request", id: "q2", method: "input", sessionPath: A });
+      expect(h.sent).toContainEqual({
+        sessionPath: A,
+        command: { type: "extension_ui_response", id: "q2", confirmed: true, value: "" },
+      });
     });
   });
 
   describe("process errors (addErrorListener)", () => {
-    it("should report a restart hint and stderr tail when the sidecar is signal-terminated", async () => {
+    it("should report a restart hint and stderr tail when a child is signal-terminated", async () => {
       const bridge = await loadBridge();
-      const msgs: string[] = [];
-      bridge.addErrorListener((m) => msgs.push(m));
-      await bridge.send({});
+      const msgs: { sessionPath: string; message: string }[] = [];
+      bridge.addErrorListener((sessionPath, message) => msgs.push({ sessionPath, message }));
       await flush();
 
-      emitTerminated({ code: null, signal: "SIGKILL", stderr: "line1\nline2" });
+      emitTerminated({ sessionPath: A, code: null, signal: "SIGKILL", stderr: "line1\nline2" });
       expect(msgs).toHaveLength(1);
-      expect(msgs[0]).toContain("(SIGKILL)");
-      expect(msgs[0]).toContain("Send a message to restart it.");
-      expect(msgs[0]).toContain("line2");
+      expect(msgs[0].sessionPath).toBe(A);
+      expect(msgs[0].message).toContain("(SIGKILL)");
+      expect(msgs[0].message).toContain("Send a message to restart it.");
+      expect(msgs[0].message).toContain("line2");
     });
 
-    it("should report the exit code when the sidecar exits without a signal", async () => {
+    it("should report the exit code when a child exits without a signal", async () => {
       const bridge = await loadBridge();
       const msgs: string[] = [];
-      bridge.addErrorListener((m) => msgs.push(m));
-      await bridge.send({});
+      bridge.addErrorListener((_s, m) => msgs.push(m));
       await flush();
 
-      emitTerminated({ code: 1, signal: null, stderr: "" });
+      emitTerminated({ sessionPath: A, code: 1, signal: null, stderr: "" });
       expect(msgs[0]).toContain("(exit 1)");
     });
 
     it("should report a bare stop message when there is neither signal nor code", async () => {
       const bridge = await loadBridge();
       const msgs: string[] = [];
-      bridge.addErrorListener((m) => msgs.push(m));
-      await bridge.send({});
+      bridge.addErrorListener((_s, m) => msgs.push(m));
       await flush();
 
-      emitTerminated({ code: null, signal: null, stderr: "" });
+      emitTerminated({ sessionPath: A, code: null, signal: null, stderr: "" });
       expect(msgs[0]).toBe("The agent stopped. Send a message to restart it.");
     });
 
     it("should truncate the stderr tail to the last 8 lines when stderr is longer", async () => {
       const bridge = await loadBridge();
       const msgs: string[] = [];
-      bridge.addErrorListener((m) => msgs.push(m));
-      await bridge.send({});
+      bridge.addErrorListener((_s, m) => msgs.push(m));
       await flush();
 
       const stderr = Array.from({ length: 12 }, (_, i) => `L${i + 1}`).join("\n"); // L1..L12
-      emitTerminated({ code: 1, signal: null, stderr });
+      emitTerminated({ sessionPath: A, code: 1, signal: null, stderr });
       expect(msgs[0]).toContain("L5"); // 12 - 8 + 1
       expect(msgs[0]).not.toContain("L4");
     });
 
-    it("should pass the message through verbatim when a spawn error occurs", async () => {
+    it("should pass the session and message through verbatim when a spawn error occurs", async () => {
       const bridge = await loadBridge();
-      const msgs: string[] = [];
-      bridge.addErrorListener((m) => msgs.push(m));
-      await bridge.send({});
+      const msgs: { sessionPath: string; message: string }[] = [];
+      bridge.addErrorListener((sessionPath, message) => msgs.push({ sessionPath, message }));
       await flush();
 
-      emitError("spawn failed");
-      expect(msgs).toContain("spawn failed");
+      emitError(B, "spawn failed");
+      expect(msgs).toEqual([{ sessionPath: B, message: "spawn failed" }]);
     });
 
     it("should stop notifying an error listener when it unsubscribes", async () => {
       const bridge = await loadBridge();
       const msgs: string[] = [];
-      const off = bridge.addErrorListener((m) => msgs.push(m));
-      await bridge.send({});
+      const off = bridge.addErrorListener((_s, m) => msgs.push(m));
       await flush();
 
       off();
-      emitError("later crash");
+      emitError(A, "later crash");
       expect(msgs).toHaveLength(0);
     });
   });

--- a/packages/desktop/src/runtime/__tests__/electronPiClient.test.ts
+++ b/packages/desktop/src/runtime/__tests__/electronPiClient.test.ts
@@ -4,22 +4,26 @@ import { encodeAttachmentRef } from "../../lib/attachmentMarker";
 import { createElectronPiClient } from "../electronPiClient";
 import { newChatModel } from "../newChatModel";
 
-// electronPiClient bridges the pi RPC stream to the runtime and reports the
+// electronPiClient bridges the per-session pi RPC streams to the runtime
+// (routing every command and event by threadId = sessionPath) and reports the
 // anonymous usage events (message/tool counts + coarse props — never content).
 // The agentBridge (sidecar IPC) and rpc/api (Electron IPC) are the faked I/O
-// boundaries; the client's own mapping/analytics logic runs for real.
+// boundaries; the client's own routing/mapping/analytics logic runs for real.
 
 const h = vi.hoisted(() => ({
   listeners: [] as Array<(e: unknown) => void>,
-  errorListeners: [] as Array<(msg: string) => void>,
-  sent: [] as Record<string, unknown>[],
-  /** Every command routed through agentBridge.request, for ordering assertions. */
-  requests: [] as Record<string, unknown>[],
+  errorListeners: [] as Array<(sessionPath: string, msg: string) => void>,
+  /** Every command routed through agentBridge.send, with its target session. */
+  sent: [] as { sessionPath: string; command: Record<string, unknown> }[],
+  /** Every command routed through agentBridge.request, with its target session. */
+  requests: [] as { sessionPath: string; command: Record<string, unknown> }[],
+  /** The path agent_create_session mints for the next new chat. */
+  newSessionPath: "/ws/sessions/new.jsonl",
   /** get_messages response — per-test override for transcript contents. */
   messages: [] as unknown[],
   /** get_state response — per-test override for the model under test. */
   state: {} as Record<string, unknown>,
-  /** get_available_models response — per-test override for the model catalog. */
+  /** auth_models response — per-test override for the model catalog. */
   availableModels: [] as unknown[],
   /** sessions_list response — per-test override for the thread list. */
   sessions: [] as unknown[],
@@ -46,22 +50,21 @@ vi.mock("../agentBridge", () => ({
         if (i >= 0) h.listeners.splice(i, 1);
       };
     },
-    addErrorListener: (fn: (msg: string) => void) => {
+    addErrorListener: (fn: (sessionPath: string, msg: string) => void) => {
       h.errorListeners.push(fn);
       return () => {
         const i = h.errorListeners.indexOf(fn);
         if (i >= 0) h.errorListeners.splice(i, 1);
       };
     },
-    send: async (command: Record<string, unknown>) => {
-      h.sent.push(command);
+    send: async (sessionPath: string, command: Record<string, unknown>) => {
+      h.sent.push({ sessionPath, command });
     },
-    request: async (command: { type: string }) => {
-      h.requests.push(command);
+    request: async (sessionPath: string, command: { type: string }) => {
+      h.requests.push({ sessionPath, command: command as Record<string, unknown> });
       if (h.errorTypes.has(command.type)) throw new Error(`fail:${command.type}`);
       if (command.type === "get_state") return h.state;
       if (command.type === "get_messages") return { messages: h.messages };
-      if (command.type === "get_available_models") return { models: h.availableModels };
       return {};
     },
   },
@@ -82,7 +85,11 @@ vi.mock("../../rpc/api", () => ({
     },
   },
   skillsApi: { list: async () => ({ skills: h.skills }) },
-  agentApi: { onModelsChanged: () => () => {} },
+  authApi: { models: async () => ({ type: "models", models: h.availableModels }) },
+  agentApi: {
+    onModelsChanged: () => () => {},
+    createSession: async () => h.newSessionPath,
+  },
 }));
 
 /** Deliver a sidecar event to every persistent listener the client registered. */
@@ -90,26 +97,38 @@ const emit = (event: Record<string, unknown>) => {
   for (const fn of h.listeners) fn(event);
 };
 
-/** Deliver a sidecar error to every error listener the client registered. */
-const emitError = (msg: string) => {
-  for (const fn of [...h.errorListeners]) fn(msg);
+/** Deliver a sidecar error for one session to every error listener. */
+const emitError = (sessionPath: string, msg: string) => {
+  for (const fn of [...h.errorListeners]) fn(sessionPath, msg);
 };
+
+/** The live-only subscription target for event-mapping tests. */
+const LIVE = "/ws/sessions/live.jsonl";
+/** Emit an event tagged as coming from LIVE's child. */
+const emitL = (event: Record<string, unknown>) => emit({ ...event, sessionPath: LIVE });
 
 const toolEnd = (toolName: string, isError = false) => ({
   type: "tool_execution_end",
   toolCallId: "t1",
   toolName,
   isError,
+  sessionPath: LIVE,
 });
 
 const message = (text: string, attachments?: string[]) =>
   ({ content: text, ...(attachments ? { attachments } : {}) }) as unknown as PiSendMessageInput;
+
+/** All commands routed through agentBridge.send, regardless of session. */
+const sentCmds = () => h.sent.map((s) => s.command);
+/** All commands routed through agentBridge.request, regardless of session. */
+const requestCmds = () => h.requests.map((r) => r.command);
 
 beforeEach(() => {
   h.listeners.length = 0;
   h.errorListeners.length = 0;
   h.sent.length = 0;
   h.requests.length = 0;
+  h.newSessionPath = "/ws/sessions/new.jsonl";
   h.messages = [];
   h.availableModels = [];
   h.sessions = [];
@@ -162,8 +181,8 @@ describe("createElectronPiClient() analytics", () => {
 
     it("should count a tool run exactly once even with multiple thread subscriptions", () => {
       const client = createElectronPiClient();
-      client.subscribe("pending-1", () => {}, { includeSnapshot: false });
-      client.subscribe("pending-2", () => {}, { includeSnapshot: false });
+      client.subscribe(LIVE, () => {}, { includeSnapshot: false });
+      client.subscribe("/ws/sessions/other.jsonl", () => {}, { includeSnapshot: false });
       emit(toolEnd("query"));
       expect(h.track.mock.calls.filter(([event]) => event === "agent_tool_used")).toHaveLength(1);
     });
@@ -201,7 +220,7 @@ describe("createElectronPiClient() analytics", () => {
     it("should track the model reading a native SKILL.md as auto usage by name", async () => {
       createElectronPiClient();
       await flushLookup();
-      emit({
+      emitL({
         type: "tool_execution_start",
         toolCallId: "t2",
         toolName: "read",
@@ -217,7 +236,7 @@ describe("createElectronPiClient() analytics", () => {
     it("should track the model reading a custom SKILL.md anonymously (file_path arg variant)", async () => {
       createElectronPiClient();
       await flushLookup();
-      emit({
+      emitL({
         type: "tool_execution_start",
         toolCallId: "t3",
         toolName: "read",
@@ -229,8 +248,8 @@ describe("createElectronPiClient() analytics", () => {
     it("should not track reads of ordinary files", async () => {
       createElectronPiClient();
       await flushLookup();
-      emit({ type: "tool_execution_start", toolCallId: "t4", toolName: "read", args: { path: "/ws/memory.md" } });
-      emit({ type: "tool_execution_start", toolCallId: "t5", toolName: "bash", args: { command: "ls" } });
+      emitL({ type: "tool_execution_start", toolCallId: "t4", toolName: "read", args: { path: "/ws/memory.md" } });
+      emitL({ type: "tool_execution_start", toolCallId: "t5", toolName: "bash", args: { command: "ls" } });
       expect(skillUsedCalls()).toHaveLength(0);
     });
   });
@@ -238,16 +257,16 @@ describe("createElectronPiClient() analytics", () => {
   describe("agent replies", () => {
     it("should track agent_message_sent when an agent turn ends", () => {
       const client = createElectronPiClient();
-      client.subscribe("pending-1", () => {}, { includeSnapshot: false });
-      emit({ type: "agent_end" });
+      client.subscribe(LIVE, () => {}, { includeSnapshot: false });
+      emitL({ type: "agent_end" });
       expect(h.track).toHaveBeenCalledWith("agent_message_sent");
     });
 
     it("should count an agent reply exactly once even with multiple thread subscriptions", () => {
       const client = createElectronPiClient();
-      client.subscribe("pending-1", () => {}, { includeSnapshot: false });
-      client.subscribe("pending-2", () => {}, { includeSnapshot: false });
-      emit({ type: "agent_end" });
+      client.subscribe(LIVE, () => {}, { includeSnapshot: false });
+      client.subscribe("/ws/sessions/other.jsonl", () => {}, { includeSnapshot: false });
+      emitL({ type: "agent_end" });
       expect(h.track.mock.calls.filter(([event]) => event === "agent_message_sent")).toHaveLength(1);
     });
   });
@@ -305,14 +324,14 @@ describe("createElectronPiClient() analytics", () => {
       const client = createElectronPiClient();
       const snapshot = await client.createThread({});
       await client.sendMessage(snapshot.metadata.id, message("add 12 EUR for coffee"));
-      expect(h.sent.at(-1)).toMatchObject({ type: "prompt", message: "add 12 EUR for coffee" });
+      expect(sentCmds().at(-1)).toMatchObject({ type: "prompt", message: "add 12 EUR for coffee" });
     });
 
     it("should hoist a skill chip into pi's leading /skill: token on send", async () => {
       const client = createElectronPiClient();
       const snapshot = await client.createThread({});
       await client.sendMessage(snapshot.metadata.id, message(":skill[pdf] summarize this receipt"));
-      expect(h.sent.at(-1)).toMatchObject({ type: "prompt", message: "/skill:pdf summarize this receipt" });
+      expect(sentCmds().at(-1)).toMatchObject({ type: "prompt", message: "/skill:pdf summarize this receipt" });
     });
 
     it("should collapse pi's expanded skill block back to the directive in transcript snapshots", async () => {
@@ -348,10 +367,10 @@ describe("createElectronPiClient() analytics", () => {
       expect(h.track).toHaveBeenCalledWith("user_message_sent", { has_attachment: "false" });
     });
 
-    it("should report the new chat's model for its initial message, not the previous session's", async () => {
+    it("should report the new chat's model for its initial message, not another thread's", async () => {
       const client = createElectronPiClient();
-      await client.getThread("/ws/sessions/old.jsonl"); // caches the previous session's model
-      h.state = { model: { provider: "openai-codex", id: "gpt-x" }, sessionFile: "/ws/sessions/s2.jsonl" };
+      await client.getThread("/ws/sessions/old.jsonl"); // caches the old thread's model
+      h.state = { model: { provider: "openai-codex", id: "gpt-x" }, sessionFile: "/ws/sessions/new.jsonl" };
       await client.createThread({ initialMessage: message("hi") });
       expect(h.track).toHaveBeenCalledWith("user_message_sent", {
         has_attachment: "false",
@@ -367,6 +386,18 @@ describe("createElectronPiClient() analytics", () => {
       expect(h.track).toHaveBeenCalledWith("user_message_sent", {
         has_attachment: "false",
         model: "openai/gpt-x",
+      });
+    });
+
+    it("should keep each thread's model separate for analytics", async () => {
+      const client = createElectronPiClient();
+      const snapshot = await client.createThread({});
+      await client.setModel("/ws/sessions/other.jsonl", { provider: "openai", modelId: "gpt-x" });
+      await client.sendMessage(snapshot.metadata.id, message("hi"));
+      // The other thread's setModel must not bleed into this thread's prop.
+      expect(h.track).toHaveBeenCalledWith("user_message_sent", {
+        has_attachment: "false",
+        model: "anthropic/claude-x",
       });
     });
 
@@ -396,7 +427,7 @@ const skillBlockUser = {
 };
 
 /** Subscribe live-only (no snapshot), collecting the mapped client events. */
-const captureLive = (client: ReturnType<typeof createElectronPiClient>, threadId = "pending-live") => {
+const captureLive = (client: ReturnType<typeof createElectronPiClient>, threadId = LIVE) => {
   const events: PiClientEvent[] = [];
   const unsub = client.subscribe(threadId, (e) => events.push(e), { includeSnapshot: false });
   return { events, unsub };
@@ -408,46 +439,46 @@ const body = (e: PiClientEvent) => e as unknown as Record<string, unknown>;
 describe("createElectronPiClient() event mapping", () => {
   it("should map agent_start to an agent_start body stamped with thread + seq", () => {
     const { events } = captureLive(createElectronPiClient());
-    emit({ type: "agent_start" });
-    expect(events[0]).toMatchObject({ type: "agent_start", threadId: "pending-live", seq: 1 });
+    emitL({ type: "agent_start" });
+    expect(events[0]).toMatchObject({ type: "agent_start", threadId: LIVE, seq: 1 });
   });
 
   it("should map agent_end to an agent_end body", () => {
     const { events } = captureLive(createElectronPiClient());
-    emit({ type: "agent_end" });
+    emitL({ type: "agent_end" });
     expect(events[0]).toMatchObject({ type: "agent_end" });
   });
 
   it("should number turns from zero, incrementing on each turn_start", () => {
     const { events } = captureLive(createElectronPiClient());
-    emit({ type: "turn_start" });
-    emit({ type: "turn_start" });
+    emitL({ type: "turn_start" });
+    emitL({ type: "turn_start" });
     expect(events.map((e) => body(e).turnIndex)).toEqual([0, 1]);
   });
 
   it("should stamp turn_end with the current turn index", () => {
     const { events } = captureLive(createElectronPiClient());
-    emit({ type: "turn_start" });
-    emit({ type: "turn_end" });
+    emitL({ type: "turn_start" });
+    emitL({ type: "turn_end" });
     expect(events[1]).toMatchObject({ type: "turn_end", turnIndex: 0 });
   });
 
   it("should default turn_end to turn zero when no turn has started", () => {
     const { events } = captureLive(createElectronPiClient());
-    emit({ type: "turn_end" });
+    emitL({ type: "turn_end" });
     expect(events[0]).toMatchObject({ type: "turn_end", turnIndex: 0 });
   });
 
   it("should pass an assistant message through message_start unchanged", () => {
     const { events } = captureLive(createElectronPiClient());
     const msg = { role: "assistant", content: [{ type: "text", text: "hi" }] };
-    emit({ type: "message_start", message: msg });
+    emitL({ type: "message_start", message: msg });
     expect(body(events[0]).message).toEqual(msg);
   });
 
   it("should collapse a skill block in a message_start user message back to the directive", () => {
     const { events } = captureLive(createElectronPiClient());
-    emit({ type: "message_start", message: skillBlockUser });
+    emitL({ type: "message_start", message: skillBlockUser });
     const message = body(events[0]).message as { content: Array<{ text: string }> };
     expect(message.content[0].text).toBe(":skill[pdf] summarize this receipt");
   });
@@ -455,27 +486,27 @@ describe("createElectronPiClient() event mapping", () => {
   it("should carry a text_delta through message_update as its assistantMessageEvent", () => {
     const { events } = captureLive(createElectronPiClient());
     const delta = { type: "text_delta", text: "hel" };
-    emit({ type: "message_update", message: { role: "assistant", content: [] }, assistantMessageEvent: delta });
+    emitL({ type: "message_update", message: { role: "assistant", content: [] }, assistantMessageEvent: delta });
     expect(events[0]).toMatchObject({ type: "message_update", assistantMessageEvent: delta });
   });
 
   it("should carry a thinking_delta through message_update as its assistantMessageEvent", () => {
     const { events } = captureLive(createElectronPiClient());
     const delta = { type: "thinking_delta", thinking: "hmm" };
-    emit({ type: "message_update", message: { role: "assistant", content: [] }, assistantMessageEvent: delta });
+    emitL({ type: "message_update", message: { role: "assistant", content: [] }, assistantMessageEvent: delta });
     expect(events[0]).toMatchObject({ type: "message_update", assistantMessageEvent: delta });
   });
 
   it("should pass the final message through message_end", () => {
     const { events } = captureLive(createElectronPiClient());
     const msg = { role: "assistant", content: [{ type: "text", text: "done" }] };
-    emit({ type: "message_end", message: msg });
+    emitL({ type: "message_end", message: msg });
     expect(body(events[0])).toMatchObject({ type: "message_end", message: msg });
   });
 
   it("should map tool_execution_start with its id, name and args", () => {
     const { events } = captureLive(createElectronPiClient());
-    emit({ type: "tool_execution_start", toolCallId: "t1", toolName: "query", args: { sql: "x" } });
+    emitL({ type: "tool_execution_start", toolCallId: "t1", toolName: "query", args: { sql: "x" } });
     expect(events[0]).toMatchObject({
       type: "tool_execution_start",
       toolCallId: "t1",
@@ -486,14 +517,14 @@ describe("createElectronPiClient() event mapping", () => {
 
   it("should map tool_execution_update with an undefined partial result", () => {
     const { events } = captureLive(createElectronPiClient());
-    emit({ type: "tool_execution_update", toolCallId: "t1", toolName: "query" });
+    emitL({ type: "tool_execution_update", toolCallId: "t1", toolName: "query" });
     expect(events[0]).toMatchObject({ type: "tool_execution_update", toolCallId: "t1", toolName: "query" });
     expect(body(events[0]).partialResult).toBeUndefined();
   });
 
   it("should map tool_execution_end carrying the result and a false error flag by default", () => {
     const { events } = captureLive(createElectronPiClient());
-    emit({ type: "tool_execution_end", toolCallId: "t1", toolName: "query", result: { rows: 3 } });
+    emitL({ type: "tool_execution_end", toolCallId: "t1", toolName: "query", result: { rows: 3 } });
     expect(events[0]).toMatchObject({
       type: "tool_execution_end",
       toolCallId: "t1",
@@ -504,36 +535,121 @@ describe("createElectronPiClient() event mapping", () => {
 
   it("should coerce a truthy error into isError true on tool_execution_end", () => {
     const { events } = captureLive(createElectronPiClient());
-    emit({ type: "tool_execution_end", toolCallId: "t1", toolName: "query", isError: true });
+    emitL({ type: "tool_execution_end", toolCallId: "t1", toolName: "query", isError: true });
     expect(events[0]).toMatchObject({ type: "tool_execution_end", isError: true });
   });
 
-  it("should pass an unrecognized event type (response) through as a bare typed body", () => {
+  it("should pass an unrecognized event type through as a bare typed body", () => {
     const { events } = captureLive(createElectronPiClient());
-    emit({ type: "response", id: "r1", command: "get_state", success: true });
-    expect(events[0]).toMatchObject({ type: "response", threadId: "pending-live", seq: 1 });
+    emitL({ type: "queue_update", queue: [] });
+    expect(events[0]).toMatchObject({ type: "queue_update", threadId: LIVE, seq: 1 });
   });
 
   it("should stamp a strictly increasing seq per emitted event", () => {
     const { events } = captureLive(createElectronPiClient());
-    emit({ type: "agent_start" });
-    emit({ type: "agent_end" });
-    emit({ type: "turn_start" });
+    emitL({ type: "agent_start" });
+    emitL({ type: "agent_end" });
+    emitL({ type: "turn_start" });
     expect(events.map((e) => body(e).seq)).toEqual([1, 2, 3]);
   });
 
-  it("should forward a sidecar error to the subscriber as an error event", () => {
+  it("should forward the session's sidecar error to the subscriber as an error event", () => {
     const { events } = captureLive(createElectronPiClient());
-    emitError("boom");
-    expect(events[0]).toMatchObject({ type: "error", error: "boom", threadId: "pending-live" });
+    emitError(LIVE, "boom");
+    expect(events[0]).toMatchObject({ type: "error", error: "boom", threadId: LIVE });
   });
 
   it("should stop delivering events after the subscription is torn down", () => {
     const { events, unsub } = captureLive(createElectronPiClient());
     unsub();
-    emit({ type: "agent_start" });
-    emitError("boom");
+    emitL({ type: "agent_start" });
+    emitError(LIVE, "boom");
     expect(events).toHaveLength(0);
+  });
+});
+
+describe("createElectronPiClient() per-session routing", () => {
+  const A = "/ws/sessions/a.jsonl";
+  const B = "/ws/sessions/b.jsonl";
+
+  it("should keep session A running and streaming its events while B is viewed", async () => {
+    // The A-33 regression: a run in chat A used to be aborted (switch_session)
+    // and its events mis-routed to whichever thread was active. Now events
+    // route by their sessionPath tag, and no session switching exists at all.
+    const client = createElectronPiClient();
+    const a = captureLive(client, A);
+    const b = captureLive(client, B);
+
+    emit({ type: "agent_start", sessionPath: A });
+    emit({
+      type: "message_update",
+      message: { role: "assistant", content: [] },
+      assistantMessageEvent: { type: "text_delta", text: "still going" },
+      sessionPath: A,
+    });
+
+    // Viewing B (snapshot fetch) must not issue any switch command.
+    await client.getThread(B);
+    expect(requestCmds().some((r) => r.type === "switch_session")).toBe(false);
+
+    // A's stream reached only A's subscriber.
+    expect(a.events.map((e) => e.type)).toEqual(["agent_start", "message_update"]);
+    expect(b.events).toHaveLength(0);
+
+    // Returning to A reports it running (the run never stopped).
+    const snap = await client.getThread(A);
+    expect(snap.metadata.status).toBe("running");
+  });
+
+  it("should route every thread operation to its own session", async () => {
+    const client = createElectronPiClient();
+    await client.getThread(A);
+    await client.sendMessage(B, message("hi"));
+    await client.setModel(A, { provider: "openai", modelId: "gpt-x" });
+    await client.setThinkingLevel(B, "high");
+    await client.renameThread(A, "Budget");
+    await client.cancelRun(B);
+
+    expect(h.requests.every((r) => r.sessionPath === A)).toBe(true);
+    expect(h.sent).toContainEqual({ sessionPath: B, command: expect.objectContaining({ type: "prompt" }) });
+    expect(h.sent).toContainEqual({
+      sessionPath: A,
+      command: { type: "set_model", provider: "openai", modelId: "gpt-x" },
+    });
+    expect(h.sent).toContainEqual({ sessionPath: B, command: { type: "set_thinking_level", level: "high" } });
+    expect(h.sent).toContainEqual({ sessionPath: A, command: { type: "set_session_name", name: "Budget" } });
+    expect(h.sent).toContainEqual({ sessionPath: B, command: { type: "abort" } });
+  });
+
+  it("should mark only the crashed session as stopped, leaving the other running", async () => {
+    const client = createElectronPiClient();
+    emit({ type: "agent_start", sessionPath: A });
+    emit({ type: "agent_start", sessionPath: B });
+
+    emitError(A, "crash");
+
+    const snapA = await client.getThread(A);
+    const snapB = await client.getThread(B);
+    expect(snapA.metadata.status).toBe("idle");
+    expect(snapB.metadata.status).toBe("running");
+  });
+
+  it("should deliver a crash error only to the crashed session's subscribers", () => {
+    const client = createElectronPiClient();
+    const a = captureLive(client, A);
+    const b = captureLive(client, B);
+
+    emitError(A, "crash");
+    expect(a.events).toEqual([expect.objectContaining({ type: "error", error: "crash", threadId: A })]);
+    expect(b.events).toHaveLength(0);
+  });
+
+  it("should clear the running flag when the session's run ends", async () => {
+    const client = createElectronPiClient();
+    emit({ type: "agent_start", sessionPath: A });
+    emit({ type: "agent_end", sessionPath: A });
+    const snap = await client.getThread(A);
+    expect(snap.metadata.status).toBe("idle");
   });
 });
 
@@ -544,7 +660,7 @@ describe("createElectronPiClient() subscribe() snapshot", () => {
     client.subscribe("/ws/sessions/s1.jsonl", (e) => events.push(e));
     await flushLookup();
     expect(events[0]).toMatchObject({ type: "snapshot", seq: 1 });
-    emit({ type: "agent_end" });
+    emit({ type: "agent_end", sessionPath: "/ws/sessions/s1.jsonl" });
     expect(events[1]).toMatchObject({ type: "agent_end", seq: 2 });
   });
 
@@ -552,115 +668,85 @@ describe("createElectronPiClient() subscribe() snapshot", () => {
     h.errorTypes = new Set(["get_state"]);
     const client = createElectronPiClient();
     const events: PiClientEvent[] = [];
-    client.subscribe("pending-err", (e) => events.push(e));
+    client.subscribe("/ws/sessions/err.jsonl", (e) => events.push(e));
     await flushLookup();
     expect(events[0]).toMatchObject({ type: "error", error: "fail:get_state", seq: 1 });
-    emit({ type: "agent_start" });
+    emit({ type: "agent_start", sessionPath: "/ws/sessions/err.jsonl" });
     expect(events[1]).toMatchObject({ type: "agent_start", seq: 2 });
   });
 });
 
-describe("createElectronPiClient() session switching", () => {
-  it("should issue switch_session before operating on a non-active thread", async () => {
-    const client = createElectronPiClient();
-    await client.getThread("/ws/sessions/other.jsonl");
-    expect(h.requests).toContainEqual({ type: "switch_session", sessionPath: "/ws/sessions/other.jsonl" });
-  });
-
-  it("should not re-issue switch_session for the already-active thread", async () => {
-    const client = createElectronPiClient();
-    await client.getThread("/ws/sessions/other.jsonl");
-    await client.getThread("/ws/sessions/other.jsonl");
-    expect(h.requests.filter((r) => r.type === "switch_session")).toHaveLength(1);
-  });
-
-  it("should not switch sessions for a pending (not-yet-created) thread id", async () => {
-    const client = createElectronPiClient();
-    await client.getThread("pending-1");
-    expect(h.requests.some((r) => r.type === "switch_session")).toBe(false);
-  });
-
-  it("should serialize switch_session in call order across concurrent threads", async () => {
-    const client = createElectronPiClient();
-    await Promise.all([client.getThread("/ws/A.jsonl"), client.getThread("/ws/B.jsonl")]);
-    const paths = h.requests.filter((r) => r.type === "switch_session").map((r) => r.sessionPath);
-    expect(paths).toEqual(["/ws/A.jsonl", "/ws/B.jsonl"]);
-  });
-
-  it("should switch to the target session before setModel forwards the model", async () => {
-    const client = createElectronPiClient();
-    await client.setModel("/ws/C.jsonl", { provider: "openai", modelId: "gpt-x" });
-    expect(h.requests).toContainEqual({ type: "switch_session", sessionPath: "/ws/C.jsonl" });
-    expect(h.sent).toContainEqual({ type: "set_model", provider: "openai", modelId: "gpt-x" });
-  });
-
-  it("should re-switch after an agent crash forgets the active thread", async () => {
-    const client = createElectronPiClient();
-    await client.createThread({}); // activeThreadId = /ws/sessions/s1.jsonl
-    h.requests.length = 0;
-    emitError("crash"); // errorListener clears activeThreadId
-    await client.getThread("/ws/sessions/s1.jsonl");
-    expect(h.requests).toContainEqual({ type: "switch_session", sessionPath: "/ws/sessions/s1.jsonl" });
-  });
-});
-
-describe("createElectronPiClient() createThread() model selection", () => {
-  it("should apply the pending new-chat model to the fresh session", async () => {
-    newChatModel.set({ provider: "openai", modelId: "gpt-x" });
-    const client = createElectronPiClient();
-    await client.createThread({});
-    expect(h.sent).toContainEqual({ type: "set_model", provider: "openai", modelId: "gpt-x" });
-  });
-
-  it("should clear the pending model after the thread is created", async () => {
-    newChatModel.set({ provider: "openai", modelId: "gpt-x" });
-    const client = createElectronPiClient();
-    await client.createThread({});
-    expect(newChatModel.get()).toBeUndefined();
-  });
-
-  it("should fall back to the configured default model when there is no pending pick", async () => {
-    h.settings = { defaultModel: "anthropic/claude-y" };
-    const client = createElectronPiClient();
-    await client.createThread({});
-    expect(h.sent).toContainEqual({ type: "set_model", provider: "anthropic", modelId: "claude-y" });
-  });
-
-  it("should prefer the pending pick over the configured default", async () => {
-    h.settings = { defaultModel: "anthropic/claude-y" };
-    newChatModel.set({ provider: "openai", modelId: "gpt-x" });
-    const client = createElectronPiClient();
-    await client.createThread({});
-    expect(h.sent).toContainEqual({ type: "set_model", provider: "openai", modelId: "gpt-x" });
-    expect(h.sent.some((c) => c.provider === "anthropic")).toBe(false);
-  });
-
-  it("should not set any model when neither a pending pick nor a default exists", async () => {
-    const client = createElectronPiClient();
-    await client.createThread({});
-    expect(h.sent.some((c) => c.type === "set_model")).toBe(false);
-  });
-
-  it("should not set a model for a malformed default id", async () => {
-    h.settings = { defaultModel: "no-slash" };
-    const client = createElectronPiClient();
-    await client.createThread({});
-    expect(h.sent.some((c) => c.type === "set_model")).toBe(false);
-  });
-
-  it("should keep pi's default and still clear the pending model when settings are unreadable", async () => {
-    h.settingsThrows = true;
-    const client = createElectronPiClient();
-    await expect(client.createThread({})).resolves.toBeDefined();
-    expect(h.sent.some((c) => c.type === "set_model")).toBe(false);
-    expect(newChatModel.get()).toBeUndefined();
-  });
-
-  it("should fall back to a pending id when pi reports neither a session file nor id", async () => {
-    h.state = { model: A_MODEL };
+describe("createElectronPiClient() createThread()", () => {
+  it("should mint the thread id via agent_create_session and fetch its state", async () => {
     const client = createElectronPiClient();
     const snap = await client.createThread({});
-    expect(snap.metadata.id).toMatch(/^pending-\d+$/);
+    expect(snap.metadata.id).toBe("/ws/sessions/new.jsonl");
+    expect(h.requests).toContainEqual({ sessionPath: "/ws/sessions/new.jsonl", command: { type: "get_state" } });
+  });
+
+  it("should send the initial message to the freshly minted session", async () => {
+    const client = createElectronPiClient();
+    await client.createThread({ initialMessage: message("hi") });
+    expect(h.sent).toContainEqual({
+      sessionPath: "/ws/sessions/new.jsonl",
+      command: expect.objectContaining({ type: "prompt", message: "hi" }),
+    });
+  });
+
+  describe("model selection", () => {
+    it("should apply the pending new-chat model to the fresh session", async () => {
+      newChatModel.set({ provider: "openai", modelId: "gpt-x" });
+      const client = createElectronPiClient();
+      await client.createThread({});
+      expect(h.sent).toContainEqual({
+        sessionPath: "/ws/sessions/new.jsonl",
+        command: { type: "set_model", provider: "openai", modelId: "gpt-x" },
+      });
+    });
+
+    it("should clear the pending model after the thread is created", async () => {
+      newChatModel.set({ provider: "openai", modelId: "gpt-x" });
+      const client = createElectronPiClient();
+      await client.createThread({});
+      expect(newChatModel.get()).toBeUndefined();
+    });
+
+    it("should fall back to the configured default model when there is no pending pick", async () => {
+      h.settings = { defaultModel: "anthropic/claude-y" };
+      const client = createElectronPiClient();
+      await client.createThread({});
+      expect(sentCmds()).toContainEqual({ type: "set_model", provider: "anthropic", modelId: "claude-y" });
+    });
+
+    it("should prefer the pending pick over the configured default", async () => {
+      h.settings = { defaultModel: "anthropic/claude-y" };
+      newChatModel.set({ provider: "openai", modelId: "gpt-x" });
+      const client = createElectronPiClient();
+      await client.createThread({});
+      expect(sentCmds()).toContainEqual({ type: "set_model", provider: "openai", modelId: "gpt-x" });
+      expect(sentCmds().some((c) => c.provider === "anthropic")).toBe(false);
+    });
+
+    it("should not set any model when neither a pending pick nor a default exists", async () => {
+      const client = createElectronPiClient();
+      await client.createThread({});
+      expect(sentCmds().some((c) => c.type === "set_model")).toBe(false);
+    });
+
+    it("should not set a model for a malformed default id", async () => {
+      h.settings = { defaultModel: "no-slash" };
+      const client = createElectronPiClient();
+      await client.createThread({});
+      expect(sentCmds().some((c) => c.type === "set_model")).toBe(false);
+    });
+
+    it("should keep pi's default and still clear the pending model when settings are unreadable", async () => {
+      h.settingsThrows = true;
+      const client = createElectronPiClient();
+      await expect(client.createThread({})).resolves.toBeDefined();
+      expect(sentCmds().some((c) => c.type === "set_model")).toBe(false);
+      expect(newChatModel.get()).toBeUndefined();
+    });
   });
 });
 
@@ -672,6 +758,29 @@ describe("createElectronPiClient() getThread() snapshot", () => {
       state: "ready",
       selection: { provider: "anthropic", modelId: "claude-x" },
       source: "session",
+    });
+  });
+
+  it("should restore a reopened thread's transcript without any prior createThread (cold start)", async () => {
+    // App relaunch: the thread exists only as a session file on disk. The
+    // first getThread must return its persisted history, and a follow-up
+    // message must go to that same session.
+    h.messages = [
+      { role: "user", content: [{ type: "text", text: "hello from yesterday" }] },
+      { role: "assistant", content: [{ type: "text", text: "welcome back" }] },
+    ];
+    h.state = { model: A_MODEL, sessionFile: "/ws/sessions/old.jsonl", sessionName: "Yesterday" };
+    const client = createElectronPiClient();
+
+    const snap = await client.getThread("/ws/sessions/old.jsonl");
+    expect(snap.messages).toHaveLength(2);
+    expect(snap.metadata.title).toBe("Yesterday");
+    expect(snap.metadata.status).toBe("idle");
+
+    await client.sendMessage("/ws/sessions/old.jsonl", message("continuing"));
+    expect(h.sent).toContainEqual({
+      sessionPath: "/ws/sessions/old.jsonl",
+      command: expect.objectContaining({ type: "prompt", message: "continuing" }),
     });
   });
 
@@ -745,15 +854,22 @@ describe("createElectronPiClient() getAvailableModels()", () => {
     expect(models[0]).toEqual({ provider: "openai", modelId: "gpt-x", supportsThinking: false });
   });
 
-  it("should return an empty list when the sidecar reports an empty catalog", async () => {
+  it("should return an empty list when the catalog is empty", async () => {
     const client = createElectronPiClient();
     expect(await client.getAvailableModels()).toEqual([]);
   });
 
-  it("should return an empty list when the sidecar omits the models field", async () => {
+  it("should return an empty list when the models field is omitted", async () => {
     (h as { availableModels: unknown }).availableModels = undefined;
     const client = createElectronPiClient();
     expect(await client.getAvailableModels()).toEqual([]);
+  });
+
+  it("should not touch any session's child for the catalog", async () => {
+    const client = createElectronPiClient();
+    await client.getAvailableModels();
+    expect(h.requests).toHaveLength(0);
+    expect(h.sent).toHaveLength(0);
   });
 });
 
@@ -810,10 +926,10 @@ describe("createElectronPiClient() listThreads()", () => {
 });
 
 describe("createElectronPiClient() thread mutations", () => {
-  it("should send abort on cancelRun", async () => {
+  it("should send abort to the thread's own session on cancelRun", async () => {
     const client = createElectronPiClient();
     await client.cancelRun("/ws/s1.jsonl");
-    expect(h.sent).toContainEqual({ type: "abort" });
+    expect(h.sent).toEqual([{ sessionPath: "/ws/s1.jsonl", command: { type: "abort" } }]);
   });
 
   it("should return empty steering and follow-up queues from clearQueue", async () => {
@@ -821,17 +937,16 @@ describe("createElectronPiClient() thread mutations", () => {
     expect(await client.clearQueue("/ws/s1.jsonl")).toEqual({ steering: [], followUp: [] });
   });
 
-  it("should switch sessions then send set_thinking_level", async () => {
+  it("should send set_thinking_level to the thread's own session", async () => {
     const client = createElectronPiClient();
     await client.setThinkingLevel("/ws/t.jsonl", "high");
-    expect(h.requests).toContainEqual({ type: "switch_session", sessionPath: "/ws/t.jsonl" });
-    expect(h.sent).toContainEqual({ type: "set_thinking_level", level: "high" });
+    expect(h.sent).toEqual([{ sessionPath: "/ws/t.jsonl", command: { type: "set_thinking_level", level: "high" } }]);
   });
 
   it("should send set_session_name on renameThread", async () => {
     const client = createElectronPiClient();
     await client.renameThread("/ws/r.jsonl", "New name");
-    expect(h.sent).toContainEqual({ type: "set_session_name", name: "New name" });
+    expect(h.sent).toEqual([{ sessionPath: "/ws/r.jsonl", command: { type: "set_session_name", name: "New name" } }]);
   });
 
   it("should delete the session file on deleteThread", async () => {
@@ -848,21 +963,23 @@ describe("createElectronPiClient() thread mutations", () => {
 });
 
 describe("createElectronPiClient() respondToHostUiRequest()", () => {
-  it("should forward a confirmation response", async () => {
+  it("should forward a confirmation response to the thread's session", async () => {
     const client = createElectronPiClient();
     await client.respondToHostUiRequest("/ws/t.jsonl", { requestId: "r1", confirmed: true } as never);
-    expect(h.sent).toContainEqual({ type: "extension_ui_response", id: "r1", confirmed: true });
+    expect(h.sent).toEqual([
+      { sessionPath: "/ws/t.jsonl", command: { type: "extension_ui_response", id: "r1", confirmed: true } },
+    ]);
   });
 
   it("should forward a value response as a confirmed value", async () => {
     const client = createElectronPiClient();
     await client.respondToHostUiRequest("/ws/t.jsonl", { requestId: "r2", value: "hello" } as never);
-    expect(h.sent).toContainEqual({ type: "extension_ui_response", id: "r2", value: "hello", confirmed: true });
+    expect(sentCmds()).toContainEqual({ type: "extension_ui_response", id: "r2", value: "hello", confirmed: true });
   });
 
   it("should forward a decline when neither confirmed nor value is present", async () => {
     const client = createElectronPiClient();
     await client.respondToHostUiRequest("/ws/t.jsonl", { requestId: "r3" } as never);
-    expect(h.sent).toContainEqual({ type: "extension_ui_response", id: "r3", confirmed: false });
+    expect(sentCmds()).toContainEqual({ type: "extension_ui_response", id: "r3", confirmed: false });
   });
 });

--- a/packages/desktop/src/runtime/agentBridge.ts
+++ b/packages/desktop/src/runtime/agentBridge.ts
@@ -1,8 +1,10 @@
-// Singleton dispatcher over the pi sidecar's RPC stream (JSON lines over Tauri IPC).
+// Singleton dispatcher over the pi sidecars' RPC streams (JSON lines over
+// Electron IPC, one pi child per session — main spawns them on demand).
 //
-// - Owns the sidecar lifecycle (`agent_start`, once) and the ONE agent-event
-//   subscription for the app's lifetime.
-// - `request()` sends a command and resolves with its matching `response`.
+// - Owns the ONE agent-event subscription for the app's lifetime; every event
+//   arrives tagged with its originating `sessionPath`.
+// - `request()` sends a command to one session's child and resolves with its
+//   matching `response`.
 // - `addEventListener()` fans out the live event stream (everything except
 //   `response`) to subscribers — this is what the PiClient's `subscribe()` taps.
 // - Auto-confirms `extension_ui_request` so the agent can never hang on a
@@ -13,10 +15,10 @@
 //   surface these to the UI instead of confirming here.
 
 import { type AgentExit, agentApi } from "../rpc/api";
-import type { AgentEvent } from "../rpc/types";
+import type { SessionAgentEvent } from "../rpc/types";
 
-type EventListener = (e: AgentEvent) => void;
-type ErrorListener = (message: string) => void;
+type EventListener = (e: SessionAgentEvent) => void;
+type ErrorListener = (sessionPath: string, message: string) => void;
 
 /** How long an unanswered `request()` waits before rejecting. Guards against a
  *  sidecar that dies without emitting a terminate/error event, or a lost
@@ -31,106 +33,107 @@ function describeExit(info: AgentExit): string {
   return `The agent stopped${how}. Send a message to restart it.${tail}`;
 }
 
+interface PendingRequest {
+  /** Which child answers this request — a crash fails only its own session's. */
+  sessionPath: string;
+  commandName: string;
+  succeed: (data: unknown) => void;
+  fail: (error: Error) => void;
+}
+
 class AgentBridge {
-  private startPromise: Promise<void> | null = null;
-  private wired = false;
+  private wirePromise: Promise<void> | null = null;
   private readonly listeners = new Set<EventListener>();
   private readonly errorListeners = new Set<ErrorListener>();
-  // Reject callbacks for in-flight request() promises, so a sidecar crash can
-  // fail them instead of leaving their callers hanging forever.
-  private readonly pendingRequests = new Set<(error: Error) => void>();
-
-  /** Spawn the sidecar (idempotent). The process-lifetime subscriptions are
-   *  attached once via wire(); a crash clears `startPromise` so the next
-   *  send()/request() respawns the agent instead of leaving the session dead. */
-  ensureStarted(): Promise<void> {
-    if (!this.startPromise) {
-      this.startPromise = (async () => {
-        await this.wire();
-        await agentApi.start();
-      })();
-    }
-    return this.startPromise;
-  }
+  /** In-flight request() promises keyed by their correlation id. */
+  private readonly pending = new Map<string, PendingRequest>();
 
   /** Attach the event/terminate/error subscriptions exactly once — they listen
    *  on the IPC channel, not a specific child, so they survive respawns. */
-  private async wire(): Promise<void> {
-    if (this.wired) return;
-    this.wired = true;
-    await agentApi.onEvent((e) => this.handle(e));
-    await agentApi.onTerminated((info) => this.onStopped(describeExit(info)));
-    await agentApi.onError((m) => this.onStopped(m));
+  private wire(): Promise<void> {
+    if (!this.wirePromise) {
+      this.wirePromise = (async () => {
+        await agentApi.onEvent((e) => this.handle(e));
+        await agentApi.onTerminated((info) => this.onStopped(info.sessionPath, describeExit(info)));
+        await agentApi.onError((info) => this.onStopped(info.sessionPath, info.message));
+      })();
+    }
+    return this.wirePromise;
   }
 
-  /** Reset the start latch (so the next call respawns), reject any in-flight
-   *  requests, and notify subscribers. */
-  private onStopped(message: string): void {
-    this.startPromise = null;
+  /** Reject the crashed session's in-flight requests and notify subscribers.
+   *  Other sessions' children are untouched; the next send to this session
+   *  respawns its child. */
+  private onStopped(sessionPath: string, message: string): void {
     const error = new Error(message);
-    for (const reject of [...this.pendingRequests]) reject(error);
-    this.fail(message);
+    for (const p of [...this.pending.values()]) if (p.sessionPath === sessionPath) p.fail(error);
+    for (const fn of [...this.errorListeners]) fn(sessionPath, message);
   }
 
-  private handle(e: AgentEvent): void {
-    if (e.type === "extension_ui_request") {
-      // Confirm so the agent can never block on a host-UI call (see header note).
-      const response: Record<string, unknown> = { type: "extension_ui_response", id: e.id, confirmed: true };
-      if (e.method === "input") response.value = "";
-      agentApi.send(response).catch(() => undefined);
+  private handle(e: SessionAgentEvent): void {
+    if (e.type === "response") {
+      // Settled here, in the one wired listener, so an in-flight request adds
+      // no extra IPC listener (each would re-parse every session's stream).
+      const p = e.id ? this.pending.get(e.id) : undefined;
+      if (p) {
+        if (e.success) p.succeed(e.data);
+        else p.fail(new Error(e.error ?? `${p.commandName} failed`));
+      }
       return;
     }
-    // `response` events are consumed by request()'s own listener; everything
-    // else is live stream output for subscribers.
-    if (e.type === "response") return;
+    if (e.type === "extension_ui_request") {
+      // Confirm so the agent can never block on a host-UI call (see header
+      // note) — replying to the child the request came from.
+      const response: Record<string, unknown> = { type: "extension_ui_response", id: e.id, confirmed: true };
+      if (e.method === "input") response.value = "";
+      agentApi.send(e.sessionPath, response).catch(() => undefined);
+      return;
+    }
     for (const fn of [...this.listeners]) fn(e);
   }
 
-  private fail(message: string): void {
-    for (const fn of [...this.errorListeners]) fn(message);
-  }
-
-  /** Subscribe to the live event stream. Returns an unsubscribe function. */
+  /** Subscribe to the live event stream (all sessions — filter by
+   *  `e.sessionPath`). Returns an unsubscribe function. */
   addEventListener(fn: EventListener): () => void {
+    void this.wire();
     this.listeners.add(fn);
     return () => this.listeners.delete(fn);
   }
 
   /** Subscribe to sidecar process errors/termination. Returns an unsubscribe. */
   addErrorListener(fn: ErrorListener): () => void {
+    void this.wire();
     this.errorListeners.add(fn);
     return () => this.errorListeners.delete(fn);
   }
 
-  /** Send a raw RPC command (ensures the sidecar is up first). */
-  async send(command: object): Promise<void> {
-    await this.ensureStarted();
-    await agentApi.send(command);
+  /** Send a raw RPC command to one session's child (main spawns it on demand). */
+  async send(sessionPath: string, command: object): Promise<void> {
+    await this.wire();
+    await agentApi.send(sessionPath, command);
   }
 
-  /** Send a command and resolve with its `response` payload. Each request gets
-   *  a unique `id` that pi echoes back, so overlapping requests — even for the
-   *  same command — each receive their own response. Rejects if the sidecar
-   *  stops (via onStopped) or the request times out, so the caller never hangs;
-   *  the per-request event listener is always removed. */
-  async request<T>(command: object, commandName: string): Promise<T> {
-    await this.ensureStarted();
+  /** Send a command to one session's child and resolve with its `response`
+   *  payload. Each request gets a unique `id` that pi echoes back, so
+   *  overlapping requests — even for the same command, even across different
+   *  children — each receive their own response (matched in handle()).
+   *  Rejects if THAT session's child stops (via onStopped), the send fails,
+   *  or the request times out, so the caller never hangs. */
+  async request<T>(sessionPath: string, command: object, commandName: string): Promise<T> {
+    await this.wire();
     const requestId = crypto.randomUUID();
     return new Promise<T>((resolve, reject) => {
-      let unlisten: (() => void) | undefined;
       let settled = false;
-      let timer: ReturnType<typeof setTimeout>;
-
+      const timer = setTimeout(() => fail(new Error(`${commandName} timed out`)), REQUEST_TIMEOUT_MS);
       const cleanup = () => {
         clearTimeout(timer);
-        this.pendingRequests.delete(fail);
-        unlisten?.();
+        this.pending.delete(requestId);
       };
-      const succeed = (data: T) => {
+      const succeed = (data: unknown) => {
         if (settled) return;
         settled = true;
         cleanup();
-        resolve(data);
+        resolve(data as T);
       };
       const fail = (error: Error) => {
         if (settled) return;
@@ -139,24 +142,8 @@ class AgentBridge {
         reject(error);
       };
 
-      timer = setTimeout(() => fail(new Error(`${commandName} timed out`)), REQUEST_TIMEOUT_MS);
-      // Registered so onStopped() can reject this request on a sidecar crash.
-      this.pendingRequests.add(fail);
-
-      void agentApi
-        .onEvent((e) => {
-          if (e.type === "response" && e.id === requestId) {
-            if (e.success) succeed(e.data as T);
-            else fail(new Error(e.error ?? `${commandName} failed`));
-          }
-        })
-        .then((un) => {
-          unlisten = un;
-          // If we already settled (timeout/crash) before the listener resolved,
-          // drop it immediately; otherwise it's live and we can send.
-          if (settled) un();
-          else void agentApi.send({ ...command, id: requestId });
-        });
+      this.pending.set(requestId, { sessionPath, commandName, succeed, fail });
+      agentApi.send(sessionPath, { ...command, id: requestId }).catch(fail);
     });
   }
 }

--- a/packages/desktop/src/runtime/electronPiClient.ts
+++ b/packages/desktop/src/runtime/electronPiClient.ts
@@ -5,11 +5,12 @@
 // This is the transport the package leaves open (HTTP/SSE is just one
 // implementation); we mirror `client/httpClient.ts` against the sidecar.
 //
-// pi is single-active-session; the runtime is multi-thread. We bridge that by
-// treating `threadId` = pi session-file path and issuing `switch_session` before
-// any operation targeting a non-active thread (the user views one thread at a
-// time). Every emitted event is stamped with a monotonic per-thread `seq` and a
-// derived `turnIndex`, exactly as the node ThreadSupervisor does.
+// pi is single-active-session PER PROCESS; the runtime is multi-thread. We
+// bridge that with one pi child per session (main spawns them on demand):
+// `threadId` = pi session-file path = the routing key on every command and
+// event, so a run keeps going — and keeps streaming — while the user views
+// other threads. Every emitted event is stamped with a monotonic per-thread
+// `seq` and a derived `turnIndex`, exactly as the node ThreadSupervisor does.
 
 import type {
   PiClient,
@@ -37,7 +38,7 @@ import { extractAttachmentRefs } from "../lib/attachmentMarker";
 import { parseModelId } from "../lib/enabledModels";
 import { mentionsToPlainText } from "../lib/mentions";
 import { collapseSkillText, hoistSkillDirective } from "../lib/skillBlock";
-import { agentApi, sessionsApi, settingsApi, skillsApi } from "../rpc/api";
+import { agentApi, authApi, sessionsApi, settingsApi, skillsApi } from "../rpc/api";
 import type { AgentEvent, ModelInfo, SessionSummary } from "../rpc/types";
 import { agentBridge } from "./agentBridge";
 import { newChatModel } from "./newChatModel";
@@ -55,8 +56,6 @@ type PiState = {
 
 const baseName = (p: string): string => p.split(/[\\/]/).pop() ?? p;
 
-let pendingCounter = 0;
-
 const deriveReadiness = (model: ModelInfo | undefined): PiRuntimeReadiness =>
   model
     ? { state: "ready", selection: { provider: model.provider, modelId: model.id }, source: "session" }
@@ -70,21 +69,18 @@ const toModelInfo = (m: ModelInfo): PiModelInfo => ({
 });
 
 export function createElectronPiClient(): PiClient {
-  /** The session pi currently has loaded (its single active session). */
-  let activeThreadId: string | undefined;
-  /** The active session's model as `provider/modelId` — an analytics prop only.
+  /** Each thread's model as `provider/modelId` — an analytics prop only.
    *  Kept from get_state snapshots and setModel; never sent back to pi. */
-  let currentModelId: string | undefined;
-  /** Serializes switch_session so events route to the intended thread. */
-  let switchChain: Promise<void> = Promise.resolve();
+  const modelByThread = new Map<string, string>();
   const seqs = new Map<string, number>();
   const turns = new Map<string, number>();
   // Threads with a run in flight. Tracked here because a NEW thread's first
   // message is sent via createThread (not the controller), so without this the
   // runtime's load() snapshot would report idle and never connect() to the
   // stream — leaving the just-sent message and its reply invisible until a
-  // manual refetch. Set on send, cleared on agent_end (runs are on the active
-  // session). A persistent listener keeps it accurate even between subscriptions.
+  // manual refetch. Set on send, cleared on agent_end, keyed by the session
+  // each event is tagged with — so background runs stay accurately "running".
+  // A persistent listener keeps it accurate even between subscriptions.
   const running = new Set<string>();
   // skill_used analytics: resolve a skill to native-or-custom without leaking
   // custom identities. The lookup refreshes on the same signal as the composer
@@ -122,32 +118,19 @@ export function createElectronPiClient(): PiClient {
       if (segments.at(-1) === "SKILL.md") trackSkillByName(segments.at(-2) ?? "", "auto");
     }
     if (e.type === "agent_end") trackAgentMessageSent();
-    if (!activeThreadId) return;
-    if (e.type === "agent_start") running.add(activeThreadId);
-    else if (e.type === "agent_end") running.delete(activeThreadId);
+    if (e.type === "agent_start") running.add(e.sessionPath);
+    else if (e.type === "agent_end") running.delete(e.sessionPath);
   });
-  // If the agent crashes, a respawn starts with no active session. Forget the
-  // active thread + in-flight runs so the next ensureActive() re-issues
-  // switch_session against the fresh process instead of assuming it's loaded.
-  agentBridge.addErrorListener(() => {
-    activeThreadId = undefined;
-    running.clear();
+  // A crashed child takes its in-flight run with it; other sessions' runs are
+  // separate processes and keep going untouched.
+  agentBridge.addErrorListener((sessionPath) => {
+    running.delete(sessionPath);
   });
 
   const nextSeq = (threadId: string): number => {
     const n = (seqs.get(threadId) ?? 0) + 1;
     seqs.set(threadId, n);
     return n;
-  };
-
-  const ensureActive = (threadId: string): Promise<void> => {
-    if (threadId === activeThreadId || threadId.startsWith("pending-")) return Promise.resolve();
-    switchChain = switchChain.then(async () => {
-      if (threadId === activeThreadId) return;
-      await agentBridge.request({ type: "switch_session", sessionPath: threadId }, "switch_session");
-      activeThreadId = threadId;
-    });
-    return switchChain;
   };
 
   /** Collapse pi's expanded skill block in a transcript USER message back to
@@ -172,7 +155,7 @@ export function createElectronPiClient(): PiClient {
   };
 
   const buildSnapshot = (threadId: string, state: PiState, messages: unknown): PiThreadSnapshot => {
-    if (state.model) currentModelId = `${state.model.provider}/${state.model.id}`;
+    if (state.model) modelByThread.set(threadId, `${state.model.provider}/${state.model.id}`);
     const list = Array.isArray(messages) ? messages.map(collapseUserMessage) : [];
     return {
       metadata: {
@@ -253,49 +236,49 @@ export function createElectronPiClient(): PiClient {
     },
 
     async createThread(input) {
-      await agentBridge.request({ type: "new_session" }, "new_session");
+      // Mint the session path up front (the first command spawns its child,
+      // which starts a fresh session AT that path — see electron/main/agent.ts),
+      // fetching the default-model setting concurrently: two independent IPC
+      // round-trips on the user-visible new-chat path.
+      const [id, settings] = await Promise.all([agentApi.createSession(), settingsApi.get().catch(() => undefined)]);
       trackChatCreated();
       // Pick the model for the fresh session: the model the user chose in the
       // composer for this new chat, else the configured default. Sent before
       // get_state so the snapshot reflects it (stdin commands run in order).
       try {
-        const chosen = newChatModel.get() ?? parseModelId((await settingsApi.get()).defaultModel ?? "");
+        const chosen = newChatModel.get() ?? parseModelId(settings?.defaultModel ?? "");
         if (chosen) {
-          await agentBridge.send({ type: "set_model", provider: chosen.provider, modelId: chosen.modelId });
+          await agentBridge.send(id, { type: "set_model", provider: chosen.provider, modelId: chosen.modelId });
         }
       } catch {
-        // No model configured / settings unreadable: keep pi's own default.
+        // No model configured: keep pi's own default.
       } finally {
         // Reset so the next new chat starts from the default again.
         newChatModel.set(undefined);
       }
-      const state = await agentBridge.request<PiState>({ type: "get_state" }, "get_state");
-      const id = state.sessionFile ?? state.sessionId ?? `pending-${(pendingCounter += 1)}`;
-      activeThreadId = id;
+      const state = await agentBridge.request<PiState>(id, { type: "get_state" }, "get_state");
       turns.delete(id);
       // Record the new chat's model before the initial message is tracked —
       // buildSnapshot below runs too late, and would leave user_message_sent
-      // stamped with the PREVIOUS session's model.
-      if (state.model) currentModelId = `${state.model.provider}/${state.model.id}`;
+      // stamped with no model.
+      if (state.model) modelByThread.set(id, `${state.model.provider}/${state.model.id}`);
       if (input?.initialMessage) await client.sendMessage(id, input.initialMessage);
       return buildSnapshot(id, state, []);
     },
 
     async getThread(threadId) {
-      await ensureActive(threadId);
       const [msgs, state] = await Promise.all([
-        agentBridge.request<{ messages: unknown }>({ type: "get_messages" }, "get_messages"),
-        agentBridge.request<PiState>({ type: "get_state" }, "get_state"),
+        agentBridge.request<{ messages: unknown }>(threadId, { type: "get_messages" }, "get_messages"),
+        agentBridge.request<PiState>(threadId, { type: "get_state" }, "get_state"),
       ]);
       return buildSnapshot(threadId, state, msgs.messages);
     },
 
     async sendMessage(threadId, input: PiSendMessageInput) {
-      await ensureActive(threadId);
       // `input.attachments` carries images only; documents (PDF, CSV, …) travel
       // as marker lines inside `content` — count both as attachments.
       const hasAttachment = Boolean(input.attachments?.length) || extractAttachmentRefs(input.content).refs.length > 0;
-      trackUserMessageSent(hasAttachment, currentModelId);
+      trackUserMessageSent(hasAttachment, modelByThread.get(threadId));
       trackUserFirstMessageSent();
       // A picked skill rides in the composer as a `:skill[name]` chip; pi
       // expects a leading `/skill:name` token instead — rewrite on the way out.
@@ -303,7 +286,7 @@ export function createElectronPiClient(): PiClient {
       const skillToken = /^\/skill:(\S+)/.exec(message)?.[1];
       if (skillToken) trackSkillByName(skillToken, "manual");
       running.add(threadId); // optimistic — flips status to running before agent_start arrives
-      await agentBridge.send({
+      await agentBridge.send(threadId, {
         type: "prompt",
         message,
         ...(input.attachments?.length ? { images: input.attachments } : {}),
@@ -311,8 +294,8 @@ export function createElectronPiClient(): PiClient {
       });
     },
 
-    async cancelRun() {
-      await agentBridge.send({ type: "abort" });
+    async cancelRun(threadId) {
+      await agentBridge.send(threadId, { type: "abort" });
     },
 
     async clearQueue() {
@@ -321,27 +304,24 @@ export function createElectronPiClient(): PiClient {
     },
 
     async getAvailableModels() {
-      const data = await agentBridge.request<{ models?: ModelInfo[] }>(
-        { type: "get_available_models" },
-        "get_available_models",
-      );
+      // Session-independent: read the catalog straight from main's in-process
+      // ModelRegistry (re-reads auth.json/models.json per call) instead of
+      // asking some child — no child needs to exist for the picker to work.
+      const data = await authApi.models();
       return (data.models ?? []).map(toModelInfo);
     },
 
     async setModel(threadId, input) {
-      await ensureActive(threadId);
-      currentModelId = `${input.provider}/${input.modelId}`;
-      await agentBridge.send({ type: "set_model", provider: input.provider, modelId: input.modelId });
+      modelByThread.set(threadId, `${input.provider}/${input.modelId}`);
+      await agentBridge.send(threadId, { type: "set_model", provider: input.provider, modelId: input.modelId });
     },
 
     async setThinkingLevel(threadId, level: PiThinkingLevel) {
-      await ensureActive(threadId);
-      await agentBridge.send({ type: "set_thinking_level", level });
+      await agentBridge.send(threadId, { type: "set_thinking_level", level });
     },
 
     async renameThread(threadId, title) {
-      await ensureActive(threadId);
-      await agentBridge.send({ type: "set_session_name", name: title });
+      await agentBridge.send(threadId, { type: "set_session_name", name: title });
     },
 
     async archiveThread() {
@@ -355,24 +335,24 @@ export function createElectronPiClient(): PiClient {
       await sessionsApi.delete(threadId);
     },
 
-    async respondToHostUiRequest(_threadId, response: PiHostUiResponse) {
+    async respondToHostUiRequest(threadId, response: PiHostUiResponse) {
       // Auto-approval in agentBridge means the runtime normally never calls this;
       // honor it anyway for completeness.
       if ("confirmed" in response) {
-        await agentBridge.send({
+        await agentBridge.send(threadId, {
           type: "extension_ui_response",
           id: response.requestId,
           confirmed: response.confirmed,
         });
       } else if ("value" in response) {
-        await agentBridge.send({
+        await agentBridge.send(threadId, {
           type: "extension_ui_response",
           id: response.requestId,
           value: response.value,
           confirmed: true,
         });
       } else {
-        await agentBridge.send({ type: "extension_ui_response", id: response.requestId, confirmed: false });
+        await agentBridge.send(threadId, { type: "extension_ui_response", id: response.requestId, confirmed: false });
       }
     },
 
@@ -388,11 +368,18 @@ export function createElectronPiClient(): PiClient {
         if (!active) return;
         offs.push(
           agentBridge.addEventListener((e) => {
+            // The bridge broadcasts every session's stream; only this thread's
+            // child's events belong here (concurrent runs stream in parallel).
+            if (e.sessionPath !== threadId) return;
             const body = mapEvent(threadId, e);
             if (body) emit(body);
           }),
         );
-        offs.push(agentBridge.addErrorListener((msg) => emit({ type: "error", error: msg })));
+        offs.push(
+          agentBridge.addErrorListener((sessionPath, msg) => {
+            if (sessionPath === threadId) emit({ type: "error", error: msg });
+          }),
+        );
       };
 
       if (includeSnapshot) {


### PR DESCRIPTION
Sending a message in chat A and switching to chat B aborted A's run — switching issued `switch_session` to the single pi process, which disposes the active session and aborts the in-flight agent. Events also carried no session id, so background progress could not be routed to its chat.

## What changed

**One pi child process per session, spawned lazily; the `switch_session` bridge is gone.**

- **Main process** (`electron/main/agent.ts`): a `Map<sessionPath, child>` replaces the single child. Each child spawns on first send with `--session <path>` (opens an existing session file or starts a fresh one at that path, so the same code serves new chats, reopened chats, and respawns). New `agent_create_session` IPC mints paths up front. Idle children are reaped after 15 min (never mid-run), capped at 8 with LRU eviction; delete kills the session's child, quit/restart kills all.
- **IPC**: every `agent_send` and every `agent-event`/`agent-terminated`/`agent-error` payload is tagged with its `sessionPath`.
- **Renderer** (`electronPiClient`, `agentBridge`): `activeThreadId`/`ensureActive`/`switchChain` and the `pending-` id machinery are deleted; commands route by threadId (= session path) and events route by their tag, so run state stays correct per chat. Request/response correlation moved into the bridge's single stream listener. Also fixes a latent bug where cancel hit whichever chat was being viewed. `getAvailableModels` now reads main's in-process model registry instead of asking a child.
- **Auto-titling** (`chat-layout`): keyed by the event's session and titled from the chat's own transcript, so a background run titles its own chat, not the viewed one.
- Full-restart restore works by construction: any spawn replays the session file (history, model, thinking level).

## Testing

- Unit/component/integration tests updated and extended across all touched layers, including a regression test that fails on the old code (background session keeps streaming while another is viewed) and cold-start restore coverage. Coverage gate, typecheck, and lint pass.
- Verified live in the dev app: a 35s agent run in chat A survived switching to chat B (both children running concurrently), kept streaming, and finished correctly; after a full quit + relaunch, the chat restored its history and continued appending to the same session file.

## Notes

- Each pi child is a Node process (~100 MB RSS); the reap TTL (15 min) and child cap (8) in `electron/main/agent.ts` are the tuning knobs.
- Relies on `pi --session <not-yet-existing path>` semantics of the vendored 0.79.x (commented in code with pointers to pi internals).
