### PR TITLE
feat: vendor a minimal python interpreter for skills

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Untap untrusted Homebrew taps from the runner image
         run: brew untap aws/tap || true
 
-      - name: Vendor CLI tools (hledger, pdftotext, tesseract)
+      - name: Vendor CLI tools (hledger, pdftotext, tesseract, python3)
         run: npx tsx scripts/vendor-bin.ts
 
       - name: Build renderer + main + extension bundle

--- a/packages/desktop/resources/bin/README.md
+++ b/packages/desktop/resources/bin/README.md
@@ -1,3 +1,4 @@
 # Vendored native tools (bundled into the .app at build time).
-# Place macOS builds of: hledger, pdftotext (poppler), tesseract here.
-# They are resolved by absolute path via injected PATH (see src/env.rs).
+# hledger, pdftotext (poppler), tesseract, and python/ (a python-build-standalone
+# interpreter) are written here by scripts/vendor-bin.ts. They are resolved by
+# absolute path via injected PATH (see electron/main/env.ts).

--- a/packages/desktop/src/main/__tests__/env.test.ts
+++ b/packages/desktop/src/main/__tests__/env.test.ts
@@ -128,6 +128,20 @@ describe("binDir()", () => {
   });
 });
 
+describe("pythonBinDir()", () => {
+  it("should resolve <resourcesPath>/bin/python/bin when the app is packaged", async () => {
+    h.app.isPackaged = true;
+    const orig = process.resourcesPath;
+    Object.defineProperty(process, "resourcesPath", { value: "/pkg-res", configurable: true });
+    try {
+      const mod = await import("../env");
+      expect(mod.pythonBinDir()).toBe("/pkg-res/bin/python/bin");
+    } finally {
+      Object.defineProperty(process, "resourcesPath", { value: orig, configurable: true });
+    }
+  });
+});
+
 describe("agentEnv()", () => {
   it("should point ACCOUNTANT24_WORKSPACE and PI_CODING_AGENT_DIR at the workspace", async () => {
     const prev = process.env.ACCOUNTANT24_WORKSPACE;
@@ -177,6 +191,26 @@ describe("agentEnv()", () => {
       const mod = await import("../env");
       const env = mod.agentEnv();
       expect(env.PATH).toBe("/usr/bin");
+    } finally {
+      Object.defineProperty(process, "resourcesPath", { value: origRes, configurable: true });
+      process.env.PATH = prevPath;
+    }
+  });
+
+  it("should prepend python/bin ahead of binDir on PATH when both exist", async () => {
+    h.app.isPackaged = true;
+    const origRes = process.resourcesPath;
+    const prevPath = process.env.PATH;
+    Object.defineProperty(process, "resourcesPath", { value: "/pkg-res", configurable: true });
+    process.env.PATH = "/usr/bin";
+    // Both bin and bin/python/bin exist; tessdata does not.
+    h.existsSync.mockImplementation(
+      (p: string) => p === `/pkg-res${path.sep}bin` || p === `/pkg-res${path.sep}bin${path.sep}python${path.sep}bin`,
+    );
+    try {
+      const mod = await import("../env");
+      const env = mod.agentEnv();
+      expect(env.PATH).toBe(`/pkg-res/bin/python/bin${path.delimiter}/pkg-res/bin${path.delimiter}/usr/bin`);
     } finally {
       Object.defineProperty(process, "resourcesPath", { value: origRes, configurable: true });
       process.env.PATH = prevPath;

--- a/packages/desktop/src/main/env.ts
+++ b/packages/desktop/src/main/env.ts
@@ -2,8 +2,8 @@
 //
 // The workspace (~/.accountant24 by default) holds the ledger + auth.json +
 // models.json; PATH exposes the vendored native tools (hledger/pdftotext/
-// tesseract) to the agent's bash/tool subprocesses; TESSDATA_PREFIX points at
-// the OCR data.
+// tesseract/python3) to the agent's bash/tool subprocesses; TESSDATA_PREFIX
+// points at the OCR data.
 //
 // ACCOUNTANT24_WORKSPACE is the single channel that names the workspace: set
 // by the `--workspace` launch flag (cli.ts) or by the caller's environment, read
@@ -69,6 +69,13 @@ export function binDir(): string {
   return path.join(resourceDir(), "bin");
 }
 
+/** bin/python/bin under binDir() - the vendored python-build-standalone
+ *  interpreter (see scripts/vendor-bin.ts), so skills invoking `python3` don't
+ *  depend on whatever (if anything) is on the user's own PATH. */
+export function pythonBinDir(): string {
+  return path.join(binDir(), "python", "bin");
+}
+
 /** The bundled extension passed to `pi -e`. Loaded as JS in both dev and
  *  packaged (Electron-as-Node can't parse the TS source); produced by
  *  scripts/bundle-extension.ts. */
@@ -125,6 +132,8 @@ export function agentEnv(): NodeJS.ProcessEnv {
   const res = resourceDir();
   const bin = binDir();
   if (existsSync(bin)) env.PATH = `${bin}${path.delimiter}${env.PATH ?? ""}`;
+  const pyBin = pythonBinDir();
+  if (existsSync(pyBin)) env.PATH = `${pyBin}${path.delimiter}${env.PATH ?? ""}`;
   const tessdata = path.join(res, "tessdata");
   if (existsSync(tessdata)) env.TESSDATA_PREFIX = tessdata;
   return env;

--- a/scripts/vendor-bin.ts
+++ b/scripts/vendor-bin.ts
@@ -1,16 +1,19 @@
 // Vendors the external CLI tools the app shells out to (hledger, pdftotext,
-// tesseract) into packages/desktop/resources so electron-builder bundles them
-// into Contents/Resources. Run on the matching-arch macOS runner BEFORE the
-// build — it installs the tools via Homebrew, relocates their non-system dylibs
-// next to the binaries (so they run on a user Mac without Homebrew), copies the
-// English OCR data, ad-hoc signs everything (required for arm64 to launch while
-// the app is unsigned), and writes THIRD-PARTY-LICENSES.txt so the bundled GPL
-// tools (hledger, poppler) ship with their license + corresponding-source offer.
-// Developer-ID re-signing happens later in the electron-builder signing pass.
+// tesseract, python3) into packages/desktop/resources so electron-builder
+// bundles them into Contents/Resources. Run on the matching-arch macOS runner
+// BEFORE the build - it installs the brew tools, relocates their non-system
+// dylibs next to the binaries (so they run on a user Mac without Homebrew),
+// downloads a pinned python-build-standalone interpreter (self-contained,
+// no relocation needed - see vendorPython() below), copies the English OCR
+// data, ad-hoc signs everything (required for arm64 to launch while the app
+// is unsigned), and writes THIRD-PARTY-LICENSES.txt so the bundled GPL/PSF
+// tools ship with their license + corresponding-source offer. Developer-ID
+// re-signing happens later in the electron-builder signing pass.
 //
 // Usage: tsx scripts/vendor-bin.ts
 
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,6 +24,21 @@ const BIN = join(RES, "bin");
 const LIB = join(BIN, "lib");
 const TESSDATA = join(RES, "tessdata");
 const LICENSES = join(RES, "THIRD-PARTY-LICENSES.txt");
+
+// python-build-standalone (the same relocatable-CPython project uv/rye embed)
+// pinned by exact release tag + version + checksum, since - unlike the brew
+// formulae above - nothing here resolves "latest" for us; bumping the
+// interpreter is a deliberate edit to these constants, not an automatic pickup.
+// "install_only_stripped" build: debug symbols stripped, and per `otool -L`
+// only links system frameworks/libs (no Homebrew Cellar deps), so it needs no
+// dylibbundler relocation - unlike the brew tools below.
+const PYTHON_RELEASE_TAG = "20260718";
+const PYTHON_VERSION = "3.12.13";
+const PYTHON_MINOR = "3.12";
+const PYTHON_ASSET = `cpython-${PYTHON_VERSION}+${PYTHON_RELEASE_TAG}-aarch64-apple-darwin-install_only_stripped.tar.gz`;
+const PYTHON_URL = `https://github.com/astral-sh/python-build-standalone/releases/download/${PYTHON_RELEASE_TAG}/${PYTHON_ASSET}`;
+const PYTHON_SHA256 = "9a1e9e06175c10efd8378b904b07fa21bd791ab3345d7cdffeb4a76c9ff55903";
+const PYTHON_DIR = join(BIN, "python");
 
 /** Run a command, inheriting stdio; throw on non-zero. */
 function run(cmd: string, args: string[], opts: { input?: string } = {}): void {
@@ -44,6 +62,70 @@ const TOOLS = [
   { formula: "poppler", exe: "pdftotext" },
   { formula: "tesseract", exe: "tesseract" },
 ];
+
+/** Download the pinned python-build-standalone tarball, verify its checksum,
+ *  extract it to BIN/python (bin/lib/include/share, stdlib-relative-path
+ *  relocatable by design), prune what a stdlib-only script never needs, and
+ *  ad-hoc sign the interpreter + its one dylib. */
+async function vendorPython(): Promise<void> {
+  // PYTHON_ASSET is pinned to an aarch64-apple-darwin build, matching this
+  // repo's arm64-only mac target (see electron-builder.yml). Re-pin (or
+  // vendor per-arch) before re-adding an x64 build - an x64 app would
+  // otherwise silently ship an arm64 interpreter that can't execute.
+  if (process.arch !== "arm64") throw new Error(`vendorPython() only supports arm64, got process.arch=${process.arch}`);
+
+  console.log(`[vendor-bin] python ${PYTHON_VERSION} (${PYTHON_RELEASE_TAG})`);
+  if (existsSync(PYTHON_DIR)) rmSync(PYTHON_DIR, { recursive: true, force: true });
+
+  const res = await fetch(PYTHON_URL);
+  if (!res.ok) throw new Error(`Failed to download ${PYTHON_URL}: ${res.status} ${res.statusText}`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  const actual = createHash("sha256").update(buf).digest("hex");
+  if (actual !== PYTHON_SHA256) {
+    throw new Error(`SHA256 mismatch for ${PYTHON_ASSET}: expected ${PYTHON_SHA256}, got ${actual}`);
+  }
+
+  // The tarball's top-level entry is "python/" - extracting into BIN lands it
+  // directly at PYTHON_DIR.
+  const tmpTar = join(BIN, "_python.tar.gz");
+  writeFileSync(tmpTar, buf);
+  run("tar", ["xzf", tmpTar, "-C", BIN]);
+  rmSync(tmpTar);
+
+  // Trim what a stdlib-only script (no pip install, no GUI, no C-extension
+  // builds) never needs: pip/ensurepip, idle/tkinter (+ the Tcl/Tk dylibs
+  // those pull in) and lib2to3 (GUI/legacy), and headers/docs.
+  const prune = [
+    `lib/python${PYTHON_MINOR}/site-packages`,
+    `lib/python${PYTHON_MINOR}/ensurepip`,
+    `lib/python${PYTHON_MINOR}/idlelib`,
+    `lib/python${PYTHON_MINOR}/tkinter`,
+    `lib/python${PYTHON_MINOR}/turtledemo`,
+    `lib/python${PYTHON_MINOR}/lib2to3`,
+    "lib/tcl9.0",
+    "lib/tk9.0",
+    "lib/itcl4.3.5",
+    "lib/thread3.0.4",
+    "lib/libtcl9.0.dylib",
+    "lib/libtcl9tk9.0.dylib",
+    "include",
+    "share",
+    "bin/idle3",
+    `bin/idle3.${PYTHON_MINOR.split(".")[1]}`,
+    "bin/2to3",
+    `bin/2to3-${PYTHON_MINOR}`,
+    "bin/pip",
+    "bin/pip3",
+    `bin/pip3.${PYTHON_MINOR.split(".")[1]}`,
+    "bin/python3-config",
+    `bin/python${PYTHON_MINOR}-config`,
+  ];
+  for (const rel of prune) rmSync(join(PYTHON_DIR, rel), { recursive: true, force: true });
+
+  const pyBin = join(PYTHON_DIR, "bin", `python${PYTHON_MINOR}`);
+  const pyDylib = join(PYTHON_DIR, "lib", `libpython${PYTHON_MINOR}.dylib`);
+  for (const f of [pyDylib, pyBin]) run("codesign", ["--force", "--sign", "-", f]);
+}
 
 type BrewMeta = { version: string; license: string; source: string; homepage: string };
 
@@ -82,7 +164,8 @@ function writeLicenses(): void {
     "",
     "This application bundles the command-line tools below. Their full license text",
     "follows each entry, and the corresponding source for the exact bundled version",
-    "is available at the listed URL (this is the GPL written offer of source).",
+    "is available at the listed URL (for the GPL-licensed tools, this is the written",
+    "offer of source).",
     "",
   ];
   for (const { formula, exe } of TOOLS) {
@@ -98,6 +181,18 @@ function writeLicenses(): void {
       "",
     );
   }
+  // Not a brew formula, so it gets its own hardcoded metadata block rather
+  // than coming from brewInfo().
+  lines.push(
+    "================================================================",
+    `python (python3) ${PYTHON_VERSION} - PSF-2.0`,
+    "Project: https://www.python.org/",
+    `Corresponding source: https://github.com/astral-sh/python-build-standalone/releases/tag/${PYTHON_RELEASE_TAG}`,
+    "----------------------------------------------------------------",
+    "(Full license text: see the source above; SPDX: PSF-2.0. Vendored as a",
+    "python-build-standalone build, a redistributable CPython + stdlib.)",
+    "",
+  );
   const libs = existsSync(LIB) ? readdirSync(LIB).filter((f) => f.endsWith(".dylib")) : [];
   lines.push(
     "================================================================",
@@ -114,7 +209,7 @@ function writeLicenses(): void {
   console.log(`[vendor-bin] wrote ${LICENSES} (${libs.length} bundled libs listed)`);
 }
 
-function main() {
+async function main() {
   console.log(`[vendor-bin] arch=${process.arch}`);
 
   // Start from a clean bin/ (keep the tracked README.md) and lib/.
@@ -160,10 +255,17 @@ function main() {
   const dylibs = readdirSync(LIB).filter((f) => f.endsWith(".dylib")).map((f) => join(LIB, f));
   for (const f of [...dylibs, ...bins]) run("codesign", ["--force", "--sign", "-", f]);
 
-  // 5. Emit the third-party license notice for the bundled GPL/permissive tools.
+  // 5. Python: downloaded + verified + pruned + signed separately (no brew
+  //    formula, no dylib relocation needed - see vendorPython()).
+  await vendorPython();
+
+  // 6. Emit the third-party license notice for the bundled GPL/PSF tools.
   writeLicenses();
 
-  console.log(`[vendor-bin] ✓ vendored ${TOOLS.map((t) => t.exe).join(", ")} + eng.traineddata + licenses`);
+  console.log(`[vendor-bin] vendored ${TOOLS.map((t) => t.exe).join(", ")}, python, eng.traineddata + licenses`);
 }
 
-main();
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Skills that shell out to python3 depend on whatever the user happens to have on PATH -- macOS hasn't shipped python3 by default since Monterey. Vendor a pinned, checksum-verified python-build-standalone build (stdlib-only, pip/idle/tkinter pruned) the same way the other CLI tools are vendored, and expose it on the agent child's PATH.

To test locally:
1. npx tsx scripts/vendor-bin.ts (needs brew + network; also (re)vendors hledger/pdftotext/tesseract)
2. packages/desktop/resources/bin/python/bin/python3 -c \ "import csv, sys; print(sys.executable, sys.version)" should print a path under resources/bin/python/bin, not a system python.
3. npm start, then in the chat ask the agent to run python3 -c "import sys; print(sys.executable)" via its bash tool -- same check, but through the running app's PATH-injected child process.

Note: step 1 rewrites packages/desktop/resources/THIRD-PARTY-LICENSES.txt with locally-resolved tool versions; discard that diff before committing unless you mean to update the checked-in file.