### PR TITLE
feat: Net Worth page, add_balance_assertions and add_prices agent tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7879,6 +7879,39 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -18640,6 +18673,7 @@
         "@earendil-works/pi-ai": "0.79.8",
         "@earendil-works/pi-coding-agent": "0.79.8",
         "@fontsource-variable/inter": "^5.2.8",
+        "@tanstack/react-table": "^8.21.3",
         "assistant-stream": "^0.3.24",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/packages/desktop/e2e/balance-sheet.e2e.ts
+++ b/packages/desktop/e2e/balance-sheet.e2e.ts
@@ -1,0 +1,42 @@
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { type LaunchedApp, launchApp } from "./helpers";
+
+// E2 — the Balance Sheet view over the real wiring: the preload allowlist,
+// the ledger_balance_sheet IPC round trip, and the sidebar view switch. A
+// stored API key makes the app boot into the chat layout (the pi agent only
+// spawns on the first send, which never happens here). The temp home has no
+// journal, so the view deterministically shows the empty state whether or
+// not an hledger binary is around.
+
+let launched: LaunchedApp;
+
+test.beforeEach(async () => {
+  launched = await launchApp({
+    seed: (home) => {
+      writeFileSync(path.join(home, "auth.json"), JSON.stringify({ anthropic: { type: "api_key", key: "sk-test" } }));
+    },
+  });
+});
+
+test.afterEach(async () => {
+  await launched?.close();
+});
+
+test("opens the Balance Sheet view from the sidebar and returns to the chat", async () => {
+  const window = await launched.app.firstWindow();
+  await window.waitForLoadState("domcontentloaded");
+
+  // Booted past onboarding into the chat layout (composer present).
+  await expect(window.getByLabel("Message input")).toBeVisible();
+
+  await window.getByRole("button", { name: "Balance Sheet" }).click();
+  await expect(window.getByRole("heading", { name: "Balance Sheet" })).toBeVisible();
+  await expect(window.getByText("No accounts yet")).toBeVisible();
+
+  // Toggling the entry brings the chat back.
+  await window.getByRole("button", { name: "Balance Sheet" }).click();
+  await expect(window.getByRole("heading", { name: "Balance Sheet" })).not.toBeVisible();
+  await expect(window.getByLabel("Message input")).toBeVisible();
+});

--- a/packages/desktop/e2e/helpers.ts
+++ b/packages/desktop/e2e/helpers.ts
@@ -1,8 +1,10 @@
 // Shared helpers for the Electron E2E smoke tests.
 //
-// Each test launches the built app pointed at a fresh, empty temp
-// ACCOUNTANT24_HOME so it boots deterministically to the onboarding screen (no
-// providers => no models => onboarding, and the pi agent child is never spawned).
+// Each test launches the built app pointed at a fresh temp ACCOUNTANT24_HOME.
+// Empty, it boots deterministically to the onboarding screen (no providers =>
+// no models => onboarding, and the pi agent child is never spawned); a `seed`
+// callback can pre-populate the home (e.g. auth.json) to boot into the chat
+// layout instead — the agent still only spawns on the first send.
 
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -22,8 +24,11 @@ export interface LaunchedApp {
 }
 
 /** Launch the built app with an isolated temp workspace. */
-export async function launchApp(env: Record<string, string> = {}): Promise<LaunchedApp> {
+export async function launchApp(
+  opts: { env?: Record<string, string>; seed?: (home: string) => void } = {},
+): Promise<LaunchedApp> {
   const home = mkdtempSync(path.join(tmpdir(), "a24-e2e-"));
+  opts.seed?.(home);
   const app = await electron.launch({
     args: [MAIN_ENTRY],
     cwd: DESKTOP_DIR,
@@ -34,7 +39,7 @@ export async function launchApp(env: Record<string, string> = {}): Promise<Launc
       A24_FAKE_UPDATE: "",
       CI: "1",
       // Per-test overrides (e.g. an agent-stub flag) win.
-      ...env,
+      ...opts.env,
     } as Record<string, string>,
   });
   return {

--- a/packages/desktop/e2e/net-worth.e2e.ts
+++ b/packages/desktop/e2e/net-worth.e2e.ts
@@ -3,8 +3,8 @@ import path from "node:path";
 import { expect, test } from "@playwright/test";
 import { type LaunchedApp, launchApp } from "./helpers";
 
-// E2 — the Balance Sheet view over the real wiring: the preload allowlist,
-// the ledger_balance_sheet IPC round trip, and the sidebar view switch. A
+// E2 — the Net Worth view over the real wiring: the preload allowlist,
+// the ledger_net_worth IPC round trip, and the sidebar view switch. A
 // stored API key makes the app boot into the chat layout (the pi agent only
 // spawns on the first send, which never happens here). The temp home has no
 // journal, so the view deterministically shows the empty state whether or
@@ -24,19 +24,19 @@ test.afterEach(async () => {
   await launched?.close();
 });
 
-test("opens the Balance Sheet view from the sidebar and returns to the chat", async () => {
+test("opens the Net Worth view from the sidebar and returns to the chat", async () => {
   const window = await launched.app.firstWindow();
   await window.waitForLoadState("domcontentloaded");
 
   // Booted past onboarding into the chat layout (composer present).
   await expect(window.getByLabel("Message input")).toBeVisible();
 
-  await window.getByRole("button", { name: "Balance Sheet" }).click();
-  await expect(window.getByRole("heading", { name: "Balance Sheet" })).toBeVisible();
+  await window.getByRole("button", { name: "Net Worth" }).click();
+  await expect(window.getByRole("heading", { name: "Net Worth" })).toBeVisible();
   await expect(window.getByText("No accounts yet")).toBeVisible();
 
   // Toggling the entry brings the chat back.
-  await window.getByRole("button", { name: "Balance Sheet" }).click();
-  await expect(window.getByRole("heading", { name: "Balance Sheet" })).not.toBeVisible();
+  await window.getByRole("button", { name: "Net Worth" }).click();
+  await expect(window.getByRole("heading", { name: "Net Worth" })).not.toBeVisible();
   await expect(window.getByLabel("Message input")).toBeVisible();
 });

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -21,6 +21,7 @@
     "@earendil-works/pi-ai": "0.79.8",
     "@earendil-works/pi-coding-agent": "0.79.8",
     "@fontsource-variable/inter": "^5.2.8",
+    "@tanstack/react-table": "^8.21.3",
     "assistant-stream": "^0.3.24",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/packages/desktop/src/main/__tests__/ledger-json.test.ts
+++ b/packages/desktop/src/main/__tests__/ledger-json.test.ts
@@ -3,6 +3,7 @@ import {
   mergeValuedBalanceSheet,
   parseAssertionDates,
   parseBalanceSheetJson,
+  parseLatestPriceTarget,
   type RawBalanceSheet,
 } from "../ledger-json";
 
@@ -311,5 +312,55 @@ describe("parseAssertionDates()", () => {
       { tpostings: [posting("assets:dateless", true)] },
     ]);
     expect(parseAssertionDates(json)).toEqual({ "assets:ok": "2026-06-02" });
+  });
+});
+
+// parseLatestPriceTarget reads the journal's de-facto base currency off
+// plain `hledger prices` output: the target commodity of the last (latest)
+// declared price, whatever display style the journal gives the amount.
+
+describe("parseLatestPriceTarget()", () => {
+  it("should return null for empty output", () => {
+    expect(parseLatestPriceTarget("")).toBeNull();
+    expect(parseLatestPriceTarget("\n\n")).toBeNull();
+  });
+
+  it("should return null for a non-directive line", () => {
+    expect(parseLatestPriceTarget("hledger: error: no journal")).toBeNull();
+  });
+
+  it("should read a right-side commodity code", () => {
+    expect(parseLatestPriceTarget("P 2026-07-22 UAH 0.01958 EUR")).toBe("EUR");
+  });
+
+  it("should read a left-glued commodity code", () => {
+    expect(parseLatestPriceTarget("P 2026-07-22 UAH EUR0.01958")).toBe("EUR");
+  });
+
+  it("should read a bare currency symbol", () => {
+    expect(parseLatestPriceTarget("P 2026-07-22 UAH \u20ac0.02")).toBe("\u20ac");
+  });
+
+  it("should survive digit grouping in the amount", () => {
+    expect(parseLatestPriceTarget("P 2026-07-15 BTC 55,849.08 USD")).toBe("USD");
+  });
+
+  it("should skip a double-quoted priced commodity", () => {
+    expect(parseLatestPriceTarget('P 2026-07-17 "SXR8" 701.93 EUR')).toBe("EUR");
+  });
+
+  it("should unquote a double-quoted target", () => {
+    expect(parseLatestPriceTarget('P 2026-07-17 EUR 51.07 "UAH"')).toBe("UAH");
+  });
+
+  it("should use the last line (hledger prints prices date-ascending)", () => {
+    const text = ["P 2026-07-10 USD 0.87 EUR", "P 2026-07-22 EUR 41.85 UAH"].join("\n");
+    expect(parseLatestPriceTarget(text)).toBe("UAH");
+  });
+
+  it("should return null when the line has no amount or no symbol", () => {
+    expect(parseLatestPriceTarget("P 2026-07-22 UAH")).toBeNull();
+    expect(parseLatestPriceTarget("P 2026-07-22 UAH 0.01958")).toBeNull();
+    expect(parseLatestPriceTarget("P not-a-date UAH 1 EUR")).toBeNull();
   });
 });

--- a/packages/desktop/src/main/__tests__/ledger-json.test.ts
+++ b/packages/desktop/src/main/__tests__/ledger-json.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from "vitest";
+import { mergeValuedBalanceSheet, parseBalanceSheetJson, type RawBalanceSheet } from "../ledger-json";
+
+// parseBalanceSheetJson turns `hledger bs -O json` output into sections and
+// the net row the Balance Sheet view renders. Fixtures follow the documented
+// compound-report shape: `{ cbrSubreports: [[name, periodicReport, bool]],
+// cbrTotals: netRow }`, periodicReport = { prRows, prTotals }, row =
+// { prrName, prrAmounts: [columnAmounts] }; expected values are hardcoded,
+// never derived from the parser itself.
+
+const amt = (commodity: string, floatingPoint: number, decimalPlaces: number | undefined = 2) => ({
+  acommodity: commodity,
+  aquantity: { decimalMantissa: 0, decimalPlaces, floatingPoint },
+  astyle: { asprecision: decimalPlaces },
+});
+const prow = (name: string, amounts: unknown[]) => ({ prrName: name, prrAmounts: [amounts] });
+const preport = (rows: unknown[], totals: unknown[]) => ({ prRows: rows, prTotals: { prrAmounts: [totals] } });
+const compound = (subreports: [string, unknown][], net: unknown[]) =>
+  JSON.stringify({ cbrSubreports: subreports.map(([name, r]) => [name, r, true]), cbrTotals: { prrAmounts: [net] } });
+
+describe("parseBalanceSheetJson()", () => {
+  it("should return null for an empty string", () => {
+    expect(parseBalanceSheetJson("")).toBeNull();
+  });
+
+  it("should return null for non-JSON garbage", () => {
+    expect(parseBalanceSheetJson("hledger: error: no journal file\n")).toBeNull();
+  });
+
+  it("should return null for JSON that is not the compound report shape", () => {
+    expect(parseBalanceSheetJson('{"rows": []}')).toBeNull();
+    expect(parseBalanceSheetJson("[1, 2]")).toBeNull();
+  });
+
+  it("should parse sections with their rows, totals, and the net", () => {
+    const json = compound(
+      [
+        ["Assets", preport([prow("assets:bank:checking", [amt("EUR", 2950.5)])], [amt("EUR", 2950.5)])],
+        ["Liabilities", preport([prow("liabilities:card", [amt("EUR", 300)])], [amt("EUR", 300)])],
+      ],
+      [amt("EUR", 2650.5)],
+    );
+    expect(parseBalanceSheetJson(json)).toEqual({
+      sections: [
+        {
+          name: "Assets",
+          rows: [{ name: "assets:bank:checking", amounts: [{ quantity: 2950.5, commodity: "EUR", precision: 2 }] }],
+          total: [{ quantity: 2950.5, commodity: "EUR", precision: 2 }],
+        },
+        {
+          name: "Liabilities",
+          rows: [{ name: "liabilities:card", amounts: [{ quantity: 300, commodity: "EUR", precision: 2 }] }],
+          total: [{ quantity: 300, commodity: "EUR", precision: 2 }],
+        },
+      ],
+      net: [{ quantity: 2650.5, commodity: "EUR", precision: 2 }],
+    });
+  });
+
+  it("should preserve hledger's row order, not sort", () => {
+    const json = compound(
+      [["Assets", preport([prow("assets:z", [amt("EUR", 1)]), prow("assets:a", [amt("EUR", 2)])], [amt("EUR", 3)])]],
+      [amt("EUR", 3)],
+    );
+    expect(parseBalanceSheetJson(json)?.sections[0]?.rows.map((r) => r.name)).toEqual(["assets:z", "assets:a"]);
+  });
+
+  it("should keep every commodity of a multi-commodity balance", () => {
+    const json = compound([["Assets", preport([prow("assets:cash", [amt("UAH", 1408.26), amt("USD", 100)])], [])]], []);
+    expect(parseBalanceSheetJson(json)?.sections[0]?.rows[0]?.amounts).toEqual([
+      { quantity: 1408.26, commodity: "UAH", precision: 2 },
+      { quantity: 100, commodity: "USD", precision: 2 },
+    ]);
+  });
+
+  it("should merge cost lots of the same commodity into one amount (like hledger's own display)", () => {
+    const json = compound(
+      [["Assets", preport([prow("assets:mono:eur", [amt("EUR", 4758.22), amt("EUR", -147.12)])], [])]],
+      [],
+    );
+    expect(parseBalanceSheetJson(json)?.sections[0]?.rows[0]?.amounts).toEqual([
+      { quantity: 4611.1, commodity: "EUR", precision: 2 },
+    ]);
+  });
+
+  it("should keep a section with no rows (an empty side of the sheet)", () => {
+    const json = compound([["Liabilities", preport([], [])]], []);
+    expect(parseBalanceSheetJson(json)?.sections).toEqual([{ name: "Liabilities", rows: [], total: [] }]);
+  });
+
+  it("should give an empty total to a section without prTotals", () => {
+    const json = JSON.stringify({
+      cbrSubreports: [["Assets", { prRows: [prow("assets", [amt("EUR", 1)])] }, true]],
+      cbrTotals: { prrAmounts: [[]] },
+    });
+    expect(parseBalanceSheetJson(json)?.sections[0]?.total).toEqual([]);
+  });
+
+  it("should skip malformed subreports and rows but keep the valid ones", () => {
+    const json = JSON.stringify({
+      cbrSubreports: [
+        "not a subreport",
+        [42, { prRows: [] }, true],
+        [
+          "Assets",
+          { prRows: ["not a row", { prrAmounts: [[amt("EUR", 1)]] }, prow("assets:ok", [amt("EUR", 7)])] },
+          true,
+        ],
+      ],
+      cbrTotals: { prrAmounts: [[amt("EUR", 7)]] },
+    });
+    expect(parseBalanceSheetJson(json)).toEqual({
+      sections: [
+        {
+          name: "Assets",
+          rows: [{ name: "assets:ok", amounts: [{ quantity: 7, commodity: "EUR", precision: 2 }] }],
+          total: [],
+        },
+      ],
+      net: [{ quantity: 7, commodity: "EUR", precision: 2 }],
+    });
+  });
+
+  it("should drop amounts without a finite quantity or a commodity", () => {
+    const bad1 = { acommodity: "EUR", aquantity: { decimalPlaces: 2 } };
+    const bad2 = { aquantity: { floatingPoint: 5, decimalPlaces: 2 } };
+    const json = compound([["Assets", preport([prow("assets", [bad1, bad2, amt("EUR", 7)])], [])]], []);
+    expect(parseBalanceSheetJson(json)?.sections[0]?.rows[0]?.amounts).toEqual([
+      { quantity: 7, commodity: "EUR", precision: 2 },
+    ]);
+  });
+
+  it("should default a missing or negative precision to 2", () => {
+    const noStyle = {
+      acommodity: "EUR",
+      aquantity: { decimalMantissa: 0, decimalPlaces: undefined, floatingPoint: 1 },
+    };
+    const json = compound([["Assets", preport([prow("a", [noStyle]), prow("b", [amt("EUR", 1, -3)])], [])]], []);
+    expect(parseBalanceSheetJson(json)?.sections[0]?.rows.map((r) => r.amounts[0]?.precision)).toEqual([2, 2]);
+  });
+
+  it("should keep a single zero amount when the whole balance is zero", () => {
+    const json = compound([["Assets", preport([prow("closed", [amt("EUR", 300), amt("EUR", -300)])], [])]], []);
+    expect(parseBalanceSheetJson(json)?.sections[0]?.rows[0]?.amounts).toEqual([
+      { quantity: 0, commodity: "EUR", precision: 2 },
+    ]);
+  });
+
+  it("should treat float dust from summed lots as zero and drop zero legs when other amounts remain", () => {
+    const json = compound(
+      [
+        [
+          "Assets",
+          preport(
+            [
+              prow("dust", [amt("EUR", 0.1), amt("EUR", 0.2), amt("EUR", -0.3)]),
+              prow("paypal", [amt("EUR", 0), amt("UAH", 521.72)]),
+            ],
+            [],
+          ),
+        ],
+      ],
+      [],
+    );
+    const rows = parseBalanceSheetJson(json)?.sections[0]?.rows;
+    expect(rows?.[0]?.amounts).toEqual([{ quantity: 0, commodity: "EUR", precision: 2 }]);
+    expect(rows?.[1]?.amounts).toEqual([{ quantity: 521.72, commodity: "UAH", precision: 2 }]);
+  });
+
+  it("should skip rows with empty names and treat missing prRows as an empty section", () => {
+    const json = JSON.stringify({
+      cbrSubreports: [
+        ["", { prRows: [prow("assets:x", [amt("EUR", 1)])] }, true],
+        ["Assets", { prRows: [prow("", [amt("EUR", 1)]), prow("assets:ok", [amt("EUR", 2)])] }, true],
+        ["Liabilities", {}, false],
+      ],
+      cbrTotals: { prrAmounts: [[]] },
+    });
+    expect(parseBalanceSheetJson(json)?.sections).toEqual([
+      {
+        name: "Assets",
+        rows: [{ name: "assets:ok", amounts: [{ quantity: 2, commodity: "EUR", precision: 2 }] }],
+        total: [],
+      },
+      { name: "Liabilities", rows: [], total: [] },
+    ]);
+  });
+});
+
+describe("mergeValuedBalanceSheet()", () => {
+  const A = (commodity: string, quantity: number): { quantity: number; commodity: string; precision: number } => ({
+    quantity,
+    commodity,
+    precision: 2,
+  });
+  const raw: RawBalanceSheet = {
+    sections: [
+      { name: "Assets", rows: [{ name: "assets:btc", amounts: [A("BTC", 0.16)] }], total: [A("BTC", 0.16)] },
+      { name: "Liabilities", rows: [{ name: "liabilities:card", amounts: [A("EUR", 300)] }], total: [A("EUR", 300)] },
+    ],
+    net: [A("BTC", 0.16), A("EUR", -300)],
+  };
+
+  it("should attach each valued figure to its raw counterpart by position", () => {
+    const valued: RawBalanceSheet = {
+      sections: [
+        { name: "Assets", rows: [{ name: "assets:btc", amounts: [A("EUR", 9990)] }], total: [A("EUR", 9990)] },
+        { name: "Liabilities", rows: [{ name: "liabilities:card", amounts: [A("EUR", 300)] }], total: [A("EUR", 300)] },
+      ],
+      net: [A("EUR", 9690)],
+    };
+    expect(mergeValuedBalanceSheet(raw, valued)).toEqual({
+      sections: [
+        {
+          name: "Assets",
+          rows: [{ name: "assets:btc", amounts: [A("BTC", 0.16)], value: [A("EUR", 9990)] }],
+          total: { amounts: [A("BTC", 0.16)], value: [A("EUR", 9990)] },
+        },
+        {
+          name: "Liabilities",
+          rows: [{ name: "liabilities:card", amounts: [A("EUR", 300)], value: [A("EUR", 300)] }],
+          total: { amounts: [A("EUR", 300)], value: [A("EUR", 300)] },
+        },
+      ],
+      net: { amounts: [A("BTC", 0.16), A("EUR", -300)], value: [A("EUR", 9690)] },
+    });
+  });
+
+  it("should fall back to the raw amounts everywhere when the valued run is null", () => {
+    const merged = mergeValuedBalanceSheet(raw, null);
+    expect(merged.sections[0]?.rows[0]?.value).toEqual([A("BTC", 0.16)]);
+    expect(merged.sections[0]?.total.value).toEqual([A("BTC", 0.16)]);
+    expect(merged.net.value).toEqual([A("BTC", 0.16), A("EUR", -300)]);
+  });
+
+  it("should fall back for a row whose valued counterpart names a different account", () => {
+    const valued: RawBalanceSheet = {
+      sections: [
+        { name: "Assets", rows: [{ name: "assets:other", amounts: [A("EUR", 1)] }], total: [A("EUR", 1)] },
+        { name: "Liabilities", rows: [{ name: "liabilities:card", amounts: [A("EUR", 300)] }], total: [A("EUR", 300)] },
+      ],
+      net: [A("EUR", 1)],
+    };
+    expect(mergeValuedBalanceSheet(raw, valued).sections[0]?.rows[0]?.value).toEqual([A("BTC", 0.16)]);
+  });
+
+  it("should fall back for a whole section whose valued counterpart has a different name", () => {
+    const valued: RawBalanceSheet = {
+      sections: [{ name: "Equity", rows: [{ name: "assets:btc", amounts: [A("EUR", 1)] }], total: [A("EUR", 1)] }],
+      net: [A("EUR", 1)],
+    };
+    const merged = mergeValuedBalanceSheet(raw, valued);
+    expect(merged.sections[0]?.rows[0]?.value).toEqual([A("BTC", 0.16)]);
+    expect(merged.sections[0]?.total.value).toEqual([A("BTC", 0.16)]);
+  });
+});

--- a/packages/desktop/src/main/__tests__/ledger-json.test.ts
+++ b/packages/desktop/src/main/__tests__/ledger-json.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { mergeValuedBalanceSheet, parseBalanceSheetJson, type RawBalanceSheet } from "../ledger-json";
+import {
+  mergeValuedBalanceSheet,
+  parseAssertionDates,
+  parseBalanceSheetJson,
+  type RawBalanceSheet,
+} from "../ledger-json";
 
 // parseBalanceSheetJson turns `hledger bs -O json` output into sections and
 // the net row the Balance Sheet view renders. Fixtures follow the documented
@@ -252,5 +257,59 @@ describe("mergeValuedBalanceSheet()", () => {
     const merged = mergeValuedBalanceSheet(raw, valued);
     expect(merged.sections[0]?.rows[0]?.value).toEqual([A("BTC", 0.16)]);
     expect(merged.sections[0]?.total.value).toEqual([A("BTC", 0.16)]);
+  });
+});
+
+// parseAssertionDates turns `hledger print -O json` output (an array of
+// transactions with postings; a posting carrying `pbalanceassertion` asserts
+// its account's balance on that date) into each account's latest assertion
+// date. Fixtures follow the documented shape.
+
+describe("parseAssertionDates()", () => {
+  const posting = (account: string, asserted: boolean, pdate: string | null = null) => ({
+    paccount: account,
+    pdate,
+    pbalanceassertion: asserted ? { baamount: {}, batotal: false } : null,
+  });
+  const txn = (date: string, postings: unknown[]) => ({ tdate: date, tpostings: postings });
+
+  it("should return {} for an empty string, garbage, or a non-array", () => {
+    expect(parseAssertionDates("")).toEqual({});
+    expect(parseAssertionDates("hledger: error")).toEqual({});
+    expect(parseAssertionDates('{"a": 1}')).toEqual({});
+  });
+
+  it("should return {} when no posting carries an assertion", () => {
+    const json = JSON.stringify([txn("2026-06-01", [posting("assets:bank", false)])]);
+    expect(parseAssertionDates(json)).toEqual({});
+  });
+
+  it("should record the transaction date of an asserting posting", () => {
+    const json = JSON.stringify([txn("2026-06-15", [posting("assets:bank", true), posting("equity", false)])]);
+    expect(parseAssertionDates(json)).toEqual({ "assets:bank": "2026-06-15" });
+  });
+
+  it("should prefer the posting's own date over the transaction's", () => {
+    const json = JSON.stringify([txn("2026-07-10", [posting("assets:bank", true, "2026-07-12")])]);
+    expect(parseAssertionDates(json)).toEqual({ "assets:bank": "2026-07-12" });
+  });
+
+  it("should keep the latest date per account regardless of journal order", () => {
+    const json = JSON.stringify([
+      txn("2026-07-01", [posting("assets:bank", true)]),
+      txn("2026-06-15", [posting("assets:bank", true)]),
+      txn("2026-05-01", [posting("assets:cash", true)]),
+    ]);
+    expect(parseAssertionDates(json)).toEqual({ "assets:bank": "2026-07-01", "assets:cash": "2026-05-01" });
+  });
+
+  it("should skip malformed transactions and postings but keep the valid ones", () => {
+    const json = JSON.stringify([
+      "not a transaction",
+      { tdate: "2026-06-01" },
+      txn("2026-06-02", ["not a posting", { pbalanceassertion: {}, paccount: "" }, posting("assets:ok", true)]),
+      { tpostings: [posting("assets:dateless", true)] },
+    ]);
+    expect(parseAssertionDates(json)).toEqual({ "assets:ok": "2026-06-02" });
   });
 });

--- a/packages/desktop/src/main/__tests__/ledger-json.test.ts
+++ b/packages/desktop/src/main/__tests__/ledger-json.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../ledger-json";
 
 // parseBalanceSheetJson turns `hledger bs -O json` output into sections and
-// the net row the Balance Sheet view renders. Fixtures follow the documented
+// the net row the Net Worth view renders. Fixtures follow the documented
 // compound-report shape: `{ cbrSubreports: [[name, periodicReport, bool]],
 // cbrTotals: netRow }`, periodicReport = { prRows, prTotals }, row =
 // { prrName, prrAmounts: [columnAmounts] }; expected values are hardcoded,

--- a/packages/desktop/src/main/__tests__/ledger.test.ts
+++ b/packages/desktop/src/main/__tests__/ledger.test.ts
@@ -43,7 +43,7 @@ type Response = string[] | Error;
 function stubHledger(bySub: Record<string, Response>) {
   h.execFile.mockImplementation((_bin: string, args: string[], _opts: unknown, cb: ExecCb) => {
     let sub = args[0] as string;
-    if (args.includes("-X")) sub += ":V";
+    if (args.includes("-X") || args.includes("-V")) sub += ":V";
     const r = bySub[sub];
     if (r instanceof Error) {
       cb(r, "", "boom");
@@ -212,7 +212,7 @@ describe("ledger_balance_sheet", () => {
     }),
   ];
   const EMPTY_REPORT = report([], []);
-  const emptyStubs = { bs: EMPTY_REPORT, "bs:V": EMPTY_REPORT };
+  const emptyStubs = { bs: EMPTY_REPORT, "bs:V": EMPTY_REPORT, prices: ["P 2026-07-22 UAH 0.01958 EUR"] };
   const printed = (txns: unknown[]) => [JSON.stringify(txns)];
 
   // Native run: BTC holding plus a positive (bs sign convention) liability;
@@ -238,6 +238,8 @@ describe("ledger_balance_sheet", () => {
         tpostings: [{ paccount: "assets:btc", pdate: null, pbalanceassertion: { baamount: {} } }],
       },
     ]),
+    // The latest price in the stub journal targets EUR: the derived base.
+    prices: ["P 2026-07-10 USD 0.87 EUR", "P 2026-07-22 UAH 0.01958 EUR"],
   };
 
   it("should pair the sections and net of the native and valued bs runs", async () => {
@@ -284,22 +286,30 @@ describe("ledger_balance_sheet", () => {
     });
   });
 
-  it("should run bs twice (native and valued in EUR with inferred prices) plus print for assertion dates, against the workspace journal in the workspace cwd with the agent env", async () => {
+  it("should run bs natively, then valued toward the base derived from the journal prices, plus print for assertion dates, against the workspace journal in the workspace cwd with the agent env", async () => {
     stubHledger(emptyStubs);
     await balanceSheet();
 
-    expect(h.execFile.mock.calls).toHaveLength(3);
+    expect(h.execFile.mock.calls).toHaveLength(4);
     const base = ["bs", "-O", "json", "-f", "/ws/ledger/main.journal"];
     const argLists = h.execFile.mock.calls.map((c) => c[1] as string[]);
     expect(argLists).toContainEqual(base);
     expect(argLists).toContainEqual([...base, "-X", "EUR", "--infer-market-prices"]);
     expect(argLists).toContainEqual(["print", "-O", "json", "-f", "/ws/ledger/main.journal"]);
+    expect(argLists).toContainEqual(["prices", "-f", "/ws/ledger/main.journal"]);
     for (const call of h.execFile.mock.calls) {
       const opts = call[2] as { cwd: string; env: unknown; maxBuffer: number };
       expect(opts.cwd).toBe("/ws");
       expect(opts.env).toEqual({ PATH: "/vendored/bin", ACCOUNTANT24_HOME: "/ws" });
       expect(opts.maxBuffer).toBe(16 * 1024 * 1024);
     }
+  });
+
+  it("should fall back to -V when the journal declares no prices", async () => {
+    stubHledger({ ...emptyStubs, prices: [] });
+    await balanceSheet();
+    const argLists = h.execFile.mock.calls.map((c) => c[1] as string[]);
+    expect(argLists).toContainEqual(["bs", "-O", "json", "-f", "/ws/ledger/main.journal", "-V"]);
   });
 
   it("should leave rows without assertions untouched when the print run fails", async () => {

--- a/packages/desktop/src/main/__tests__/ledger.test.ts
+++ b/packages/desktop/src/main/__tests__/ledger.test.ts
@@ -213,6 +213,7 @@ describe("ledger_balance_sheet", () => {
   ];
   const EMPTY_REPORT = report([], []);
   const emptyStubs = { bs: EMPTY_REPORT, "bs:V": EMPTY_REPORT };
+  const printed = (txns: unknown[]) => [JSON.stringify(txns)];
 
   // Native run: BTC holding plus a positive (bs sign convention) liability;
   // valued run: everything in EUR.
@@ -231,6 +232,12 @@ describe("ledger_balance_sheet", () => {
       ],
       [amt("EUR", 9690)],
     ),
+    print: printed([
+      {
+        tdate: "2026-07-05",
+        tpostings: [{ paccount: "assets:btc", pdate: null, pbalanceassertion: { baamount: {} } }],
+      },
+    ]),
   };
 
   it("should pair the sections and net of the native and valued bs runs", async () => {
@@ -244,6 +251,7 @@ describe("ledger_balance_sheet", () => {
               name: "assets:btc",
               amounts: [{ quantity: 0.16, commodity: "BTC", precision: 8 }],
               value: [{ quantity: 9990, commodity: "EUR", precision: 2 }],
+              assertedOn: "2026-07-05",
             },
           ],
           total: {
@@ -276,21 +284,28 @@ describe("ledger_balance_sheet", () => {
     });
   });
 
-  it("should run bs twice (native and valued in EUR with inferred prices) against the workspace journal in the workspace cwd with the agent env", async () => {
+  it("should run bs twice (native and valued in EUR with inferred prices) plus print for assertion dates, against the workspace journal in the workspace cwd with the agent env", async () => {
     stubHledger(emptyStubs);
     await balanceSheet();
 
-    expect(h.execFile.mock.calls).toHaveLength(2);
+    expect(h.execFile.mock.calls).toHaveLength(3);
     const base = ["bs", "-O", "json", "-f", "/ws/ledger/main.journal"];
     const argLists = h.execFile.mock.calls.map((c) => c[1] as string[]);
     expect(argLists).toContainEqual(base);
     expect(argLists).toContainEqual([...base, "-X", "EUR", "--infer-market-prices"]);
+    expect(argLists).toContainEqual(["print", "-O", "json", "-f", "/ws/ledger/main.journal"]);
     for (const call of h.execFile.mock.calls) {
       const opts = call[2] as { cwd: string; env: unknown; maxBuffer: number };
       expect(opts.cwd).toBe("/ws");
       expect(opts.env).toEqual({ PATH: "/vendored/bin", ACCOUNTANT24_HOME: "/ws" });
       expect(opts.maxBuffer).toBe(16 * 1024 * 1024);
     }
+  });
+
+  it("should leave rows without assertions untouched when the print run fails", async () => {
+    stubHledger({ ...STUBS, print: new Error("boom") });
+    const sheet = await balanceSheet();
+    expect(sheet.sections[0]?.rows[0]?.assertedOn).toBeUndefined();
   });
 
   it("should fall back to the raw amounts as the value when the valued run fails", async () => {

--- a/packages/desktop/src/main/__tests__/ledger.test.ts
+++ b/packages/desktop/src/main/__tests__/ledger.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BalanceSheet } from "../../shared/types";
 
-// ledger.ts answers the composer's @-mention query by running the vendored
-// `hledger accounts|payees|tags` against the workspace journal. child_process
-// (the real hledger binary), node:fs, Electron IPC, and env paths are the faked
-// boundaries; the line-shaping (trim / drop-empty / case-insensitive sort) and
-// the []-on-any-failure contract run for real.
+// ledger.ts answers the composer's @-mention query (`hledger
+// accounts|payees|tags`) and the Balance Sheet view's report query
+// (`hledger bs`) against the workspace journal. child_process (the real
+// hledger binary), node:fs, Electron IPC, and env paths are the faked
+// boundaries; the line-shaping, the JSON parse, and the
+// empty-on-any-failure contract run for real.
 type Handler = (event: unknown, payload?: unknown) => unknown;
 type ExecCb = (err: Error | null, stdout: string, stderr: string) => void;
 
@@ -34,10 +36,14 @@ vi.mock("../env", () => ({
  *  Error to simulate a failure (missing binary, no journal, parse error). */
 type Response = string[] | Error;
 
-/** Program execFile so each `hledger <sub>` returns the given canned result. */
+/** Program execFile so each `hledger <sub>` returns the given canned result.
+ *  Balance-sheet variants are keyed by their flags: "bs" (native holdings),
+ *  "bs:V" (at market value, `-X`). A sub without a canned result returns
+ *  empty output. */
 function stubHledger(bySub: Record<string, Response>) {
   h.execFile.mockImplementation((_bin: string, args: string[], _opts: unknown, cb: ExecCb) => {
-    const sub = args[0];
+    let sub = args[0] as string;
+    if (args.includes("-X")) sub += ":V";
     const r = bySub[sub];
     if (r instanceof Error) {
       cb(r, "", "boom");
@@ -47,13 +53,16 @@ function stubHledger(bySub: Record<string, Response>) {
   });
 }
 
-async function mentions(): Promise<{ accounts: string[]; payees: string[]; tags: string[] }> {
+async function invoke<T>(channel: string): Promise<T> {
   const mod = await import("../ledger");
   mod.registerLedgerIpc();
-  const handler = h.handlers.get("ledger_mentions");
-  if (!handler) throw new Error("no handler for ledger_mentions");
-  return (await handler(null)) as { accounts: string[]; payees: string[]; tags: string[] };
+  const handler = h.handlers.get(channel);
+  if (!handler) throw new Error(`no handler for ${channel}`);
+  return (await handler(null)) as T;
 }
+
+const mentions = () => invoke<{ accounts: string[]; payees: string[]; tags: string[] }>("ledger_mentions");
+const balanceSheet = () => invoke<BalanceSheet>("ledger_balance_sheet");
 
 beforeEach(() => {
   h.handlers.clear();
@@ -179,6 +188,146 @@ describe("ledger_mentions", () => {
     h.existsSync.mockReturnValue(false);
     stubHledger({ accounts: [], payees: [], tags: [] });
     await mentions();
+    for (const call of h.execFile.mock.calls) {
+      expect(call[0]).toBe("hledger");
+    }
+  });
+});
+
+describe("ledger_balance_sheet", () => {
+  const amt = (commodity: string, floatingPoint: number, decimalPlaces = 2) => ({
+    acommodity: commodity,
+    aquantity: { decimalMantissa: 0, decimalPlaces, floatingPoint },
+    astyle: { asprecision: decimalPlaces },
+  });
+  const prow = (name: string, amounts: unknown[]) => ({ prrName: name, prrAmounts: [amounts] });
+  const report = (subreports: [string, unknown[], unknown[]][], net: unknown[]) => [
+    JSON.stringify({
+      cbrSubreports: subreports.map(([name, rows, total]) => [
+        name,
+        { prRows: rows, prTotals: { prrAmounts: [total] } },
+        true,
+      ]),
+      cbrTotals: { prrAmounts: [net] },
+    }),
+  ];
+  const EMPTY_REPORT = report([], []);
+  const emptyStubs = { bs: EMPTY_REPORT, "bs:V": EMPTY_REPORT };
+
+  // Native run: BTC holding plus a positive (bs sign convention) liability;
+  // valued run: everything in EUR.
+  const STUBS = {
+    bs: report(
+      [
+        ["Assets", [prow("assets:btc", [amt("BTC", 0.16, 8)])], [amt("BTC", 0.16, 8)]],
+        ["Liabilities", [prow("liabilities:card", [amt("EUR", 300)])], [amt("EUR", 300)]],
+      ],
+      [amt("BTC", 0.16, 8), amt("EUR", -300)],
+    ),
+    "bs:V": report(
+      [
+        ["Assets", [prow("assets:btc", [amt("EUR", 9990)])], [amt("EUR", 9990)]],
+        ["Liabilities", [prow("liabilities:card", [amt("EUR", 300)])], [amt("EUR", 300)]],
+      ],
+      [amt("EUR", 9690)],
+    ),
+  };
+
+  it("should pair the sections and net of the native and valued bs runs", async () => {
+    stubHledger(STUBS);
+    expect(await balanceSheet()).toEqual({
+      sections: [
+        {
+          name: "Assets",
+          rows: [
+            {
+              name: "assets:btc",
+              amounts: [{ quantity: 0.16, commodity: "BTC", precision: 8 }],
+              value: [{ quantity: 9990, commodity: "EUR", precision: 2 }],
+            },
+          ],
+          total: {
+            amounts: [{ quantity: 0.16, commodity: "BTC", precision: 8 }],
+            value: [{ quantity: 9990, commodity: "EUR", precision: 2 }],
+          },
+        },
+        {
+          name: "Liabilities",
+          rows: [
+            {
+              name: "liabilities:card",
+              amounts: [{ quantity: 300, commodity: "EUR", precision: 2 }],
+              value: [{ quantity: 300, commodity: "EUR", precision: 2 }],
+            },
+          ],
+          total: {
+            amounts: [{ quantity: 300, commodity: "EUR", precision: 2 }],
+            value: [{ quantity: 300, commodity: "EUR", precision: 2 }],
+          },
+        },
+      ],
+      net: {
+        amounts: [
+          { quantity: 0.16, commodity: "BTC", precision: 8 },
+          { quantity: -300, commodity: "EUR", precision: 2 },
+        ],
+        value: [{ quantity: 9690, commodity: "EUR", precision: 2 }],
+      },
+    });
+  });
+
+  it("should run bs twice (native and valued in EUR with inferred prices) against the workspace journal in the workspace cwd with the agent env", async () => {
+    stubHledger(emptyStubs);
+    await balanceSheet();
+
+    expect(h.execFile.mock.calls).toHaveLength(2);
+    const base = ["bs", "-O", "json", "-f", "/ws/ledger/main.journal"];
+    const argLists = h.execFile.mock.calls.map((c) => c[1] as string[]);
+    expect(argLists).toContainEqual(base);
+    expect(argLists).toContainEqual([...base, "-X", "EUR", "--infer-market-prices"]);
+    for (const call of h.execFile.mock.calls) {
+      const opts = call[2] as { cwd: string; env: unknown; maxBuffer: number };
+      expect(opts.cwd).toBe("/ws");
+      expect(opts.env).toEqual({ PATH: "/vendored/bin", ACCOUNTANT24_HOME: "/ws" });
+      expect(opts.maxBuffer).toBe(16 * 1024 * 1024);
+    }
+  });
+
+  it("should fall back to the raw amounts as the value when the valued run fails", async () => {
+    stubHledger({ ...STUBS, "bs:V": new Error("no prices") });
+    const sheet = await balanceSheet();
+    expect(sheet.sections[0]?.rows[0]?.value).toEqual([{ quantity: 0.16, commodity: "BTC", precision: 8 }]);
+    expect(sheet.net.value).toEqual([
+      { quantity: 0.16, commodity: "BTC", precision: 8 },
+      { quantity: -300, commodity: "EUR", precision: 2 },
+    ]);
+  });
+
+  it("should return an empty sheet when hledger fails (no journal yet)", async () => {
+    const err = new Error("hledger: no journal");
+    stubHledger({ bs: err, "bs:V": err });
+    expect(await balanceSheet()).toEqual({ sections: [], net: { amounts: [], value: [] } });
+  });
+
+  it("should return an empty sheet when hledger is missing entirely", async () => {
+    const enoent = Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" });
+    stubHledger({ bs: enoent, "bs:V": enoent });
+    expect(await balanceSheet()).toEqual({ sections: [], net: { amounts: [], value: [] } });
+  });
+
+  it("should run the vendored hledger binary when it exists in binDir", async () => {
+    h.existsSync.mockReturnValue(true);
+    stubHledger(emptyStubs);
+    await balanceSheet();
+    for (const call of h.execFile.mock.calls) {
+      expect(call[0]).toBe("/vendored/bin/hledger");
+    }
+  });
+
+  it("should fall back to a PATH lookup of `hledger` when the vendored binary is absent", async () => {
+    h.existsSync.mockReturnValue(false);
+    stubHledger(emptyStubs);
+    await balanceSheet();
     for (const call of h.execFile.mock.calls) {
       expect(call[0]).toBe("hledger");
     }

--- a/packages/desktop/src/main/__tests__/ledger.test.ts
+++ b/packages/desktop/src/main/__tests__/ledger.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { BalanceSheet } from "../../shared/types";
+import type { NetWorth } from "../../shared/types";
 
 // ledger.ts answers the composer's @-mention query (`hledger
-// accounts|payees|tags`) and the Balance Sheet view's report query
+// accounts|payees|tags`) and the Net Worth view's report query
 // (`hledger bs`) against the workspace journal. child_process (the real
 // hledger binary), node:fs, Electron IPC, and env paths are the faked
 // boundaries; the line-shaping, the JSON parse, and the
@@ -62,7 +62,7 @@ async function invoke<T>(channel: string): Promise<T> {
 }
 
 const mentions = () => invoke<{ accounts: string[]; payees: string[]; tags: string[] }>("ledger_mentions");
-const balanceSheet = () => invoke<BalanceSheet>("ledger_balance_sheet");
+const netWorth = () => invoke<NetWorth>("ledger_net_worth");
 
 beforeEach(() => {
   h.handlers.clear();
@@ -194,7 +194,7 @@ describe("ledger_mentions", () => {
   });
 });
 
-describe("ledger_balance_sheet", () => {
+describe("ledger_net_worth", () => {
   const amt = (commodity: string, floatingPoint: number, decimalPlaces = 2) => ({
     acommodity: commodity,
     aquantity: { decimalMantissa: 0, decimalPlaces, floatingPoint },
@@ -244,7 +244,7 @@ describe("ledger_balance_sheet", () => {
 
   it("should pair the sections and net of the native and valued bs runs", async () => {
     stubHledger(STUBS);
-    expect(await balanceSheet()).toEqual({
+    expect(await netWorth()).toEqual({
       sections: [
         {
           name: "Assets",
@@ -288,7 +288,7 @@ describe("ledger_balance_sheet", () => {
 
   it("should run bs natively, then valued toward the base derived from the journal prices, plus print for assertion dates, against the workspace journal in the workspace cwd with the agent env", async () => {
     stubHledger(emptyStubs);
-    await balanceSheet();
+    await netWorth();
 
     expect(h.execFile.mock.calls).toHaveLength(4);
     const base = ["bs", "-O", "json", "-f", "/ws/ledger/main.journal"];
@@ -307,20 +307,20 @@ describe("ledger_balance_sheet", () => {
 
   it("should fall back to -V when the journal declares no prices", async () => {
     stubHledger({ ...emptyStubs, prices: [] });
-    await balanceSheet();
+    await netWorth();
     const argLists = h.execFile.mock.calls.map((c) => c[1] as string[]);
     expect(argLists).toContainEqual(["bs", "-O", "json", "-f", "/ws/ledger/main.journal", "-V"]);
   });
 
   it("should leave rows without assertions untouched when the print run fails", async () => {
     stubHledger({ ...STUBS, print: new Error("boom") });
-    const sheet = await balanceSheet();
+    const sheet = await netWorth();
     expect(sheet.sections[0]?.rows[0]?.assertedOn).toBeUndefined();
   });
 
   it("should fall back to the raw amounts as the value when the valued run fails", async () => {
     stubHledger({ ...STUBS, "bs:V": new Error("no prices") });
-    const sheet = await balanceSheet();
+    const sheet = await netWorth();
     expect(sheet.sections[0]?.rows[0]?.value).toEqual([{ quantity: 0.16, commodity: "BTC", precision: 8 }]);
     expect(sheet.net.value).toEqual([
       { quantity: 0.16, commodity: "BTC", precision: 8 },
@@ -331,19 +331,19 @@ describe("ledger_balance_sheet", () => {
   it("should return an empty sheet when hledger fails (no journal yet)", async () => {
     const err = new Error("hledger: no journal");
     stubHledger({ bs: err, "bs:V": err });
-    expect(await balanceSheet()).toEqual({ sections: [], net: { amounts: [], value: [] } });
+    expect(await netWorth()).toEqual({ sections: [], net: { amounts: [], value: [] } });
   });
 
   it("should return an empty sheet when hledger is missing entirely", async () => {
     const enoent = Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" });
     stubHledger({ bs: enoent, "bs:V": enoent });
-    expect(await balanceSheet()).toEqual({ sections: [], net: { amounts: [], value: [] } });
+    expect(await netWorth()).toEqual({ sections: [], net: { amounts: [], value: [] } });
   });
 
   it("should run the vendored hledger binary when it exists in binDir", async () => {
     h.existsSync.mockReturnValue(true);
     stubHledger(emptyStubs);
-    await balanceSheet();
+    await netWorth();
     for (const call of h.execFile.mock.calls) {
       expect(call[0]).toBe("/vendored/bin/hledger");
     }
@@ -352,7 +352,7 @@ describe("ledger_balance_sheet", () => {
   it("should fall back to a PATH lookup of `hledger` when the vendored binary is absent", async () => {
     h.existsSync.mockReturnValue(false);
     stubHledger(emptyStubs);
-    await balanceSheet();
+    await netWorth();
     for (const call of h.execFile.mock.calls) {
       expect(call[0]).toBe("hledger");
     }

--- a/packages/desktop/src/main/ledger-json.ts
+++ b/packages/desktop/src/main/ledger-json.ts
@@ -101,6 +101,34 @@ export function parseBalanceSheetJson(json: string): RawBalanceSheet | null {
   return { sections, net: parseRowAmounts(report.cbrTotals) };
 }
 
+/** Parse `hledger print -O json` output into each account's most recent
+ *  balance-assertion date — the posting's own date when it has one, the
+ *  transaction's otherwise. Accounts without assertions are absent; anything
+ *  unparseable yields {}. */
+export function parseAssertionDates(json: string): Record<string, string> {
+  let data: unknown;
+  try {
+    data = JSON.parse(json);
+  } catch {
+    return {};
+  }
+  if (!Array.isArray(data)) return {};
+  const latest: Record<string, string> = {};
+  for (const txn of data) {
+    const t = txn as { tdate?: unknown; tpostings?: unknown };
+    if (!Array.isArray(t?.tpostings)) continue;
+    for (const posting of t.tpostings) {
+      const p = posting as { paccount?: unknown; pdate?: unknown; pbalanceassertion?: unknown };
+      if (!p?.pbalanceassertion || typeof p.paccount !== "string" || !p.paccount) continue;
+      const date = typeof p.pdate === "string" && p.pdate ? p.pdate : t.tdate;
+      if (typeof date !== "string" || !date) continue;
+      const prev = latest[p.paccount];
+      if (!prev || date > prev) latest[p.paccount] = date;
+    }
+  }
+  return latest;
+}
+
 /** Merge the raw and market-value (`-X`) runs of the same `bs` report. Both
  *  runs cover the identical sections and account lists, so everything pairs
  *  by position; if the valued run is missing or disagrees (partial hledger

--- a/packages/desktop/src/main/ledger-json.ts
+++ b/packages/desktop/src/main/ledger-json.ts
@@ -1,0 +1,124 @@
+// Parser for `hledger bs -O json` output (the Balance Sheet view). The
+// compound report carries exact quantities and clean commodity symbols (no
+// display-string ambiguity), so the renderer can format numbers for humans
+// while every figure stays hledger-computed.
+//
+// Shape: `{ cbrSubreports: [[name, periodicReport, increasesTotal], ...],
+// cbrTotals: netRow, ... }`; a periodic report has `prRows` (one per
+// account: `prrName`, `prrAmounts: [columnAmounts]`) and `prTotals` (the
+// section total, same row shape). Each amount has `acommodity`,
+// `aquantity: { floatingPoint, decimalPlaces, ... }`, and
+// `astyle: { asprecision, ... }`. Unlike hledger's text output, the JSON
+// keeps cost lots separate — one commodity can appear several times per
+// row — so amounts are aggregated per commodity here, exactly what
+// hledger's own display does.
+
+import type { AccountBalance, BalanceSheet, BalanceSheetSection, LedgerAmount } from "../shared/types";
+
+/** A parsed balance row before the market-value report is merged in. */
+export type RawBalanceRow = Omit<AccountBalance, "value">;
+
+/** Display-zero threshold: sums of cost lots can leave float dust. */
+const isZero = (quantity: number): boolean => Math.abs(quantity) < 1e-9;
+
+function parseAmount(a: unknown): LedgerAmount | null {
+  const amount = a as {
+    acommodity?: unknown;
+    aquantity?: { floatingPoint?: unknown; decimalPlaces?: unknown };
+    astyle?: { asprecision?: unknown };
+  };
+  const quantity = amount?.aquantity?.floatingPoint;
+  const commodity = amount?.acommodity;
+  if (typeof quantity !== "number" || !Number.isFinite(quantity) || typeof commodity !== "string") return null;
+  // The commodity's display precision when the journal declares one; the
+  // amount's own decimal places otherwise.
+  const style = amount?.astyle?.asprecision;
+  const places = amount?.aquantity?.decimalPlaces;
+  const precision =
+    typeof style === "number" && style >= 0 ? style : typeof places === "number" && places >= 0 ? places : 2;
+  return { quantity, commodity, precision };
+}
+
+/** Merge cost lots of the same commodity into one amount (hledger's text
+ *  output does the same), then drop zero legs unless the whole balance is
+ *  zero — a zeroed account keeps a single zero amount. */
+function aggregateAmounts(amounts: LedgerAmount[]): LedgerAmount[] {
+  const byCommodity = new Map<string, LedgerAmount>();
+  for (const a of amounts) {
+    const prev = byCommodity.get(a.commodity);
+    if (prev) {
+      prev.quantity += a.quantity;
+      prev.precision = Math.max(prev.precision, a.precision);
+    } else {
+      byCommodity.set(a.commodity, { ...a });
+    }
+  }
+  const all = [...byCommodity.values()].map((a) => (isZero(a.quantity) ? { ...a, quantity: 0 } : a));
+  const nonZero = all.filter((a) => a.quantity !== 0);
+  return nonZero.length > 0 ? nonZero : all.slice(0, 1);
+}
+
+/** A parsed `bs` report before the market-value run is merged in. */
+export interface RawBalanceSheet {
+  sections: { name: string; rows: RawBalanceRow[]; total: LedgerAmount[] }[];
+  net: LedgerAmount[];
+}
+
+/** The amounts of a compound-report row (`prrAmounts` holds one amount list
+ *  per report column; ours are single-period), aggregated per commodity. */
+function parseRowAmounts(row: unknown): LedgerAmount[] {
+  const columns = (row as { prrAmounts?: unknown })?.prrAmounts;
+  const first = Array.isArray(columns) ? columns[0] : undefined;
+  if (!Array.isArray(first)) return [];
+  return aggregateAmounts(first.map(parseAmount).filter((a): a is LedgerAmount => a !== null));
+}
+
+/** Parse `hledger bs -O json` output into sections and the net row,
+ *  preserving hledger's order and sign convention. Anything unparseable
+ *  (including empty output) yields null — the caller's empty-state path. */
+export function parseBalanceSheetJson(json: string): RawBalanceSheet | null {
+  let data: unknown;
+  try {
+    data = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  const report = data as { cbrSubreports?: unknown; cbrTotals?: unknown };
+  if (!Array.isArray(report?.cbrSubreports)) return null;
+  const sections: RawBalanceSheet["sections"] = [];
+  for (const entry of report.cbrSubreports) {
+    if (!Array.isArray(entry)) continue;
+    const [name, subreport] = entry as [unknown, { prRows?: unknown; prTotals?: unknown } | undefined];
+    if (typeof name !== "string" || !name) continue;
+    const rows: RawBalanceRow[] = [];
+    for (const row of Array.isArray(subreport?.prRows) ? subreport.prRows : []) {
+      const accountName = (row as { prrName?: unknown })?.prrName;
+      if (typeof accountName !== "string" || !accountName) continue;
+      rows.push({ name: accountName, amounts: parseRowAmounts(row) });
+    }
+    sections.push({ name, rows, total: parseRowAmounts(subreport?.prTotals) });
+  }
+  return { sections, net: parseRowAmounts(report.cbrTotals) };
+}
+
+/** Merge the raw and market-value (`-X`) runs of the same `bs` report. Both
+ *  runs cover the identical sections and account lists, so everything pairs
+ *  by position; if the valued run is missing or disagrees (partial hledger
+ *  failure), the raw amounts stand in for the value. */
+export function mergeValuedBalanceSheet(raw: RawBalanceSheet, valued: RawBalanceSheet | null): BalanceSheet {
+  const orRaw = (amounts: LedgerAmount[], candidate: LedgerAmount[] | undefined): LedgerAmount[] =>
+    candidate ?? amounts;
+  const sections: BalanceSheetSection[] = raw.sections.map((section, s) => {
+    const valuedSection = valued?.sections[s];
+    const aligned = valuedSection?.name === section.name ? valuedSection : undefined;
+    return {
+      name: section.name,
+      rows: section.rows.map((row, r) => {
+        const valuedRow = aligned?.rows[r];
+        return { ...row, value: valuedRow?.name === row.name ? valuedRow.amounts : row.amounts };
+      }),
+      total: { amounts: section.total, value: orRaw(section.total, aligned?.total) },
+    };
+  });
+  return { sections, net: { amounts: raw.net, value: orRaw(raw.net, valued?.net) } };
+}

--- a/packages/desktop/src/main/ledger-json.ts
+++ b/packages/desktop/src/main/ledger-json.ts
@@ -101,6 +101,31 @@ export function parseBalanceSheetJson(json: string): RawBalanceSheet | null {
   return { sections, net: parseRowAmounts(report.cbrTotals) };
 }
 
+/** The target commodity of the journal's latest declared market price — the
+ *  last line of `hledger prices` output. This is the journal's de-facto base
+ *  currency: the agent records prices toward the user's currency, and it is
+ *  the same "latest P directive" rule hledger's own `-V` valuation applies
+ *  per commodity, read once for the whole report. The amount's display style
+ *  is journal-defined ("0.01 EUR", "EUR0.01", "€0.01"), so the symbol is
+ *  whatever remains once the number is stripped away. Null when the journal
+ *  declares no prices or the line is unparseable. */
+export function parseLatestPriceTarget(text: string): string | null {
+  const line = text.trim().split("\n").at(-1)?.trim();
+  if (!line?.startsWith("P ")) return null;
+  // P <date> <commodity> <amount> — the commodity may be double-quoted.
+  const afterP = line.slice(2).trimStart();
+  const afterDate = afterP.replace(/^\d{4}-\d{2}-\d{2}\s+/, "");
+  if (afterDate === afterP) return null;
+  const afterCommodity = afterDate.startsWith('"')
+    ? afterDate.replace(/^"[^"]*"\s+/, "")
+    : afterDate.replace(/^\S+\s+/, "");
+  if (afterCommodity === afterDate) return null;
+  const quoted = afterCommodity.match(/"([^"]+)"/);
+  if (quoted?.[1]) return quoted[1];
+  const symbol = afterCommodity.replace(/[\s\d.,+-]/g, "");
+  return symbol.length > 0 ? symbol : null;
+}
+
 /** Parse `hledger print -O json` output into each account's most recent
  *  balance-assertion date — the posting's own date when it has one, the
  *  transaction's otherwise. Accounts without assertions are absent; anything

--- a/packages/desktop/src/main/ledger-json.ts
+++ b/packages/desktop/src/main/ledger-json.ts
@@ -1,4 +1,4 @@
-// Parser for `hledger bs -O json` output (the Balance Sheet view). The
+// Parser for `hledger bs -O json` output (the Net Worth view). The
 // compound report carries exact quantities and clean commodity symbols (no
 // display-string ambiguity), so the renderer can format numbers for humans
 // while every figure stays hledger-computed.
@@ -13,7 +13,7 @@
 // row — so amounts are aggregated per commodity here, exactly what
 // hledger's own display does.
 
-import type { AccountBalance, BalanceSheet, BalanceSheetSection, LedgerAmount } from "../shared/types";
+import type { AccountBalance, LedgerAmount, NetWorth, NetWorthSection } from "../shared/types";
 
 /** A parsed balance row before the market-value report is merged in. */
 export type RawBalanceRow = Omit<AccountBalance, "value">;
@@ -158,10 +158,10 @@ export function parseAssertionDates(json: string): Record<string, string> {
  *  runs cover the identical sections and account lists, so everything pairs
  *  by position; if the valued run is missing or disagrees (partial hledger
  *  failure), the raw amounts stand in for the value. */
-export function mergeValuedBalanceSheet(raw: RawBalanceSheet, valued: RawBalanceSheet | null): BalanceSheet {
+export function mergeValuedBalanceSheet(raw: RawBalanceSheet, valued: RawBalanceSheet | null): NetWorth {
   const orRaw = (amounts: LedgerAmount[], candidate: LedgerAmount[] | undefined): LedgerAmount[] =>
     candidate ?? amounts;
-  const sections: BalanceSheetSection[] = raw.sections.map((section, s) => {
+  const sections: NetWorthSection[] = raw.sections.map((section, s) => {
     const valuedSection = valued?.sections[s];
     const aligned = valuedSection?.name === section.name ? valuedSection : undefined;
     return {

--- a/packages/desktop/src/main/ledger.ts
+++ b/packages/desktop/src/main/ledger.ts
@@ -14,7 +14,7 @@ import path from "node:path";
 import { ipcMain } from "electron";
 import type { BalanceSheet, LedgerMentions } from "../shared/types";
 import { agentEnv, binDir, mainJournalPath, workspaceDir } from "./env";
-import { mergeValuedBalanceSheet, parseBalanceSheetJson } from "./ledger-json";
+import { mergeValuedBalanceSheet, parseAssertionDates, parseBalanceSheetJson } from "./ledger-json";
 
 function hledgerBin(): string {
   const exe = path.join(binDir(), process.platform === "win32" ? "hledger.exe" : "hledger");
@@ -68,13 +68,27 @@ const VALUATION = ["-X", BASE_COMMODITY, "--infer-market-prices"];
  *  Run twice — native holdings and the market valuation — and paired; the
  *  valued run collapses multi-commodity holdings to one base-currency figure
  *  wherever hledger finds any price path (direct, reverse, chained, or
- *  cost-inferred). Empty when there's no journal yet or hledger fails. */
+ *  cost-inferred). Each row also carries the date of the account's latest
+ *  balance assertion (from `print -O json`) — when the balance was last
+ *  reconciled. Empty when there's no journal yet or hledger fails. */
 async function ledgerBalanceSheet(): Promise<BalanceSheet> {
   const base = ["bs", "-O", "json", "-f", mainJournalPath()];
-  const [native, valued] = await Promise.all([hledgerRaw(base), hledgerRaw([...base, ...VALUATION])]);
+  const [native, valued, printed] = await Promise.all([
+    hledgerRaw(base),
+    hledgerRaw([...base, ...VALUATION]),
+    hledgerRaw(["print", "-O", "json", "-f", mainJournalPath()]),
+  ]);
   const raw = parseBalanceSheetJson(native);
   if (raw === null) return { sections: [], net: { amounts: [], value: [] } };
-  return mergeValuedBalanceSheet(raw, parseBalanceSheetJson(valued));
+  const sheet = mergeValuedBalanceSheet(raw, parseBalanceSheetJson(valued));
+  const asserted = parseAssertionDates(printed);
+  return {
+    ...sheet,
+    sections: sheet.sections.map((section) => ({
+      ...section,
+      rows: section.rows.map((row) => (asserted[row.name] ? { ...row, assertedOn: asserted[row.name] } : row)),
+    })),
+  };
 }
 
 /** Register the ledger IPC handlers. */

--- a/packages/desktop/src/main/ledger.ts
+++ b/packages/desktop/src/main/ledger.ts
@@ -1,47 +1,45 @@
-// Ledger mention data for the chat composer's @-mention picker.
+// Ledger data served straight from the main process: the @-mention picker's
+// entity lists and the Accounts view's balance report.
 //
-// Runs the same `hledger payees|accounts|tags` queries the pi-extension uses, but
-// straight from the main process so the renderer can populate the @-mention
-// popover without round-tripping through the agent's RPC stream. Reads the same
-// workspace journal the agent does and resolves the vendored hledger binary
-// explicitly — `execFile` looks the command up on the parent's PATH, which (unlike
-// the spawned agent's env) does not include the bundled bin dir.
+// Runs the same `hledger` queries the pi-extension uses, but directly so the
+// renderer gets its data without round-tripping through the agent's RPC stream.
+// Reads the same workspace journal the agent does and resolves the vendored
+// hledger binary explicitly — `execFile` looks the command up on the parent's
+// PATH, which (unlike the spawned agent's env) does not include the bundled
+// bin dir.
 
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { ipcMain } from "electron";
-import type { LedgerMentions } from "../shared/types";
+import type { BalanceSheet, LedgerMentions } from "../shared/types";
 import { agentEnv, binDir, mainJournalPath, workspaceDir } from "./env";
+import { mergeValuedBalanceSheet, parseBalanceSheetJson } from "./ledger-json";
 
 function hledgerBin(): string {
   const exe = path.join(binDir(), process.platform === "win32" ? "hledger.exe" : "hledger");
   return existsSync(exe) ? exe : "hledger";
 }
 
-/** Run one `hledger` subcommand and return its sorted, non-empty output lines.
- *  Any failure (missing binary, no journal yet, parse error) yields []. */
-function hledger(args: string[]): Promise<string[]> {
+/** Run one `hledger` subcommand and return its raw stdout, untouched (the
+ *  balance report's JSON must not be line-shaped). Any failure (missing
+ *  binary, no journal yet, parse error) yields "". */
+function hledgerRaw(args: string[]): Promise<string> {
   return new Promise((resolve) => {
-    execFile(
-      hledgerBin(),
-      args,
-      { cwd: workspaceDir(), env: agentEnv(), maxBuffer: 16 * 1024 * 1024 },
-      (err, stdout) => {
-        if (err) {
-          resolve([]);
-          return;
-        }
-        resolve(
-          stdout
-            .split("\n")
-            .map((l) => l.trim())
-            .filter(Boolean)
-            .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" })),
-        );
-      },
+    execFile(hledgerBin(), args, { cwd: workspaceDir(), env: agentEnv(), maxBuffer: 16 * 1024 * 1024 }, (err, stdout) =>
+      resolve(err ? "" : stdout),
     );
   });
+}
+
+/** Run one `hledger` subcommand and return its sorted, non-empty output lines. */
+async function hledger(args: string[]): Promise<string[]> {
+  const stdout = await hledgerRaw(args);
+  return stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
 }
 
 async function ledgerMentions(): Promise<LedgerMentions> {
@@ -54,7 +52,33 @@ async function ledgerMentions(): Promise<LedgerMentions> {
   return { accounts, payees, tags };
 }
 
-/** Register the ledger IPC handler (one call returns all three mention lists). */
+/** The app's base currency: every balance is valued in it. Explicit here
+ *  (rather than implied by the journal's P directives) so hledger converts
+ *  through reverse and chained prices too; a future setting could replace it. */
+const BASE_COMMODITY = "EUR";
+
+/** Flags shared by every valued report: value in the base currency, using
+ *  declared P prices plus prices inferred from transaction costs — the
+ *  manual-recommended pairing (`-X COMM --infer-market-prices`). */
+const VALUATION = ["-X", BASE_COMMODITY, "--infer-market-prices"];
+
+/** The classic balance sheet, straight from `hledger bs`: Assets and
+ *  Liabilities sections (liabilities already sign-flipped positive by
+ *  hledger), each with hledger's own total, plus the hledger-computed net.
+ *  Run twice — native holdings and the market valuation — and paired; the
+ *  valued run collapses multi-commodity holdings to one base-currency figure
+ *  wherever hledger finds any price path (direct, reverse, chained, or
+ *  cost-inferred). Empty when there's no journal yet or hledger fails. */
+async function ledgerBalanceSheet(): Promise<BalanceSheet> {
+  const base = ["bs", "-O", "json", "-f", mainJournalPath()];
+  const [native, valued] = await Promise.all([hledgerRaw(base), hledgerRaw([...base, ...VALUATION])]);
+  const raw = parseBalanceSheetJson(native);
+  if (raw === null) return { sections: [], net: { amounts: [], value: [] } };
+  return mergeValuedBalanceSheet(raw, parseBalanceSheetJson(valued));
+}
+
+/** Register the ledger IPC handlers. */
 export function registerLedgerIpc(): void {
   ipcMain.handle("ledger_mentions", () => ledgerMentions());
+  ipcMain.handle("ledger_balance_sheet", () => ledgerBalanceSheet());
 }

--- a/packages/desktop/src/main/ledger.ts
+++ b/packages/desktop/src/main/ledger.ts
@@ -14,7 +14,12 @@ import path from "node:path";
 import { ipcMain } from "electron";
 import type { BalanceSheet, LedgerMentions } from "../shared/types";
 import { agentEnv, binDir, mainJournalPath, workspaceDir } from "./env";
-import { mergeValuedBalanceSheet, parseAssertionDates, parseBalanceSheetJson } from "./ledger-json";
+import {
+  mergeValuedBalanceSheet,
+  parseAssertionDates,
+  parseBalanceSheetJson,
+  parseLatestPriceTarget,
+} from "./ledger-json";
 
 function hledgerBin(): string {
   const exe = path.join(binDir(), process.platform === "win32" ? "hledger.exe" : "hledger");
@@ -52,32 +57,36 @@ async function ledgerMentions(): Promise<LedgerMentions> {
   return { accounts, payees, tags };
 }
 
-/** The app's base currency: every balance is valued in it. Explicit here
- *  (rather than implied by the journal's P directives) so hledger converts
- *  through reverse and chained prices too; a future setting could replace it. */
-const BASE_COMMODITY = "EUR";
-
-/** Flags shared by every valued report: value in the base currency, using
- *  declared P prices plus prices inferred from transaction costs — the
- *  manual-recommended pairing (`-X COMM --infer-market-prices`). */
-const VALUATION = ["-X", BASE_COMMODITY, "--infer-market-prices"];
+/** The report's base commodity — the target of the journal's latest
+ *  declared market price. The agent records prices toward the user's
+ *  currency, so the journal itself answers "which currency is home" and no
+ *  currency is hardcoded. Seam for the future default-currency setting: once
+ *  it exists, resolve it here first and fall back to the derivation. Null
+ *  when the journal declares no prices. */
+async function resolveBaseCommodity(): Promise<string | null> {
+  return parseLatestPriceTarget(await hledgerRaw(["prices", "-f", mainJournalPath()]));
+}
 
 /** The classic balance sheet, straight from `hledger bs`: Assets and
  *  Liabilities sections (liabilities already sign-flipped positive by
  *  hledger), each with hledger's own total, plus the hledger-computed net.
- *  Run twice — native holdings and the market valuation — and paired; the
- *  valued run collapses multi-commodity holdings to one base-currency figure
- *  wherever hledger finds any price path (direct, reverse, chained, or
- *  cost-inferred). Each row also carries the date of the account's latest
- *  balance assertion (from `print -O json`) — when the balance was last
- *  reconciled. Empty when there's no journal yet or hledger fails. */
+ *  Run twice — native holdings and the market valuation — and paired. With a
+ *  base commodity the valued run is `-X <base> --infer-market-prices`, which
+ *  collapses multi-commodity holdings to one base-currency figure wherever
+ *  hledger finds any price path (direct, reverse, chained, or cost-
+ *  inferred); with no prices declared there is nothing to aim at, and `-V`
+ *  lets hledger value what it can. Each row also carries the date of the
+ *  account's latest balance assertion (from `print -O json`) — when the
+ *  balance was last reconciled. Empty when there's no journal yet or hledger
+ *  fails. */
 async function ledgerBalanceSheet(): Promise<BalanceSheet> {
   const base = ["bs", "-O", "json", "-f", mainJournalPath()];
-  const [native, valued, printed] = await Promise.all([
+  const [native, printed, target] = await Promise.all([
     hledgerRaw(base),
-    hledgerRaw([...base, ...VALUATION]),
     hledgerRaw(["print", "-O", "json", "-f", mainJournalPath()]),
+    resolveBaseCommodity(),
   ]);
+  const valued = await hledgerRaw(target ? [...base, "-X", target, "--infer-market-prices"] : [...base, "-V"]);
   const raw = parseBalanceSheetJson(native);
   if (raw === null) return { sections: [], net: { amounts: [], value: [] } };
   const sheet = mergeValuedBalanceSheet(raw, parseBalanceSheetJson(valued));

--- a/packages/desktop/src/main/ledger.ts
+++ b/packages/desktop/src/main/ledger.ts
@@ -12,7 +12,7 @@ import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { ipcMain } from "electron";
-import type { BalanceSheet, LedgerMentions } from "../shared/types";
+import type { LedgerMentions, NetWorth } from "../shared/types";
 import { agentEnv, binDir, mainJournalPath, workspaceDir } from "./env";
 import {
   mergeValuedBalanceSheet,
@@ -79,7 +79,7 @@ async function resolveBaseCommodity(): Promise<string | null> {
  *  account's latest balance assertion (from `print -O json`) — when the
  *  balance was last reconciled. Empty when there's no journal yet or hledger
  *  fails. */
-async function ledgerBalanceSheet(): Promise<BalanceSheet> {
+async function ledgerNetWorth(): Promise<NetWorth> {
   const base = ["bs", "-O", "json", "-f", mainJournalPath()];
   const [native, printed, target] = await Promise.all([
     hledgerRaw(base),
@@ -103,5 +103,5 @@ async function ledgerBalanceSheet(): Promise<BalanceSheet> {
 /** Register the ledger IPC handlers. */
 export function registerLedgerIpc(): void {
   ipcMain.handle("ledger_mentions", () => ledgerMentions());
-  ipcMain.handle("ledger_balance_sheet", () => ledgerBalanceSheet());
+  ipcMain.handle("ledger_net_worth", () => ledgerNetWorth());
 }

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -31,6 +31,7 @@ const INVOKE_CHANNELS = new Set([
   "skills_set_enabled",
   "files_archive_to_workspace",
   "ledger_mentions",
+  "ledger_balance_sheet",
   "analytics_track",
   "update_pending",
   "update_install",

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -31,7 +31,7 @@ const INVOKE_CHANNELS = new Set([
   "skills_set_enabled",
   "files_archive_to_workspace",
   "ledger_mentions",
-  "ledger_balance_sheet",
+  "ledger_net_worth",
   "analytics_track",
   "update_pending",
   "update_install",

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/balance-sheet-view.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/balance-sheet-view.test.tsx
@@ -70,7 +70,7 @@ const DATA: BalanceSheet = {
       total: { amounts: [A("EUR", 346.75)], value: [A("EUR", 346.75)] },
     },
   ],
-  net: { amounts: [], value: [A("EUR", 1738.97)] },
+  net: { amounts: [A("UAH", 1408.26), A("USD", 100), A("SXR8", 22.45), A("EUR", -296.75)], value: [A("EUR", 1738.97)] },
 };
 
 const EMPTY: BalanceSheet = { sections: [], net: { amounts: [], value: [] } };
@@ -110,7 +110,10 @@ describe("<BalanceSheetView />", () => {
     renderView();
     expect(await screen.findByRole("heading", { level: 2, name: "Assets" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 2, name: "Liabilities" })).toBeInTheDocument();
-    expect(screen.getByText("2,085.72 EUR")).toBeInTheDocument();
+    // The assets total includes converted holdings: an estimate, so ~.
+    expect(screen.getByText("~2,085.72 EUR")).toBeInTheDocument();
+    // The liabilities total is exact EUR: no marker.
+    expect(screen.getByText("346.75 EUR", { selector: "div" })).toBeInTheDocument();
     expect(screen.getByRole("table", { name: "Assets" })).toBeInTheDocument();
     expect(screen.getByRole("table", { name: "Liabilities" })).toBeInTheDocument();
   });
@@ -129,7 +132,7 @@ describe("<BalanceSheetView />", () => {
     vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
     renderView();
     const net = await screen.findByText("Net");
-    expect(screen.getByText("1,738.97 EUR")).toBeInTheDocument();
+    expect(screen.getByText("~1,738.97 EUR")).toBeInTheDocument();
     // Net comes after both section tables in document order.
     const tables = screen.getAllByRole("table");
     const lastTable = tables[tables.length - 1] as HTMLElement;
@@ -158,11 +161,15 @@ describe("<BalanceSheetView />", () => {
     expect(accountOrder("Assets")).toEqual(["assets:bank", "assets:cash", "assets:darka:etf:sxr8"]);
   });
 
-  it("should show the locale-formatted market value as the primary figure on every row", async () => {
+  it("should mark converted row values with ~ and leave exact ones unmarked", async () => {
     vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
     renderView();
-    expect(await screen.findByText("115.57 EUR")).toBeInTheDocument();
-    expect(screen.getByText("1,920.15 EUR")).toBeInTheDocument();
+    // Converted (UAH+USD and SXR8 valued into EUR): estimates.
+    expect(await screen.findByText("~115.57 EUR")).toBeInTheDocument();
+    expect(screen.getByText("~1,920.15 EUR")).toBeInTheDocument();
+    // The plain EUR account is exact: holding and value, no marker.
+    expect(screen.getAllByText("50.00 EUR")).toHaveLength(2);
+    expect(screen.queryByText("~50.00 EUR")).not.toBeInTheDocument();
   });
 
   it("should show a multi-commodity holding comma-joined on one line", async () => {
@@ -172,13 +179,35 @@ describe("<BalanceSheetView />", () => {
     expect(screen.getByText("22.45 SXR8")).toBeInTheDocument();
   });
 
-  it("should show a multi-commodity net comma-joined on one line", async () => {
+  it("should show an unconverted multi-commodity net comma-joined, without ~", async () => {
+    // No rates in the journal: the valued run returns the same figures.
     vi.mocked(ledgerApi.balanceSheet).mockResolvedValue({
       ...DATA,
-      net: { amounts: [], value: [A("EUR", 7796.25), A("UAH", 1000)] },
+      net: { amounts: [A("EUR", 7796.25), A("UAH", 1000)], value: [A("EUR", 7796.25), A("UAH", 1000)] },
     });
     renderView();
     expect(await screen.findByText("7,796.25 EUR, 1,000.00 UAH")).toBeInTheDocument();
+    expect(screen.queryByText("~7,796.25 EUR, 1,000.00 UAH")).not.toBeInTheDocument();
+  });
+
+  it("should show no ~ anywhere when nothing was converted, totals included", async () => {
+    // An all-exact journal: every value equals its native amounts.
+    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue({
+      sections: [
+        {
+          name: "Assets",
+          rows: [
+            { name: "assets:bank:mono", amounts: [A("UAH", 1000)], value: [A("UAH", 1000)] },
+            { name: "assets:bank:n26", amounts: [A("EUR", 7796.25)], value: [A("EUR", 7796.25)] },
+          ],
+          total: { amounts: [A("EUR", 7796.25), A("UAH", 1000)], value: [A("EUR", 7796.25), A("UAH", 1000)] },
+        },
+      ],
+      net: { amounts: [A("EUR", 7796.25), A("UAH", 1000)], value: [A("EUR", 7796.25), A("UAH", 1000)] },
+    });
+    renderView();
+    await screen.findByTitle("assets:bank:mono");
+    expect(screen.queryByText(/~/)).not.toBeInTheDocument();
   });
 
   describe("sorting", () => {
@@ -317,7 +346,7 @@ describe("<BalanceSheetView />", () => {
   it("should refetch the report when the agent goes from running to idle", async () => {
     vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
     const { rerender } = renderView(false);
-    await screen.findByText("115.57 EUR");
+    await screen.findByText("~115.57 EUR");
     expect(ledgerApi.balanceSheet).toHaveBeenCalledTimes(1);
 
     rerender(
@@ -343,7 +372,7 @@ describe("<BalanceSheetView />", () => {
       .mockResolvedValueOnce(DATA)
       .mockReturnValue(new Promise(() => {}));
     const { rerender } = renderView(false);
-    await screen.findByText("115.57 EUR");
+    await screen.findByText("~115.57 EUR");
 
     rerender(
       <Chrome isRunning={true}>
@@ -359,7 +388,7 @@ describe("<BalanceSheetView />", () => {
     // Once the refetch is genuinely in flight (its promise never resolves),
     // the previous rows must still be up, with no skeleton.
     await waitFor(() => expect(ledgerApi.balanceSheet).toHaveBeenCalledTimes(2));
-    expect(screen.getByText("115.57 EUR")).toBeInTheDocument();
+    expect(screen.getByText("~115.57 EUR")).toBeInTheDocument();
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
 });

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/balance-sheet-view.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/balance-sheet-view.test.tsx
@@ -96,11 +96,18 @@ const accountOrder = (tableName: string) =>
     .map((row) => row.querySelector("td")?.getAttribute("title"));
 
 describe("<BalanceSheetView />", () => {
-  it("should show a loading status and no tables while the first load is in flight", () => {
+  it("should show the page chrome immediately and skeletons only for the loading data", () => {
     vi.mocked(ledgerApi.balanceSheet).mockReturnValue(new Promise(() => {}));
     renderView();
     expect(screen.getByRole("status", { name: "Loading accounts" })).toBeInTheDocument();
-    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    // Everything that needs no data is up before the report arrives: the
+    // search box, the Assets band, the column labels, and the Net band.
+    expect(screen.getByRole("searchbox", { name: "Search accounts" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "Assets" })).toBeInTheDocument();
+    expect(screen.getByText("Account")).toBeInTheDocument();
+    expect(screen.getByText("Net")).toBeInTheDocument();
+    // But no figures yet — those are what's loading.
+    expect(screen.queryByText(/EUR/)).not.toBeInTheDocument();
   });
 
   it("should render the pinned Balance Sheet title without a figure", async () => {
@@ -113,7 +120,9 @@ describe("<BalanceSheetView />", () => {
   it("should render one section per bs subreport, with hledger's own totals", async () => {
     vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
     renderView();
-    expect(await screen.findByRole("heading", { level: 2, name: "Assets" })).toBeInTheDocument();
+    // Settle on loaded data first — the skeleton also carries an Assets band.
+    await screen.findByTitle("assets:cash");
+    expect(screen.getByRole("heading", { level: 2, name: "Assets" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 2, name: "Liabilities" })).toBeInTheDocument();
     // The assets total includes converted holdings: an estimate, so ~.
     expect(screen.getByText("~2,085.72 EUR")).toBeInTheDocument();
@@ -180,8 +189,10 @@ describe("<BalanceSheetView />", () => {
   it("should show each account's last balance assertion date, and an em dash when it was never asserted", async () => {
     vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
     renderView();
+    // Settle on loaded data first — the skeleton also carries the header.
+    await screen.findByTitle("assets:cash");
     // One sortable header per section table.
-    expect(await screen.findAllByRole("button", { name: "Last Balance Assertion" })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: "Last Balance Assertion" })).toHaveLength(2);
     // The journal's own ISO dates, verbatim.
     expect(screen.getByText("2026-07-12")).toBeInTheDocument();
     expect(screen.getByText("2026-06-15")).toBeInTheDocument();

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/balance-sheet-view.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/balance-sheet-view.test.tsx
@@ -1,0 +1,365 @@
+// @vitest-environment jsdom
+
+// Spec for the Balance Sheet view: skeleton while the first load is in
+// flight, a pinned title and search box, one data table per `hledger bs`
+// section (Assets, Liabilities — the latter already sign-flipped positive by
+// hledger) with the section's own total, the hledger-computed Net as the
+// closing line, sorting on every column (A-Z on the account path by default,
+// independent per section), search filtering every section by path, the
+// empty state (no journal yet or hledger failed), and the refetch on the
+// agent's running → idle edge. jsdom pins navigator.language to en-US, so
+// formatted expectations are deterministic.
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// IPC boundary: the view reads the bs report over the Electron bridge.
+vi.mock("@/rpc/api", () => ({
+  ledgerApi: { balanceSheet: vi.fn() },
+}));
+
+import { AssistantRuntimeProvider, type ExternalStoreAdapter, useExternalStoreRuntime } from "@assistant-ui/react";
+import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { ledgerApi } from "@/rpc/api";
+import type { BalanceSheet, LedgerAmount } from "@/rpc/types";
+import { installJsdomPolyfills } from "@/test/jsdomPolyfills";
+import { BalanceSheetView } from "../balance-sheet-view";
+
+beforeAll(() => installJsdomPolyfills());
+afterEach(() => cleanup());
+beforeEach(() => {
+  vi.mocked(ledgerApi.balanceSheet).mockReset();
+});
+
+/** Real assistant-ui chrome so the view's `useAuiState` reads an honest
+ *  `thread.isRunning`; the prop drives the running → idle refetch edge. */
+function Chrome({ children, isRunning = false }: { children: ReactNode; isRunning?: boolean }) {
+  const store: ExternalStoreAdapter = {
+    messages: [],
+    isRunning,
+    onNew: async () => {},
+    convertMessage: (m: unknown) => m,
+  } as unknown as ExternalStoreAdapter;
+  const runtime = useExternalStoreRuntime(store);
+  return <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>;
+}
+
+const A = (commodity: string, quantity: number, precision = 2): LedgerAmount => ({ commodity, quantity, precision });
+
+// A two-section sheet the way hledger bs hands it over: assets with a
+// converted multi-commodity account, a share account, and a plain EUR one;
+// liabilities already positive; hledger's own section totals and net.
+const DATA: BalanceSheet = {
+  sections: [
+    {
+      name: "Assets",
+      rows: [
+        { name: "assets:cash", amounts: [A("UAH", 1408.26), A("USD", 100)], value: [A("EUR", 115.573, 3)] },
+        { name: "assets:darka:etf:sxr8", amounts: [A("SXR8", 22.45)], value: [A("EUR", 1920.148, 3)] },
+        { name: "assets:bank", amounts: [A("EUR", 50)], value: [A("EUR", 50)] },
+      ],
+      total: {
+        amounts: [A("UAH", 1408.26), A("USD", 100), A("SXR8", 22.45), A("EUR", 50)],
+        value: [A("EUR", 2085.72)],
+      },
+    },
+    {
+      name: "Liabilities",
+      rows: [{ name: "liabilities:creditcard", amounts: [A("EUR", 346.75)], value: [A("EUR", 346.75)] }],
+      total: { amounts: [A("EUR", 346.75)], value: [A("EUR", 346.75)] },
+    },
+  ],
+  net: { amounts: [], value: [A("EUR", 1738.97)] },
+};
+
+const EMPTY: BalanceSheet = { sections: [], net: { amounts: [], value: [] } };
+
+const renderView = (isRunning = false) =>
+  render(
+    <Chrome isRunning={isRunning}>
+      <BalanceSheetView />
+    </Chrome>,
+  );
+
+/** The rendered account order of one section's table: each body row's
+ *  account-cell title. */
+const accountOrder = (tableName: string) =>
+  within(screen.getByRole("table", { name: tableName }))
+    .getAllByRole("row")
+    .slice(1) // the column-header row
+    .map((row) => row.querySelector("td")?.getAttribute("title"));
+
+describe("<BalanceSheetView />", () => {
+  it("should show a loading status and no tables while the first load is in flight", () => {
+    vi.mocked(ledgerApi.balanceSheet).mockReturnValue(new Promise(() => {}));
+    renderView();
+    expect(screen.getByRole("status", { name: "Loading accounts" })).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("should render the pinned Balance Sheet title without a figure", async () => {
+    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+    renderView();
+    expect(await screen.findByRole("heading", { level: 1, name: "Balance Sheet" })).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("should render one section per bs subreport, with hledger's own totals", async () => {
+    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+    renderView();
+    expect(await screen.findByRole("heading", { level: 2, name: "Assets" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "Liabilities" })).toBeInTheDocument();
+    expect(screen.getByText("2,085.72 EUR")).toBeInTheDocument();
+    expect(screen.getByRole("table", { name: "Assets" })).toBeInTheDocument();
+    expect(screen.getByRole("table", { name: "Liabilities" })).toBeInTheDocument();
+  });
+
+  it("should show liabilities with hledger's positive sign", async () => {
+    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+    renderView();
+    expect(await screen.findByTitle("liabilities:creditcard")).toBeInTheDocument();
+    // The account row (holding + value) and the section total all read
+    // €346.75 — never a minus.
+    expect(screen.getAllByText("346.75 EUR")).toHaveLength(3);
+    expect(screen.queryByText("-346.75 EUR")).not.toBeInTheDocument();
+  });
+
+  it("should render the classic Net line last, with hledger's own figure", async () => {
+    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+    renderView();
+    const net = await screen.findByText("Net");
+    expect(screen.getByText("1,738.97 EUR")).toBeInTheDocument();
+    // Net comes after both section tables in document order.
+    const tables = screen.getAllByRole("table");
+    const lastTable = tables[tables.length - 1] as HTMLElement;
+    expect(lastTable.compareDocumentPosition(net) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("should not render a section hledger sent empty", async () => {
+    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue({
+      ...DATA,
+      sections: [
+        DATA.sections[0] as BalanceSheet["sections"][number],
+        { name: "Liabilities", rows: [], total: { amounts: [], value: [] } },
+      ],
+    });
+    renderView();
+    await screen.findByRole("heading", { level: 2, name: "Assets" });
+    expect(screen.queryByRole("heading", { level: 2, name: "Liabilities" })).not.toBeInTheDocument();
+  });
+
+  it("should list complete account paths sorted A-Z by default", async () => {
+    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+    renderView();
+    expect(await screen.findByTitle("assets:cash")).toHaveTextContent("assets:cash");
+    // The fixture arrives in hledger's order (cash, darka, bank); the table
+    // re-sorts it alphabetically.
+    expect(accountOrder("Assets")).toEqual(["assets:bank", "assets:cash", "assets:darka:etf:sxr8"]);
+  });
+
+  it("should show the locale-formatted market value as the primary figure on every row", async () => {
+    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+    renderView();
+    expect(await screen.findByText("115.57 EUR")).toBeInTheDocument();
+    expect(screen.getByText("1,920.15 EUR")).toBeInTheDocument();
+  });
+
+  it("should show a multi-commodity holding comma-joined on one line", async () => {
+    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+    renderView();
+    expect(await screen.findByText("1,408.26 UAH, 100.00 USD")).toBeInTheDocument();
+    expect(screen.getByText("22.45 SXR8")).toBeInTheDocument();
+  });
+
+  it("should show a multi-commodity net comma-joined on one line", async () => {
+    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue({
+      ...DATA,
+      net: { amounts: [], value: [A("EUR", 7796.25), A("UAH", 1000)] },
+    });
+    renderView();
+    expect(await screen.findByText("7,796.25 EUR, 1,000.00 UAH")).toBeInTheDocument();
+  });
+
+  describe("sorting", () => {
+    const assetsButton = (name: string) =>
+      within(screen.getByRole("table", { name: "Assets" })).getByRole("button", { name });
+
+    it("should sort Z-A when the Account header is clicked", async () => {
+      vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+      renderView();
+      await screen.findByTitle("assets:cash");
+      await userEvent.click(assetsButton("Account"));
+      expect(accountOrder("Assets")).toEqual(["assets:darka:etf:sxr8", "assets:cash", "assets:bank"]);
+    });
+
+    it("should sort by market value, biggest first, when the Value header is clicked", async () => {
+      vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+      renderView();
+      await screen.findByTitle("assets:cash");
+      // €1,920.15 (darka) > €115.57 (cash) > €50.00 (bank).
+      await userEvent.click(assetsButton("Value"));
+      expect(accountOrder("Assets")).toEqual(["assets:darka:etf:sxr8", "assets:cash", "assets:bank"]);
+      // A second click flips to smallest first.
+      await userEvent.click(assetsButton("Value"));
+      expect(accountOrder("Assets")).toEqual(["assets:bank", "assets:cash", "assets:darka:etf:sxr8"]);
+    });
+
+    it("should sort by the native quantity, biggest first, when the Holding header is clicked", async () => {
+      vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+      renderView();
+      await screen.findByTitle("assets:cash");
+      // Primary native quantities: cash=1,408.26, bank=50, darka=22.45 — a
+      // plain number sort so the column reads monotonic.
+      await userEvent.click(assetsButton("Holding"));
+      expect(accountOrder("Assets")).toEqual(["assets:cash", "assets:bank", "assets:darka:etf:sxr8"]);
+      // A second click flips to smallest first.
+      await userEvent.click(assetsButton("Holding"));
+      expect(accountOrder("Assets")).toEqual(["assets:darka:etf:sxr8", "assets:bank", "assets:cash"]);
+    });
+
+    it("should keep each section's sorting independent", async () => {
+      vi.mocked(ledgerApi.balanceSheet).mockResolvedValue({
+        ...DATA,
+        sections: [
+          DATA.sections[0] as BalanceSheet["sections"][number],
+          {
+            name: "Liabilities",
+            rows: [
+              { name: "liabilities:card", amounts: [A("EUR", 100)], value: [A("EUR", 100)] },
+              { name: "liabilities:loan", amounts: [A("EUR", 900)], value: [A("EUR", 900)] },
+            ],
+            total: { amounts: [A("EUR", 1000)], value: [A("EUR", 1000)] },
+          },
+        ],
+      });
+      renderView();
+      await screen.findByTitle("assets:cash");
+      const liabilitiesValue = within(screen.getByRole("table", { name: "Liabilities" })).getByRole("button", {
+        name: "Value",
+      });
+      await userEvent.click(liabilitiesValue);
+      // Liabilities re-sorted by value, biggest first...
+      expect(accountOrder("Liabilities")).toEqual(["liabilities:loan", "liabilities:card"]);
+      // ...while Assets keeps its default A-Z order.
+      expect(accountOrder("Assets")).toEqual(["assets:bank", "assets:cash", "assets:darka:etf:sxr8"]);
+    });
+
+    it("should keep rows without amounts sortable and put bigger same-commodity holdings first", async () => {
+      // A parsed report can emit a row with no amounts at all; it must not
+      // break sorting.
+      vi.mocked(ledgerApi.balanceSheet).mockResolvedValue({
+        sections: [
+          {
+            name: "Assets",
+            rows: [
+              { name: "assets:wallet:small", amounts: [A("EUR", 50)], value: [A("EUR", 50)] },
+              { name: "assets:closed", amounts: [], value: [] },
+              { name: "assets:wallet:big", amounts: [A("EUR", 120)], value: [A("EUR", 120)] },
+            ],
+            total: { amounts: [A("EUR", 170)], value: [A("EUR", 170)] },
+          },
+        ],
+        net: { amounts: [], value: [A("EUR", 170)] },
+      });
+      renderView();
+      await screen.findByTitle("assets:closed");
+      // The amount-less row counts as zero and sinks below real holdings.
+      await userEvent.click(assetsButton("Holding"));
+      expect(accountOrder("Assets")).toEqual(["assets:wallet:big", "assets:wallet:small", "assets:closed"]);
+      // The same for market value.
+      await userEvent.click(assetsButton("Value"));
+      expect(accountOrder("Assets")).toEqual(["assets:wallet:big", "assets:wallet:small", "assets:closed"]);
+    });
+  });
+
+  describe("search", () => {
+    it("should filter every section by account path, case-insensitively", async () => {
+      vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+      renderView();
+      await screen.findByTitle("assets:cash");
+      await userEvent.type(screen.getByRole("searchbox", { name: "Search accounts" }), "CASH");
+      expect(accountOrder("Assets")).toEqual(["assets:cash"]);
+      // The liabilities table has no matching account.
+      expect(
+        within(screen.getByRole("table", { name: "Liabilities" })).getByText("No matching accounts"),
+      ).toBeInTheDocument();
+    });
+
+    it("should show empty messages when nothing matches, and restore rows when cleared", async () => {
+      vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+      renderView();
+      await screen.findByTitle("assets:cash");
+      const box = screen.getByRole("searchbox", { name: "Search accounts" });
+      await userEvent.type(box, "zzz");
+      expect(screen.getAllByText("No matching accounts")).toHaveLength(2);
+      await userEvent.clear(box);
+      expect(accountOrder("Assets")).toHaveLength(3);
+    });
+  });
+
+  it("should show the empty state when the report has no accounts", async () => {
+    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(EMPTY);
+    renderView();
+    expect(await screen.findByText("No accounts yet")).toBeInTheDocument();
+    expect(screen.getByText(/Ask the agent to record your first transaction/)).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    // No rows — nothing to search either.
+    expect(screen.queryByRole("searchbox")).not.toBeInTheDocument();
+  });
+
+  it("should fall back to the empty state when the report query rejects", async () => {
+    vi.mocked(ledgerApi.balanceSheet).mockRejectedValue(new Error("bridge down"));
+    renderView();
+    expect(await screen.findByText("No accounts yet")).toBeInTheDocument();
+  });
+
+  it("should refetch the report when the agent goes from running to idle", async () => {
+    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+    const { rerender } = renderView(false);
+    await screen.findByText("115.57 EUR");
+    expect(ledgerApi.balanceSheet).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <Chrome isRunning={true}>
+        <BalanceSheetView />
+      </Chrome>,
+    );
+    // Flush the runtime's async store propagation before asserting no refetch
+    // happened on the idle → running edge.
+    await act(async () => {});
+    expect(ledgerApi.balanceSheet).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <Chrome isRunning={false}>
+        <BalanceSheetView />
+      </Chrome>,
+    );
+    await waitFor(() => expect(ledgerApi.balanceSheet).toHaveBeenCalledTimes(2));
+  });
+
+  it("should keep the current rows visible while a refetch is in flight", async () => {
+    vi.mocked(ledgerApi.balanceSheet)
+      .mockResolvedValueOnce(DATA)
+      .mockReturnValue(new Promise(() => {}));
+    const { rerender } = renderView(false);
+    await screen.findByText("115.57 EUR");
+
+    rerender(
+      <Chrome isRunning={true}>
+        <BalanceSheetView />
+      </Chrome>,
+    );
+    await act(async () => {});
+    rerender(
+      <Chrome isRunning={false}>
+        <BalanceSheetView />
+      </Chrome>,
+    );
+    // Once the refetch is genuinely in flight (its promise never resolves),
+    // the previous rows must still be up, with no skeleton.
+    await waitFor(() => expect(ledgerApi.balanceSheet).toHaveBeenCalledTimes(2));
+    expect(screen.getByText("115.57 EUR")).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+});

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/balance-sheet-view.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/balance-sheet-view.test.tsx
@@ -55,9 +55,14 @@ const DATA: BalanceSheet = {
     {
       name: "Assets",
       rows: [
-        { name: "assets:cash", amounts: [A("UAH", 1408.26), A("USD", 100)], value: [A("EUR", 115.573, 3)] },
+        {
+          name: "assets:cash",
+          amounts: [A("UAH", 1408.26), A("USD", 100)],
+          value: [A("EUR", 115.573, 3)],
+          assertedOn: "2026-06-15",
+        },
         { name: "assets:darka:etf:sxr8", amounts: [A("SXR8", 22.45)], value: [A("EUR", 1920.148, 3)] },
-        { name: "assets:bank", amounts: [A("EUR", 50)], value: [A("EUR", 50)] },
+        { name: "assets:bank", amounts: [A("EUR", 50)], value: [A("EUR", 50)], assertedOn: "2026-07-12" },
       ],
       total: {
         amounts: [A("UAH", 1408.26), A("USD", 100), A("SXR8", 22.45), A("EUR", 50)],
@@ -172,6 +177,18 @@ describe("<BalanceSheetView />", () => {
     expect(screen.queryByText("~50.00 EUR")).not.toBeInTheDocument();
   });
 
+  it("should show each account's last balance assertion date, and an em dash when it was never asserted", async () => {
+    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+    renderView();
+    // One sortable header per section table.
+    expect(await screen.findAllByRole("button", { name: "Last Balance Assertion" })).toHaveLength(2);
+    // The journal's own ISO dates, verbatim.
+    expect(screen.getByText("2026-07-12")).toBeInTheDocument();
+    expect(screen.getByText("2026-06-15")).toBeInTheDocument();
+    // Never asserted: the SXR8 account and the liability.
+    expect(screen.getAllByText("\u2014")).toHaveLength(2);
+  });
+
   it("should show a multi-commodity holding comma-joined on one line", async () => {
     vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
     renderView();
@@ -245,6 +262,18 @@ describe("<BalanceSheetView />", () => {
       // A second click flips to smallest first.
       await userEvent.click(assetsButton("Holding"));
       expect(accountOrder("Assets")).toEqual(["assets:darka:etf:sxr8", "assets:bank", "assets:cash"]);
+    });
+
+    it("should sort by assertion date, most recent first, with never-asserted rows last", async () => {
+      vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+      renderView();
+      await screen.findByTitle("assets:cash");
+      await userEvent.click(assetsButton("Last Balance Assertion"));
+      // bank (07-12) > cash (06-15) > darka (never asserted).
+      expect(accountOrder("Assets")).toEqual(["assets:bank", "assets:cash", "assets:darka:etf:sxr8"]);
+      // A second click flips: never-asserted first, then oldest.
+      await userEvent.click(assetsButton("Last Balance Assertion"));
+      expect(accountOrder("Assets")).toEqual(["assets:darka:etf:sxr8", "assets:cash", "assets:bank"]);
     });
 
     it("should keep each section's sorting independent", async () => {

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/balance-sheet.integration.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/balance-sheet.integration.test.tsx
@@ -145,16 +145,15 @@ describe("Balance Sheet view flow", () => {
     expect((thread.parentElement as HTMLElement).className).toContain("hidden");
   });
 
-  it("should return to the chat, without extra IPC, when Balance Sheet is toggled closed", async () => {
+  it("should ignore a second click on the active entry: the page stays, with no extra IPC", async () => {
     render(<ChatLayout />);
     openSheet();
     await screen.findByTitle("assets:cash");
 
     openSheet();
 
-    expect(screen.queryByTitle("assets:cash")).toBeNull();
-    expect((screen.getByTestId("thread").parentElement as HTMLElement).className).not.toContain("hidden");
-    expect(screen.getByRole("button", { name: "Balance Sheet" })).not.toHaveAttribute("data-active");
+    expect(screen.getByTitle("assets:cash")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Balance Sheet" })).toHaveAttribute("data-active");
     expect(bridge.callsFor("ledger_balance_sheet")).toHaveLength(1);
   });
 
@@ -162,7 +161,9 @@ describe("Balance Sheet view flow", () => {
     render(<ChatLayout />);
     openSheet();
     await screen.findByTitle("assets:cash");
-    openSheet();
+    // Returning to the chat goes through new chat (Cmd/Ctrl+N), not the entry.
+    fireEvent.keyDown(document.body, { key: "n", metaKey: true });
+    expect(screen.queryByTitle("assets:cash")).toBeNull();
 
     openSheet();
     await screen.findByTitle("assets:cash");

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/balance-sheet.integration.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/balance-sheet.integration.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+
+// Integration: the Balance Sheet flow across real ChatLayout + real
+// BalanceSheetView + the real rpc/api layer, over the fake `window.api`
+// bridge. Asserts both the UI and the exact IPC traffic. The pi runtime and
+// heavy chat children are stubbed (they have their own suites); the IPC
+// boundary is the fake bridge.
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { installJsdomPolyfills } from "@/test/jsdomPolyfills";
+
+// rpc/api.ts captures `window.api` at module load — install the fake bridge
+// before any import pulls it in (async vi.hoisted runs before the imports).
+const bridge = await vi.hoisted(async () => (await import("@/test/fakeApi")).installFakeApi());
+
+// The pi runtime surface ChatLayout drives; only what this flow touches.
+vi.mock("@assistant-ui/react", () => ({
+  AssistantRuntimeProvider: ({ children }: { children: React.ReactNode }) => children,
+  CompositeAttachmentAdapter: class {},
+  useAuiState: (sel: (s: unknown) => unknown) => sel({ thread: { isRunning: false } }),
+}));
+vi.mock("@assistant-ui/react-pi", () => ({
+  usePiRuntime: () => ({ threads: { switchToNewThread: vi.fn() } }),
+}));
+vi.mock("@/runtime/electronPiClient", () => ({
+  createElectronPiClient: () => ({ getThread: vi.fn() }),
+}));
+vi.mock("@/runtime/fileAttachmentAdapter", () => ({
+  ArchivingImageAttachmentAdapter: class {},
+  WorkspaceFileAttachmentAdapter: class {},
+}));
+vi.mock("@/runtime/agentBridge", () => ({
+  agentBridge: { addEventListener: () => () => {} },
+}));
+
+// Heavy chat children with their own suites; the Balance Sheet view stays REAL.
+vi.mock("../thread", () => ({ Thread: () => <div data-testid="thread" /> }));
+vi.mock("../thread-list", () => ({
+  ThreadList: () => <div data-testid="thread-list" />,
+  ThreadListNew: () => <div data-testid="thread-list-new" />,
+}));
+vi.mock("../settings/settings", () => ({ Settings: () => null }));
+
+import type { BalanceSheet } from "@/rpc/types";
+import { ChatLayout } from "../chat-layout";
+
+const DATA: BalanceSheet = {
+  sections: [
+    {
+      name: "Assets",
+      rows: [
+        {
+          name: "assets:cash",
+          amounts: [{ quantity: 100, commodity: "USD", precision: 2 }],
+          value: [{ quantity: 86, commodity: "EUR", precision: 2 }],
+        },
+        {
+          name: "assets:checking",
+          amounts: [{ quantity: 2950, commodity: "EUR", precision: 2 }],
+          value: [{ quantity: 2950, commodity: "EUR", precision: 2 }],
+        },
+      ],
+      total: {
+        amounts: [{ quantity: 3036, commodity: "EUR", precision: 2 }],
+        value: [{ quantity: 3036, commodity: "EUR", precision: 2 }],
+      },
+    },
+    {
+      name: "Liabilities",
+      rows: [
+        {
+          name: "liabilities:card",
+          amounts: [{ quantity: 300, commodity: "EUR", precision: 2 }],
+          value: [{ quantity: 300, commodity: "EUR", precision: 2 }],
+        },
+      ],
+      total: {
+        amounts: [{ quantity: 300, commodity: "EUR", precision: 2 }],
+        value: [{ quantity: 300, commodity: "EUR", precision: 2 }],
+      },
+    },
+  ],
+  net: {
+    amounts: [{ quantity: 2736, commodity: "EUR", precision: 2 }],
+    value: [{ quantity: 2736, commodity: "EUR", precision: 2 }],
+  },
+};
+
+beforeAll(() => {
+  installJsdomPolyfills();
+  // The sidebar seeds its width from localStorage, which this jsdom env omits.
+  if (!window.localStorage) {
+    const store = new Map<string, string>();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (k: string) => store.get(k) ?? null,
+        setItem: (k: string, v: string) => void store.set(k, String(v)),
+        removeItem: (k: string) => void store.delete(k),
+        clear: () => store.clear(),
+        key: (i: number) => [...store.keys()][i] ?? null,
+        get length() {
+          return store.size;
+        },
+      },
+    });
+  }
+});
+
+beforeEach(() => {
+  bridge.reset();
+  bridge.setHandler("update_pending", () => null);
+  bridge.setHandler("ledger_balance_sheet", () => DATA);
+});
+
+afterEach(() => cleanup());
+
+const openSheet = () => fireEvent.click(screen.getByRole("button", { name: "Balance Sheet" }));
+
+describe("Balance Sheet view flow", () => {
+  it("should fetch the report over IPC exactly once and render both sections when Balance Sheet is opened", async () => {
+    render(<ChatLayout />);
+    expect(bridge.callsFor("ledger_balance_sheet")).toHaveLength(0);
+
+    openSheet();
+
+    expect(await screen.findByTitle("assets:cash")).toBeInTheDocument();
+    expect(screen.getByTitle("assets:checking")).toBeInTheDocument();
+    expect(screen.getByText("86.00 EUR")).toBeInTheDocument();
+    expect(screen.getByTitle("liabilities:card")).toBeInTheDocument();
+    expect(bridge.callsFor("ledger_balance_sheet")).toHaveLength(1);
+  });
+
+  it("should mark the sidebar entry active and keep the chat mounted but hidden while open", async () => {
+    render(<ChatLayout />);
+    openSheet();
+    await screen.findByTitle("assets:cash");
+
+    expect(screen.getByRole("button", { name: "Balance Sheet" })).toHaveAttribute("data-active");
+    const thread = screen.getByTestId("thread");
+    expect(thread).toBeInTheDocument();
+    expect((thread.parentElement as HTMLElement).className).toContain("hidden");
+  });
+
+  it("should return to the chat, without extra IPC, when Balance Sheet is toggled closed", async () => {
+    render(<ChatLayout />);
+    openSheet();
+    await screen.findByTitle("assets:cash");
+
+    openSheet();
+
+    expect(screen.queryByTitle("assets:cash")).toBeNull();
+    expect((screen.getByTestId("thread").parentElement as HTMLElement).className).not.toContain("hidden");
+    expect(screen.getByRole("button", { name: "Balance Sheet" })).not.toHaveAttribute("data-active");
+    expect(bridge.callsFor("ledger_balance_sheet")).toHaveLength(1);
+  });
+
+  it("should fetch a fresh report on every open", async () => {
+    render(<ChatLayout />);
+    openSheet();
+    await screen.findByTitle("assets:cash");
+    openSheet();
+
+    openSheet();
+    await screen.findByTitle("assets:cash");
+    expect(bridge.callsFor("ledger_balance_sheet")).toHaveLength(2);
+  });
+
+  it("should show the empty state when the report has no accounts", async () => {
+    bridge.setHandler("ledger_balance_sheet", () => ({ sections: [], net: { amounts: [], value: [] } }));
+    render(<ChatLayout />);
+    openSheet();
+
+    expect(await screen.findByText("No accounts yet")).toBeInTheDocument();
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+});

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/balance-sheet.integration.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/balance-sheet.integration.test.tsx
@@ -54,6 +54,7 @@ const DATA: BalanceSheet = {
           name: "assets:cash",
           amounts: [{ quantity: 100, commodity: "USD", precision: 2 }],
           value: [{ quantity: 86, commodity: "EUR", precision: 2 }],
+          assertedOn: "2026-07-01",
         },
         {
           name: "assets:checking",
@@ -129,6 +130,7 @@ describe("Balance Sheet view flow", () => {
     expect(screen.getByTitle("assets:checking")).toBeInTheDocument();
     expect(screen.getByText("~86.00 EUR")).toBeInTheDocument();
     expect(screen.getByTitle("liabilities:card")).toBeInTheDocument();
+    expect(screen.getByText("2026-07-01")).toBeInTheDocument();
     expect(bridge.callsFor("ledger_balance_sheet")).toHaveLength(1);
   });
 

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/balance-sheet.integration.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/balance-sheet.integration.test.tsx
@@ -127,7 +127,7 @@ describe("Balance Sheet view flow", () => {
 
     expect(await screen.findByTitle("assets:cash")).toBeInTheDocument();
     expect(screen.getByTitle("assets:checking")).toBeInTheDocument();
-    expect(screen.getByText("86.00 EUR")).toBeInTheDocument();
+    expect(screen.getByText("~86.00 EUR")).toBeInTheDocument();
     expect(screen.getByTitle("liabilities:card")).toBeInTheDocument();
     expect(bridge.callsFor("ledger_balance_sheet")).toHaveLength(1);
   });

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/chat-layout.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/chat-layout.test.tsx
@@ -247,14 +247,14 @@ describe("ChatLayout Balance Sheet view", () => {
     expect(sheetButton()).toHaveAttribute("data-active");
   });
 
-  it("should return to the chat when the active Balance Sheet entry is clicked again", () => {
+  it("should keep the Balance Sheet open when the active entry is clicked again", () => {
     render(<ChatLayout />);
     fireEvent.click(sheetButton());
     fireEvent.click(sheetButton());
 
-    expect(screen.queryByTestId("balance-sheet-view")).toBeNull();
-    expect(threadWrapper().className).not.toContain("hidden");
-    expect(sheetButton()).not.toHaveAttribute("data-active");
+    expect(screen.getByTestId("balance-sheet-view")).toBeInTheDocument();
+    expect(threadWrapper().className).toContain("hidden");
+    expect(sheetButton()).toHaveAttribute("data-active");
   });
 
   it("should return to the chat when a thread is selected in the sidebar", () => {

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/chat-layout.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/chat-layout.test.tsx
@@ -105,8 +105,8 @@ vi.mock("@/rpc/api", () => ({
 // stubs surface their selection callbacks as buttons so tests can fire them.
 vi.mock("../thread", () => ({ Thread: () => <div data-testid="thread" /> }));
 vi.mock("../thread-list", () => ({
-  ThreadList: ({ onSelectThread }: { onSelectThread?: () => void }) => (
-    <div data-testid="thread-list">
+  ThreadList: ({ onSelectThread, highlightActive }: { onSelectThread?: () => void; highlightActive?: boolean }) => (
+    <div data-testid="thread-list" data-highlight-active={String(highlightActive)}>
       <button type="button" onClick={onSelectThread}>
         Select thread stub
       </button>
@@ -120,7 +120,7 @@ vi.mock("../thread-list", () => ({
     </div>
   ),
 }));
-vi.mock("../balance-sheet-view", () => ({ BalanceSheetView: () => <div data-testid="balance-sheet-view" /> }));
+vi.mock("../net-worth-view", () => ({ NetWorthView: () => <div data-testid="net-worth-view" /> }));
 // The Settings dialog is a real dialog elsewhere; here a light stub that mirrors
 // the `open` prop, so we can assert ChatLayout opens/closes it.
 vi.mock("../settings/settings", () => ({
@@ -224,35 +224,46 @@ describe("ChatLayout Settings dialog", () => {
   });
 });
 
-describe("ChatLayout Balance Sheet view", () => {
-  const sheetButton = () => screen.getByRole("button", { name: "Balance Sheet" });
+describe("ChatLayout Net Worth view", () => {
+  const sheetButton = () => screen.getByRole("button", { name: "Net Worth" });
   /** The wrapper ChatLayout hides (display:none) while Accounts is open — the
    *  CSS contract for "the chat survives the switch" (jsdom applies no CSS). */
   const threadWrapper = () => screen.getByTestId("thread").parentElement as HTMLElement;
 
-  it("should not show the Balance Sheet view initially", () => {
+  it("should not show the Net Worth view initially", () => {
     render(<ChatLayout />);
-    expect(screen.queryByTestId("balance-sheet-view")).toBeNull();
+    expect(screen.queryByTestId("net-worth-view")).toBeNull();
     expect(sheetButton()).not.toHaveAttribute("data-active");
   });
 
-  it("should show the Balance Sheet view and keep the chat mounted but hidden when Balance Sheet is clicked", () => {
+  it("should show the Net Worth view and keep the chat mounted but hidden when Net Worth is clicked", () => {
     render(<ChatLayout />);
     fireEvent.click(sheetButton());
 
-    expect(screen.getByTestId("balance-sheet-view")).toBeInTheDocument();
+    expect(screen.getByTestId("net-worth-view")).toBeInTheDocument();
     // The thread is still in the document (state preserved), only hidden.
     expect(screen.getByTestId("thread")).toBeInTheDocument();
     expect(threadWrapper().className).toContain("hidden");
     expect(sheetButton()).toHaveAttribute("data-active");
   });
 
-  it("should keep the Balance Sheet open when the active entry is clicked again", () => {
+  it("should mute the thread highlight while the Net Worth is open, and restore it back in the chat", () => {
+    render(<ChatLayout />);
+    expect(screen.getByTestId("thread-list")).toHaveAttribute("data-highlight-active", "true");
+
+    fireEvent.click(sheetButton());
+    expect(screen.getByTestId("thread-list")).toHaveAttribute("data-highlight-active", "false");
+
+    fireEvent.keyDown(document.body, { key: "n", metaKey: true });
+    expect(screen.getByTestId("thread-list")).toHaveAttribute("data-highlight-active", "true");
+  });
+
+  it("should keep the Net Worth open when the active entry is clicked again", () => {
     render(<ChatLayout />);
     fireEvent.click(sheetButton());
     fireEvent.click(sheetButton());
 
-    expect(screen.getByTestId("balance-sheet-view")).toBeInTheDocument();
+    expect(screen.getByTestId("net-worth-view")).toBeInTheDocument();
     expect(threadWrapper().className).toContain("hidden");
     expect(sheetButton()).toHaveAttribute("data-active");
   });
@@ -262,7 +273,7 @@ describe("ChatLayout Balance Sheet view", () => {
     fireEvent.click(sheetButton());
     fireEvent.click(screen.getByRole("button", { name: "Select thread stub" }));
 
-    expect(screen.queryByTestId("balance-sheet-view")).toBeNull();
+    expect(screen.queryByTestId("net-worth-view")).toBeNull();
     expect(threadWrapper().className).not.toContain("hidden");
   });
 
@@ -271,7 +282,7 @@ describe("ChatLayout Balance Sheet view", () => {
     fireEvent.click(sheetButton());
     fireEvent.click(screen.getByRole("button", { name: "New chat stub" }));
 
-    expect(screen.queryByTestId("balance-sheet-view")).toBeNull();
+    expect(screen.queryByTestId("net-worth-view")).toBeNull();
     expect(threadWrapper().className).not.toContain("hidden");
   });
 
@@ -280,7 +291,7 @@ describe("ChatLayout Balance Sheet view", () => {
     fireEvent.click(sheetButton());
     fireEvent.keyDown(document.body, { key: "n", metaKey: true });
 
-    expect(screen.queryByTestId("balance-sheet-view")).toBeNull();
+    expect(screen.queryByTestId("net-worth-view")).toBeNull();
     expect(threadWrapper().className).not.toContain("hidden");
     expect(h.switchToNewThread).toHaveBeenCalledTimes(1);
   });

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/chat-layout.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/chat-layout.test.tsx
@@ -91,19 +91,36 @@ vi.mock("@/rpc/api", () => ({
     get: vi.fn().mockResolvedValue({ enabledModels: [], defaultModel: undefined }),
     onChange: () => () => {},
   },
-  ledgerApi: { mentions: vi.fn().mockResolvedValue({ accounts: [], payees: [], tags: [] }) },
+  ledgerApi: {
+    mentions: vi.fn().mockResolvedValue({ accounts: [], payees: [], tags: [] }),
+    balances: vi.fn().mockResolvedValue([]),
+  },
   skillsApi: { list: vi.fn().mockResolvedValue({ skills: [] }) },
   sessionsApi: { list: vi.fn().mockResolvedValue({ type: "ok", sessions: [] }) },
   appApi: { version: vi.fn().mockResolvedValue("1.0.0") },
 }));
 
 // Heavy children: ChatLayout only composes them, and each has its own test file.
-// Stubbing keeps this suite focused on ChatLayout's own wiring.
+// Stubbing keeps this suite focused on ChatLayout's own wiring. The thread-list
+// stubs surface their selection callbacks as buttons so tests can fire them.
 vi.mock("../thread", () => ({ Thread: () => <div data-testid="thread" /> }));
 vi.mock("../thread-list", () => ({
-  ThreadList: () => <div data-testid="thread-list" />,
-  ThreadListNew: () => <div data-testid="thread-list-new" />,
+  ThreadList: ({ onSelectThread }: { onSelectThread?: () => void }) => (
+    <div data-testid="thread-list">
+      <button type="button" onClick={onSelectThread}>
+        Select thread stub
+      </button>
+    </div>
+  ),
+  ThreadListNew: ({ onSelect }: { onSelect?: () => void }) => (
+    <div data-testid="thread-list-new">
+      <button type="button" onClick={onSelect}>
+        New chat stub
+      </button>
+    </div>
+  ),
 }));
+vi.mock("../balance-sheet-view", () => ({ BalanceSheetView: () => <div data-testid="balance-sheet-view" /> }));
 // The Settings dialog is a real dialog elsewhere; here a light stub that mirrors
 // the `open` prop, so we can assert ChatLayout opens/closes it.
 vi.mock("../settings/settings", () => ({
@@ -204,6 +221,68 @@ describe("ChatLayout Settings dialog", () => {
     fireEvent.click(screen.getByRole("button", { name: "Settings" }));
     fireEvent.click(screen.getByRole("button", { name: "Close settings" }));
     expect(screen.queryByRole("dialog", { name: "Settings" })).toBeNull();
+  });
+});
+
+describe("ChatLayout Balance Sheet view", () => {
+  const sheetButton = () => screen.getByRole("button", { name: "Balance Sheet" });
+  /** The wrapper ChatLayout hides (display:none) while Accounts is open — the
+   *  CSS contract for "the chat survives the switch" (jsdom applies no CSS). */
+  const threadWrapper = () => screen.getByTestId("thread").parentElement as HTMLElement;
+
+  it("should not show the Balance Sheet view initially", () => {
+    render(<ChatLayout />);
+    expect(screen.queryByTestId("balance-sheet-view")).toBeNull();
+    expect(sheetButton()).not.toHaveAttribute("data-active");
+  });
+
+  it("should show the Balance Sheet view and keep the chat mounted but hidden when Balance Sheet is clicked", () => {
+    render(<ChatLayout />);
+    fireEvent.click(sheetButton());
+
+    expect(screen.getByTestId("balance-sheet-view")).toBeInTheDocument();
+    // The thread is still in the document (state preserved), only hidden.
+    expect(screen.getByTestId("thread")).toBeInTheDocument();
+    expect(threadWrapper().className).toContain("hidden");
+    expect(sheetButton()).toHaveAttribute("data-active");
+  });
+
+  it("should return to the chat when the active Balance Sheet entry is clicked again", () => {
+    render(<ChatLayout />);
+    fireEvent.click(sheetButton());
+    fireEvent.click(sheetButton());
+
+    expect(screen.queryByTestId("balance-sheet-view")).toBeNull();
+    expect(threadWrapper().className).not.toContain("hidden");
+    expect(sheetButton()).not.toHaveAttribute("data-active");
+  });
+
+  it("should return to the chat when a thread is selected in the sidebar", () => {
+    render(<ChatLayout />);
+    fireEvent.click(sheetButton());
+    fireEvent.click(screen.getByRole("button", { name: "Select thread stub" }));
+
+    expect(screen.queryByTestId("balance-sheet-view")).toBeNull();
+    expect(threadWrapper().className).not.toContain("hidden");
+  });
+
+  it("should return to the chat when a new chat is started from the sidebar", () => {
+    render(<ChatLayout />);
+    fireEvent.click(sheetButton());
+    fireEvent.click(screen.getByRole("button", { name: "New chat stub" }));
+
+    expect(screen.queryByTestId("balance-sheet-view")).toBeNull();
+    expect(threadWrapper().className).not.toContain("hidden");
+  });
+
+  it("should return to the chat on the Cmd/Ctrl+N shortcut", () => {
+    render(<ChatLayout />);
+    fireEvent.click(sheetButton());
+    fireEvent.keyDown(document.body, { key: "n", metaKey: true });
+
+    expect(screen.queryByTestId("balance-sheet-view")).toBeNull();
+    expect(threadWrapper().className).not.toContain("hidden");
+    expect(h.switchToNewThread).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/chat-layout.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/chat-layout.test.tsx
@@ -121,6 +121,7 @@ vi.mock("../thread-list", () => ({
   ),
 }));
 vi.mock("../net-worth-view", () => ({ NetWorthView: () => <div data-testid="net-worth-view" /> }));
+vi.mock("../net-worth-badge", () => ({ NetWorthBadge: () => null }));
 // The Settings dialog is a real dialog elsewhere; here a light stub that mirrors
 // the `open` prop, so we can assert ChatLayout opens/closes it.
 vi.mock("../settings/settings", () => ({

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-badge.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-badge.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+// Spec for the sidebar's net worth badge: nothing while the report loads or
+// is empty, the compact ~ figure once loaded, and a refresh on the agent's
+// running → idle edge. jsdom pins navigator.language to en-US, so the
+// compact expectations are deterministic.
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// IPC boundary: the badge reads the report over the Electron bridge.
+vi.mock("@/rpc/api", () => ({
+  ledgerApi: { netWorth: vi.fn() },
+}));
+
+import { AssistantRuntimeProvider, type ExternalStoreAdapter, useExternalStoreRuntime } from "@assistant-ui/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { ledgerApi } from "@/rpc/api";
+import type { NetWorth } from "@/rpc/types";
+import { installJsdomPolyfills } from "@/test/jsdomPolyfills";
+import { NetWorthBadge } from "../net-worth-badge";
+
+beforeAll(() => installJsdomPolyfills());
+afterEach(() => cleanup());
+beforeEach(() => {
+  vi.mocked(ledgerApi.netWorth).mockReset();
+});
+
+/** Real assistant-ui chrome so the badge's `useAuiState` reads an honest
+ *  `thread.isRunning`; the prop drives the running → idle refetch edge. */
+function Chrome({ children, isRunning = false }: { children: ReactNode; isRunning?: boolean }) {
+  const store: ExternalStoreAdapter = {
+    messages: [],
+    isRunning,
+    onNew: async () => {},
+    convertMessage: (m: unknown) => m,
+  } as unknown as ExternalStoreAdapter;
+  const runtime = useExternalStoreRuntime(store);
+  return <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>;
+}
+
+const sheet = (net: NetWorth["net"]): NetWorth => ({ sections: [], net });
+
+const CONVERTED = sheet({
+  amounts: [{ quantity: 1408.26, commodity: "UAH", precision: 2 }],
+  value: [{ quantity: 333534.3, commodity: "EUR", precision: 2 }],
+});
+
+const renderBadge = (isRunning = false) =>
+  render(
+    <Chrome isRunning={isRunning}>
+      <NetWorthBadge />
+    </Chrome>,
+  );
+
+describe("<NetWorthBadge />", () => {
+  it("should render nothing while the report is loading", () => {
+    vi.mocked(ledgerApi.netWorth).mockReturnValue(new Promise(() => {}));
+    const { container } = renderBadge();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("should show the compact figure with ~ when the net worth is a converted estimate", async () => {
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(CONVERTED);
+    renderBadge();
+    expect(await screen.findByText("~334K EUR")).toBeInTheDocument();
+  });
+
+  it("should show the compact figure without ~ when nothing was converted", async () => {
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(
+      sheet({
+        amounts: [{ quantity: 2736, commodity: "EUR", precision: 2 }],
+        value: [{ quantity: 2736, commodity: "EUR", precision: 2 }],
+      }),
+    );
+    renderBadge();
+    expect(await screen.findByText("2.7K EUR")).toBeInTheDocument();
+  });
+
+  it("should render nothing when the report has no value (empty journal)", async () => {
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(sheet({ amounts: [], value: [] }));
+    const { container } = renderBadge();
+    await waitFor(() => expect(ledgerApi.netWorth).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("should refetch and update the figure when the agent turn finishes", async () => {
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(CONVERTED);
+    const { rerender } = renderBadge(true);
+    expect(await screen.findByText("~334K EUR")).toBeInTheDocument();
+
+    // The finished turn changed the ledger: the badge must show the new figure.
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(
+      sheet({
+        amounts: [{ quantity: 1500.26, commodity: "UAH", precision: 2 }],
+        value: [{ quantity: 400123.4, commodity: "EUR", precision: 2 }],
+      }),
+    );
+    rerender(
+      <Chrome isRunning={false}>
+        <NetWorthBadge />
+      </Chrome>,
+    );
+    expect(await screen.findByText("~400K EUR")).toBeInTheDocument();
+    expect(ledgerApi.netWorth).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-view.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-view.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-// Spec for the Balance Sheet view: skeleton while the first load is in
+// Spec for the Net Worth view: skeleton while the first load is in
 // flight, a pinned title and search box, one data table per `hledger bs`
 // section (Assets, Liabilities — the latter already sign-flipped positive by
 // hledger) with the section's own total, the hledger-computed Net as the
@@ -14,7 +14,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 
 // IPC boundary: the view reads the bs report over the Electron bridge.
 vi.mock("@/rpc/api", () => ({
-  ledgerApi: { balanceSheet: vi.fn() },
+  ledgerApi: { netWorth: vi.fn() },
 }));
 
 import { AssistantRuntimeProvider, type ExternalStoreAdapter, useExternalStoreRuntime } from "@assistant-ui/react";
@@ -22,14 +22,14 @@ import { act, cleanup, render, screen, waitFor, within } from "@testing-library/
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { ledgerApi } from "@/rpc/api";
-import type { BalanceSheet, LedgerAmount } from "@/rpc/types";
+import type { LedgerAmount, NetWorth } from "@/rpc/types";
 import { installJsdomPolyfills } from "@/test/jsdomPolyfills";
-import { BalanceSheetView } from "../balance-sheet-view";
+import { NetWorthView } from "../net-worth-view";
 
 beforeAll(() => installJsdomPolyfills());
 afterEach(() => cleanup());
 beforeEach(() => {
-  vi.mocked(ledgerApi.balanceSheet).mockReset();
+  vi.mocked(ledgerApi.netWorth).mockReset();
 });
 
 /** Real assistant-ui chrome so the view's `useAuiState` reads an honest
@@ -50,7 +50,7 @@ const A = (commodity: string, quantity: number, precision = 2): LedgerAmount => 
 // A two-section sheet the way hledger bs hands it over: assets with a
 // converted multi-commodity account, a share account, and a plain EUR one;
 // liabilities already positive; hledger's own section totals and net.
-const DATA: BalanceSheet = {
+const DATA: NetWorth = {
   sections: [
     {
       name: "Assets",
@@ -78,12 +78,12 @@ const DATA: BalanceSheet = {
   net: { amounts: [A("UAH", 1408.26), A("USD", 100), A("SXR8", 22.45), A("EUR", -296.75)], value: [A("EUR", 1738.97)] },
 };
 
-const EMPTY: BalanceSheet = { sections: [], net: { amounts: [], value: [] } };
+const EMPTY: NetWorth = { sections: [], net: { amounts: [], value: [] } };
 
 const renderView = (isRunning = false) =>
   render(
     <Chrome isRunning={isRunning}>
-      <BalanceSheetView />
+      <NetWorthView />
     </Chrome>,
   );
 
@@ -95,9 +95,9 @@ const accountOrder = (tableName: string) =>
     .slice(1) // the column-header row
     .map((row) => row.querySelector("td")?.getAttribute("title"));
 
-describe("<BalanceSheetView />", () => {
+describe("<NetWorthView />", () => {
   it("should show the page chrome immediately and skeletons only for the loading data", () => {
-    vi.mocked(ledgerApi.balanceSheet).mockReturnValue(new Promise(() => {}));
+    vi.mocked(ledgerApi.netWorth).mockReturnValue(new Promise(() => {}));
     renderView();
     expect(screen.getByRole("status", { name: "Loading accounts" })).toBeInTheDocument();
     // Everything that needs no data is up before the report arrives: the
@@ -105,20 +105,21 @@ describe("<BalanceSheetView />", () => {
     expect(screen.getByRole("searchbox", { name: "Search accounts" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 2, name: "Assets" })).toBeInTheDocument();
     expect(screen.getByText("Account")).toBeInTheDocument();
-    expect(screen.getByText("Net")).toBeInTheDocument();
+    // The Net Worth band (the page h1 reads Net Worth too, hence the selector).
+    expect(screen.getByText("Net Worth", { selector: "div" })).toBeInTheDocument();
     // But no figures yet — those are what's loading.
     expect(screen.queryByText(/EUR/)).not.toBeInTheDocument();
   });
 
-  it("should render the pinned Balance Sheet title without a figure", async () => {
-    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+  it("should render the pinned Net Worth title without a figure", async () => {
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
     renderView();
-    expect(await screen.findByRole("heading", { level: 1, name: "Balance Sheet" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { level: 1, name: "Net Worth" })).toBeInTheDocument();
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
 
   it("should render one section per bs subreport, with hledger's own totals", async () => {
-    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
     renderView();
     // Settle on loaded data first — the skeleton also carries an Assets band.
     await screen.findByTitle("assets:cash");
@@ -133,7 +134,7 @@ describe("<BalanceSheetView />", () => {
   });
 
   it("should show liabilities with hledger's positive sign", async () => {
-    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
     renderView();
     expect(await screen.findByTitle("liabilities:creditcard")).toBeInTheDocument();
     // The account row (holding + value) and the section total all read
@@ -143,9 +144,9 @@ describe("<BalanceSheetView />", () => {
   });
 
   it("should render the classic Net line last, with hledger's own figure", async () => {
-    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
     renderView();
-    const net = await screen.findByText("Net");
+    const net = await screen.findByText("Net Worth", { selector: "div" });
     expect(screen.getByText("~1,738.97 EUR")).toBeInTheDocument();
     // Net comes after both section tables in document order.
     const tables = screen.getAllByRole("table");
@@ -154,10 +155,10 @@ describe("<BalanceSheetView />", () => {
   });
 
   it("should not render a section hledger sent empty", async () => {
-    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue({
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue({
       ...DATA,
       sections: [
-        DATA.sections[0] as BalanceSheet["sections"][number],
+        DATA.sections[0] as NetWorth["sections"][number],
         { name: "Liabilities", rows: [], total: { amounts: [], value: [] } },
       ],
     });
@@ -167,7 +168,7 @@ describe("<BalanceSheetView />", () => {
   });
 
   it("should list complete account paths sorted A-Z by default", async () => {
-    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
     renderView();
     expect(await screen.findByTitle("assets:cash")).toHaveTextContent("assets:cash");
     // The fixture arrives in hledger's order (cash, darka, bank); the table
@@ -176,7 +177,7 @@ describe("<BalanceSheetView />", () => {
   });
 
   it("should mark converted row values with ~ and leave exact ones unmarked", async () => {
-    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
     renderView();
     // Converted (UAH+USD and SXR8 valued into EUR): estimates.
     expect(await screen.findByText("~115.57 EUR")).toBeInTheDocument();
@@ -187,7 +188,7 @@ describe("<BalanceSheetView />", () => {
   });
 
   it("should show each account's last balance assertion date, and an em dash when it was never asserted", async () => {
-    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
     renderView();
     // Settle on loaded data first — the skeleton also carries the header.
     await screen.findByTitle("assets:cash");
@@ -201,7 +202,7 @@ describe("<BalanceSheetView />", () => {
   });
 
   it("should show a multi-commodity holding comma-joined on one line", async () => {
-    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
     renderView();
     expect(await screen.findByText("1,408.26 UAH, 100.00 USD")).toBeInTheDocument();
     expect(screen.getByText("22.45 SXR8")).toBeInTheDocument();
@@ -209,7 +210,7 @@ describe("<BalanceSheetView />", () => {
 
   it("should show an unconverted multi-commodity net comma-joined, without ~", async () => {
     // No rates in the journal: the valued run returns the same figures.
-    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue({
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue({
       ...DATA,
       net: { amounts: [A("EUR", 7796.25), A("UAH", 1000)], value: [A("EUR", 7796.25), A("UAH", 1000)] },
     });
@@ -220,7 +221,7 @@ describe("<BalanceSheetView />", () => {
 
   it("should show no ~ anywhere when nothing was converted, totals included", async () => {
     // An all-exact journal: every value equals its native amounts.
-    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue({
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue({
       sections: [
         {
           name: "Assets",
@@ -243,7 +244,7 @@ describe("<BalanceSheetView />", () => {
       within(screen.getByRole("table", { name: "Assets" })).getByRole("button", { name });
 
     it("should sort Z-A when the Account header is clicked", async () => {
-      vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
       await screen.findByTitle("assets:cash");
       await userEvent.click(assetsButton("Account"));
@@ -251,7 +252,7 @@ describe("<BalanceSheetView />", () => {
     });
 
     it("should sort by market value, biggest first, when the Value header is clicked", async () => {
-      vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
       await screen.findByTitle("assets:cash");
       // €1,920.15 (darka) > €115.57 (cash) > €50.00 (bank).
@@ -263,7 +264,7 @@ describe("<BalanceSheetView />", () => {
     });
 
     it("should sort by the native quantity, biggest first, when the Holding header is clicked", async () => {
-      vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
       await screen.findByTitle("assets:cash");
       // Primary native quantities: cash=1,408.26, bank=50, darka=22.45 — a
@@ -276,7 +277,7 @@ describe("<BalanceSheetView />", () => {
     });
 
     it("should sort by assertion date, most recent first, with never-asserted rows last", async () => {
-      vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
       await screen.findByTitle("assets:cash");
       await userEvent.click(assetsButton("Last Balance Assertion"));
@@ -288,10 +289,10 @@ describe("<BalanceSheetView />", () => {
     });
 
     it("should keep each section's sorting independent", async () => {
-      vi.mocked(ledgerApi.balanceSheet).mockResolvedValue({
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue({
         ...DATA,
         sections: [
-          DATA.sections[0] as BalanceSheet["sections"][number],
+          DATA.sections[0] as NetWorth["sections"][number],
           {
             name: "Liabilities",
             rows: [
@@ -317,7 +318,7 @@ describe("<BalanceSheetView />", () => {
     it("should keep rows without amounts sortable and put bigger same-commodity holdings first", async () => {
       // A parsed report can emit a row with no amounts at all; it must not
       // break sorting.
-      vi.mocked(ledgerApi.balanceSheet).mockResolvedValue({
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue({
         sections: [
           {
             name: "Assets",
@@ -342,9 +343,63 @@ describe("<BalanceSheetView />", () => {
     });
   });
 
+  describe("column explanations", () => {
+    const hoverInfo = async (label: string) => {
+      const marker = within(screen.getByRole("table", { name: "Assets" })).getByRole("button", {
+        name: `About ${label}`,
+      });
+      await userEvent.hover(marker);
+    };
+
+    it("should explain the Holding column behind its info marker", async () => {
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
+      renderView();
+      await screen.findByTitle("assets:cash");
+      await hoverInfo("Holding");
+      expect(
+        await screen.findByText(/What the account actually holds: cash in its own currency, shares, or crypto/),
+      ).toBeInTheDocument();
+    });
+
+    it("should explain the Last Balance Assertion column, including the dash", async () => {
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
+      renderView();
+      await screen.findByTitle("assets:cash");
+      await hoverInfo("Last Balance Assertion");
+      expect(
+        await screen.findByText(/When the ledger balance was last confirmed to match the real account balance/),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/A dash means it was never confirmed/)).toBeInTheDocument();
+      // The tooltip also teaches how to confirm one.
+      expect(screen.getByText(/My cash balance is 200 EUR/)).toBeInTheDocument();
+    });
+
+    it("should explain the Value column, including the ~ marker", async () => {
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
+      renderView();
+      await screen.findByTitle("assets:cash");
+      await hoverInfo("Value");
+      expect(
+        await screen.findByText(
+          /What the holding is worth in your main currency, at the latest rate recorded in the ledger/,
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/~ means the value was converted and is an estimate/)).toBeInTheDocument();
+      // The tooltip also teaches how to refresh a rate.
+      expect(screen.getByText(/1 USD is 0.92 EUR/)).toBeInTheDocument();
+    });
+
+    it("should give the Account column no info marker", async () => {
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
+      renderView();
+      await screen.findByTitle("assets:cash");
+      expect(screen.queryByRole("button", { name: "About Account" })).not.toBeInTheDocument();
+    });
+  });
+
   describe("search", () => {
     it("should filter every section by account path, case-insensitively", async () => {
-      vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
       await screen.findByTitle("assets:cash");
       await userEvent.type(screen.getByRole("searchbox", { name: "Search accounts" }), "CASH");
@@ -356,7 +411,7 @@ describe("<BalanceSheetView />", () => {
     });
 
     it("should show empty messages when nothing matches, and restore rows when cleared", async () => {
-      vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
       await screen.findByTitle("assets:cash");
       const box = screen.getByRole("searchbox", { name: "Search accounts" });
@@ -368,7 +423,7 @@ describe("<BalanceSheetView />", () => {
   });
 
   it("should show the empty state when the report has no accounts", async () => {
-    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(EMPTY);
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(EMPTY);
     renderView();
     expect(await screen.findByText("No accounts yet")).toBeInTheDocument();
     expect(screen.getByText(/Ask the agent to record your first transaction/)).toBeInTheDocument();
@@ -378,37 +433,37 @@ describe("<BalanceSheetView />", () => {
   });
 
   it("should fall back to the empty state when the report query rejects", async () => {
-    vi.mocked(ledgerApi.balanceSheet).mockRejectedValue(new Error("bridge down"));
+    vi.mocked(ledgerApi.netWorth).mockRejectedValue(new Error("bridge down"));
     renderView();
     expect(await screen.findByText("No accounts yet")).toBeInTheDocument();
   });
 
   it("should refetch the report when the agent goes from running to idle", async () => {
-    vi.mocked(ledgerApi.balanceSheet).mockResolvedValue(DATA);
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
     const { rerender } = renderView(false);
     await screen.findByText("~115.57 EUR");
-    expect(ledgerApi.balanceSheet).toHaveBeenCalledTimes(1);
+    expect(ledgerApi.netWorth).toHaveBeenCalledTimes(1);
 
     rerender(
       <Chrome isRunning={true}>
-        <BalanceSheetView />
+        <NetWorthView />
       </Chrome>,
     );
     // Flush the runtime's async store propagation before asserting no refetch
     // happened on the idle → running edge.
     await act(async () => {});
-    expect(ledgerApi.balanceSheet).toHaveBeenCalledTimes(1);
+    expect(ledgerApi.netWorth).toHaveBeenCalledTimes(1);
 
     rerender(
       <Chrome isRunning={false}>
-        <BalanceSheetView />
+        <NetWorthView />
       </Chrome>,
     );
-    await waitFor(() => expect(ledgerApi.balanceSheet).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(ledgerApi.netWorth).toHaveBeenCalledTimes(2));
   });
 
   it("should keep the current rows visible while a refetch is in flight", async () => {
-    vi.mocked(ledgerApi.balanceSheet)
+    vi.mocked(ledgerApi.netWorth)
       .mockResolvedValueOnce(DATA)
       .mockReturnValue(new Promise(() => {}));
     const { rerender } = renderView(false);
@@ -416,18 +471,18 @@ describe("<BalanceSheetView />", () => {
 
     rerender(
       <Chrome isRunning={true}>
-        <BalanceSheetView />
+        <NetWorthView />
       </Chrome>,
     );
     await act(async () => {});
     rerender(
       <Chrome isRunning={false}>
-        <BalanceSheetView />
+        <NetWorthView />
       </Chrome>,
     );
     // Once the refetch is genuinely in flight (its promise never resolves),
     // the previous rows must still be up, with no skeleton.
-    await waitFor(() => expect(ledgerApi.balanceSheet).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(ledgerApi.netWorth).toHaveBeenCalledTimes(2));
     expect(screen.getByText("~115.57 EUR")).toBeInTheDocument();
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth.integration.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth.integration.test.tsx
@@ -34,7 +34,8 @@ vi.mock("@/runtime/agentBridge", () => ({
   agentBridge: { addEventListener: () => () => {} },
 }));
 
-// Heavy chat children with their own suites; the Net Worth view stays REAL.
+// Heavy chat children with their own suites; the Net Worth view and the
+// sidebar badge stay REAL.
 vi.mock("../thread", () => ({ Thread: () => <div data-testid="thread" /> }));
 vi.mock("../thread-list", () => ({
   ThreadList: () => <div data-testid="thread-list" />,
@@ -120,9 +121,17 @@ afterEach(() => cleanup());
 const openSheet = () => fireEvent.click(screen.getByRole("button", { name: "Net Worth" }));
 
 describe("Net Worth view flow", () => {
-  it("should fetch the report over IPC exactly once and render both sections when Net Worth is opened", async () => {
+  it("should show the compact net worth in the sidebar as soon as the layout loads", async () => {
     render(<ChatLayout />);
-    expect(bridge.callsFor("ledger_net_worth")).toHaveLength(0);
+    // The badge's own fetch, before the page was ever opened.
+    expect(await screen.findByText("2.7K EUR")).toBeInTheDocument();
+    expect(bridge.callsFor("ledger_net_worth")).toHaveLength(1);
+  });
+
+  it("should fetch the report over IPC and render both sections when Net Worth is opened", async () => {
+    render(<ChatLayout />);
+    // One badge fetch on mount; the page adds its own on open.
+    expect(bridge.callsFor("ledger_net_worth")).toHaveLength(1);
 
     openSheet();
 
@@ -131,7 +140,7 @@ describe("Net Worth view flow", () => {
     expect(screen.getByText("~86.00 EUR")).toBeInTheDocument();
     expect(screen.getByTitle("liabilities:card")).toBeInTheDocument();
     expect(screen.getByText("2026-07-01")).toBeInTheDocument();
-    expect(bridge.callsFor("ledger_net_worth")).toHaveLength(1);
+    expect(bridge.callsFor("ledger_net_worth")).toHaveLength(2);
   });
 
   it("should mark the sidebar entry active and keep the chat mounted but hidden while open", async () => {
@@ -154,7 +163,7 @@ describe("Net Worth view flow", () => {
 
     expect(screen.getByTitle("assets:cash")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Net Worth" })).toHaveAttribute("data-active");
-    expect(bridge.callsFor("ledger_net_worth")).toHaveLength(1);
+    expect(bridge.callsFor("ledger_net_worth")).toHaveLength(2);
   });
 
   it("should fetch a fresh report on every open", async () => {
@@ -167,7 +176,7 @@ describe("Net Worth view flow", () => {
 
     openSheet();
     await screen.findByTitle("assets:cash");
-    expect(bridge.callsFor("ledger_net_worth")).toHaveLength(2);
+    expect(bridge.callsFor("ledger_net_worth")).toHaveLength(3);
   });
 
   it("should show the empty state when the report has no accounts", async () => {

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth.integration.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth.integration.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-// Integration: the Balance Sheet flow across real ChatLayout + real
-// BalanceSheetView + the real rpc/api layer, over the fake `window.api`
+// Integration: the Net Worth flow across real ChatLayout + real
+// NetWorthView + the real rpc/api layer, over the fake `window.api`
 // bridge. Asserts both the UI and the exact IPC traffic. The pi runtime and
 // heavy chat children are stubbed (they have their own suites); the IPC
 // boundary is the fake bridge.
@@ -34,7 +34,7 @@ vi.mock("@/runtime/agentBridge", () => ({
   agentBridge: { addEventListener: () => () => {} },
 }));
 
-// Heavy chat children with their own suites; the Balance Sheet view stays REAL.
+// Heavy chat children with their own suites; the Net Worth view stays REAL.
 vi.mock("../thread", () => ({ Thread: () => <div data-testid="thread" /> }));
 vi.mock("../thread-list", () => ({
   ThreadList: () => <div data-testid="thread-list" />,
@@ -42,10 +42,10 @@ vi.mock("../thread-list", () => ({
 }));
 vi.mock("../settings/settings", () => ({ Settings: () => null }));
 
-import type { BalanceSheet } from "@/rpc/types";
+import type { NetWorth } from "@/rpc/types";
 import { ChatLayout } from "../chat-layout";
 
-const DATA: BalanceSheet = {
+const DATA: NetWorth = {
   sections: [
     {
       name: "Assets",
@@ -112,17 +112,17 @@ beforeAll(() => {
 beforeEach(() => {
   bridge.reset();
   bridge.setHandler("update_pending", () => null);
-  bridge.setHandler("ledger_balance_sheet", () => DATA);
+  bridge.setHandler("ledger_net_worth", () => DATA);
 });
 
 afterEach(() => cleanup());
 
-const openSheet = () => fireEvent.click(screen.getByRole("button", { name: "Balance Sheet" }));
+const openSheet = () => fireEvent.click(screen.getByRole("button", { name: "Net Worth" }));
 
-describe("Balance Sheet view flow", () => {
-  it("should fetch the report over IPC exactly once and render both sections when Balance Sheet is opened", async () => {
+describe("Net Worth view flow", () => {
+  it("should fetch the report over IPC exactly once and render both sections when Net Worth is opened", async () => {
     render(<ChatLayout />);
-    expect(bridge.callsFor("ledger_balance_sheet")).toHaveLength(0);
+    expect(bridge.callsFor("ledger_net_worth")).toHaveLength(0);
 
     openSheet();
 
@@ -131,7 +131,7 @@ describe("Balance Sheet view flow", () => {
     expect(screen.getByText("~86.00 EUR")).toBeInTheDocument();
     expect(screen.getByTitle("liabilities:card")).toBeInTheDocument();
     expect(screen.getByText("2026-07-01")).toBeInTheDocument();
-    expect(bridge.callsFor("ledger_balance_sheet")).toHaveLength(1);
+    expect(bridge.callsFor("ledger_net_worth")).toHaveLength(1);
   });
 
   it("should mark the sidebar entry active and keep the chat mounted but hidden while open", async () => {
@@ -139,7 +139,7 @@ describe("Balance Sheet view flow", () => {
     openSheet();
     await screen.findByTitle("assets:cash");
 
-    expect(screen.getByRole("button", { name: "Balance Sheet" })).toHaveAttribute("data-active");
+    expect(screen.getByRole("button", { name: "Net Worth" })).toHaveAttribute("data-active");
     const thread = screen.getByTestId("thread");
     expect(thread).toBeInTheDocument();
     expect((thread.parentElement as HTMLElement).className).toContain("hidden");
@@ -153,8 +153,8 @@ describe("Balance Sheet view flow", () => {
     openSheet();
 
     expect(screen.getByTitle("assets:cash")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Balance Sheet" })).toHaveAttribute("data-active");
-    expect(bridge.callsFor("ledger_balance_sheet")).toHaveLength(1);
+    expect(screen.getByRole("button", { name: "Net Worth" })).toHaveAttribute("data-active");
+    expect(bridge.callsFor("ledger_net_worth")).toHaveLength(1);
   });
 
   it("should fetch a fresh report on every open", async () => {
@@ -167,11 +167,11 @@ describe("Balance Sheet view flow", () => {
 
     openSheet();
     await screen.findByTitle("assets:cash");
-    expect(bridge.callsFor("ledger_balance_sheet")).toHaveLength(2);
+    expect(bridge.callsFor("ledger_net_worth")).toHaveLength(2);
   });
 
   it("should show the empty state when the report has no accounts", async () => {
-    bridge.setHandler("ledger_balance_sheet", () => ({ sections: [], net: { amounts: [], value: [] } }));
+    bridge.setHandler("ledger_net_worth", () => ({ sections: [], net: { amounts: [], value: [] } }));
     render(<ChatLayout />);
     openSheet();
 

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/thread-list.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/thread-list.test.tsx
@@ -181,6 +181,26 @@ describe("ThreadList row hover highlight", () => {
     expect(rowButton!.className).toContain("group-hover/menu-item:bg-sidebar-accent");
   });
 
+  it("should mute the active-thread highlight when highlightActive is off (Net Worth open)", async () => {
+    render(
+      <Chrome>
+        <ThreadList highlightActive={false} />
+      </Chrome>,
+    );
+    const rowButton = (await screen.findByText("test chat")).closest("button");
+    // jsdom has no CSS engine, so pin the CSS contract: the active-mirror
+    // styles must be absent while another sidebar destination is selected;
+    // hover feedback stays.
+    expect(rowButton!.className).not.toContain("group-data-active/menu-item:bg-sidebar-accent");
+    expect(rowButton!.className).toContain("group-hover/menu-item:bg-sidebar-accent");
+  });
+
+  it("should keep the active-thread highlight by default", async () => {
+    renderList();
+    const rowButton = (await screen.findByText("test chat")).closest("button");
+    expect(rowButton!.className).toContain("group-data-active/menu-item:bg-sidebar-accent");
+  });
+
   it("should hide the ••• action until hover at every window width (drawer mode included)", async () => {
     renderList();
     const trigger = await screen.findByRole("button", { name: "More options" });

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/thread-list.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/thread-list.test.tsx
@@ -13,7 +13,7 @@ import { AssistantRuntimeProvider, type ExternalStoreAdapter, useExternalStoreRu
 import { SidebarProvider } from "@/components/shadcn/sidebar";
 import { sessionsApi } from "@/rpc/api";
 import type { SessionSummary } from "@/rpc/types";
-import { ThreadList } from "../thread-list";
+import { ThreadList, ThreadListNew } from "../thread-list";
 
 const listMock = vi.mocked(sessionsApi.list);
 
@@ -30,6 +30,8 @@ function makeChrome(opts: {
   threadId?: string;
   isLoading?: boolean;
   onDelete?: (threadId: string) => void | Promise<void>;
+  onSwitchToThread?: (threadId: string) => void | Promise<void>;
+  onSwitchToNewThread?: () => void | Promise<void>;
 }) {
   return function CustomChrome({ children }: { children: ReactNode }) {
     const store: ExternalStoreAdapter = {
@@ -40,8 +42,8 @@ function makeChrome(opts: {
           threadId: opts.threadId ?? opts.threads[0]?.id,
           isLoading: opts.isLoading,
           threads: opts.threads.map((t) => ({ id: t.id, status: "regular", title: t.title })),
-          onSwitchToThread: () => {},
-          onSwitchToNewThread: () => {},
+          onSwitchToThread: opts.onSwitchToThread ?? (() => {}),
+          onSwitchToNewThread: opts.onSwitchToNewThread ?? (() => {}),
           onDelete: opts.onDelete ?? (async () => {}),
         },
       },
@@ -308,6 +310,107 @@ describe("ThreadList delete", () => {
     press(del);
 
     await waitFor(() => expect(onDelete).toHaveBeenCalledWith("t1"));
+  });
+});
+
+describe("ThreadList selection callbacks", () => {
+  // Two threads with t2 active: clicking t1 must genuinely switch (assistant-ui
+  // skips the switch action for the already-active row).
+  const TWO_THREADS = [
+    { id: "t1", title: "test chat" },
+    { id: "t2", title: "other chat" },
+  ];
+
+  it("should fire onSelectThread alongside the thread switch when a row is clicked", async () => {
+    const onSwitchToThread = vi.fn();
+    const onSelectThread = vi.fn();
+    const Chrome = makeChrome({ threads: TWO_THREADS, threadId: "t2", onSwitchToThread });
+    render(
+      <Chrome>
+        <ThreadList onSelectThread={onSelectThread} />
+      </Chrome>,
+    );
+
+    press(await screen.findByText("test chat"));
+
+    // Both the primitive's own action and our callback must run — proves the
+    // asChild trigger composes the child's onClick instead of replacing it.
+    await waitFor(() => expect(onSwitchToThread).toHaveBeenCalledWith("t1"));
+    expect(onSelectThread).toHaveBeenCalledTimes(1);
+  });
+
+  it("should fire onSelectThread even for the already-active row (it only re-shows the chat)", async () => {
+    const onSelectThread = vi.fn();
+    const Chrome = makeChrome({ threads: TWO_THREADS, threadId: "t2" });
+    render(
+      <Chrome>
+        <ThreadList onSelectThread={onSelectThread} />
+      </Chrome>,
+    );
+
+    press(await screen.findByText("other chat"));
+    await waitFor(() => expect(onSelectThread).toHaveBeenCalledTimes(1));
+  });
+
+  it("should not fire onSelectThread from the row's ••• menu or its Delete action", async () => {
+    const onSelectThread = vi.fn();
+    const onDelete = vi.fn();
+    const Chrome = makeChrome({ threads: [{ id: "t1", title: "test chat" }], onDelete });
+    render(
+      <Chrome>
+        <ThreadList onSelectThread={onSelectThread} />
+      </Chrome>,
+    );
+
+    press(await screen.findByRole("button", { name: "More options" }));
+    press(await screen.findByText("Delete"));
+
+    await waitFor(() => expect(onDelete).toHaveBeenCalledWith("t1"));
+    expect(onSelectThread).not.toHaveBeenCalled();
+  });
+
+  it("should still switch the thread when onSelectThread is omitted", async () => {
+    const onSwitchToThread = vi.fn();
+    const Chrome = makeChrome({ threads: TWO_THREADS, threadId: "t2", onSwitchToThread });
+    render(
+      <Chrome>
+        <ThreadList />
+      </Chrome>,
+    );
+
+    press(await screen.findByText("test chat"));
+    await waitFor(() => expect(onSwitchToThread).toHaveBeenCalledWith("t1"));
+  });
+});
+
+describe("ThreadListNew", () => {
+  it("should fire onSelect alongside the new-thread action when clicked", async () => {
+    const onSwitchToNewThread = vi.fn();
+    const onSelect = vi.fn();
+    const Chrome = makeChrome({ threads: [], onSwitchToNewThread });
+    render(
+      <Chrome>
+        <ThreadListNew onSelect={onSelect} />
+      </Chrome>,
+    );
+
+    press(screen.getByRole("button", { name: "New Chat" }));
+
+    await waitFor(() => expect(onSwitchToNewThread).toHaveBeenCalled());
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("should still start a new thread when onSelect is omitted", async () => {
+    const onSwitchToNewThread = vi.fn();
+    const Chrome = makeChrome({ threads: [], onSwitchToNewThread });
+    render(
+      <Chrome>
+        <ThreadListNew />
+      </Chrome>,
+    );
+
+    press(screen.getByRole("button", { name: "New Chat" }));
+    await waitFor(() => expect(onSwitchToNewThread).toHaveBeenCalled());
   });
 });
 

--- a/packages/desktop/src/renderer/components/accountant24/balance-sheet-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/balance-sheet-view.tsx
@@ -210,10 +210,15 @@ const AccountsTable: FC<{ rows: AccountBalance[]; search: string; label: string 
   );
 };
 
+/** The soft summary-band surface shared by the section headers and the Net
+ *  line: label left, hledger's figure right, on the app's muted panel. px-5
+ *  inside mx-3 keeps the text on the px-8 line of the page title. */
+const BAND_CLASS = "mx-3 flex items-baseline justify-between gap-8 rounded-xl bg-muted/50 px-5 py-4";
+
 /** One `bs` section: its hledger name and total over its accounts table. */
 const SheetSection: FC<{ section: BalanceSheetSection; search: string }> = ({ section, search }) => (
   <section>
-    <div className="flex items-baseline justify-between gap-8 px-8 pt-8 pb-2">
+    <div className={`mt-8 mb-2 ${BAND_CLASS}`}>
       <h2 className="text-xl font-semibold">{section.name}</h2>
       <div className="shrink-0 text-right text-lg font-semibold tabular-nums">
         {formatValue(section.total, navigator.language)}
@@ -295,11 +300,8 @@ export const BalanceSheetView: FC = () => {
               {sections.map((section) => (
                 <SheetSection key={section.name} section={section} search={search} />
               ))}
-              {/* The closing Net band, straight from hledger's own net — a
-                  soft muted panel like the app's other surfaces (search
-                  field, composer) instead of a bare rule. px-5 inside mx-3
-                  keeps the text on the px-8 line of the headings above. */}
-              <div className="mx-3 mt-10 flex items-baseline justify-between gap-8 rounded-xl bg-muted/50 px-5 py-4">
+              {/* The closing Net band, straight from hledger's own net. */}
+              <div className={`mt-10 ${BAND_CLASS}`}>
                 <div className="text-xl font-semibold">Net</div>
                 <div className="shrink-0 text-right text-lg font-semibold tabular-nums">
                   {formatValue(sheet.net, navigator.language)}

--- a/packages/desktop/src/renderer/components/accountant24/balance-sheet-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/balance-sheet-view.tsx
@@ -30,7 +30,7 @@ import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@/components/s
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/shadcn/input-group";
 import { Skeleton } from "@/components/shadcn/skeleton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/shadcn/table";
-import { formatAmounts } from "@/lib/amountFormat";
+import { formatAmounts, formatValue } from "@/lib/amountFormat";
 import { ledgerApi } from "@/rpc/api";
 import type { AccountBalance, BalanceSheet, BalanceSheetSection } from "@/rpc/types";
 
@@ -122,7 +122,7 @@ const columns: ColumnDef<AccountBalance>[] = [
         <SortHeader column={column} label="Value" className="-mr-3" />
       </div>
     ),
-    cell: ({ row }) => formatAmounts(row.original.value, "value", navigator.language),
+    cell: ({ row }) => formatValue(row.original, navigator.language),
   },
 ];
 
@@ -199,7 +199,7 @@ const SheetSection: FC<{ section: BalanceSheetSection; search: string }> = ({ se
     <div className="flex items-baseline justify-between gap-8 px-8 pt-8 pb-2">
       <h2 className="text-xl font-semibold">{section.name}</h2>
       <div className="shrink-0 text-right text-lg font-semibold tabular-nums">
-        {formatAmounts(section.total.value, "value", navigator.language)}
+        {formatValue(section.total, navigator.language)}
       </div>
     </div>
     {/* px-5: with the cells' own px-3, the table text lines up with the px-8
@@ -285,7 +285,7 @@ export const BalanceSheetView: FC = () => {
               <div className="mx-3 mt-10 flex items-baseline justify-between gap-8 rounded-xl bg-muted/50 px-5 py-4">
                 <div className="text-xl font-semibold">Net</div>
                 <div className="shrink-0 text-right text-lg font-semibold tabular-nums">
-                  {formatAmounts(sheet.net.value, "value", navigator.language)}
+                  {formatValue(sheet.net, navigator.language)}
                 </div>
               </div>
             </>

--- a/packages/desktop/src/renderer/components/accountant24/balance-sheet-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/balance-sheet-view.tsx
@@ -234,14 +234,63 @@ const SheetSection: FC<{ section: BalanceSheetSection; search: string }> = ({ se
 
 const SKELETON_ROWS = ["s1", "s2", "s3", "s4", "s5", "s6"];
 
+/** The loading state mirrors the loaded page: everything that needs no data
+ *  (the Assets band, the column labels, the Net band) is up immediately, and
+ *  skeletons stand in only for the figures and rows hledger is still
+ *  computing. Assets and Net always exist on a balance sheet; Liabilities
+ *  may not, so no placeholder for it. */
 const SheetSkeleton: FC = () => (
-  <div role="status" aria-label="Loading accounts" className="flex flex-col gap-5 px-8 pt-8">
-    {SKELETON_ROWS.map((row) => (
-      <div key={row} className="flex items-center justify-between gap-8">
-        <Skeleton className="h-4 w-56" />
-        <Skeleton className="h-4 w-24" />
-      </div>
-    ))}
+  <div role="status" aria-label="Loading accounts">
+    <div className={`mt-8 mb-2 ${BAND_CLASS}`}>
+      <h2 className="text-xl font-semibold">Assets</h2>
+      <Skeleton className="h-5 w-36 self-center" />
+    </div>
+    <div className="px-5">
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead className="w-full">
+              <Button variant="ghost" size="sm" className="-ml-3" disabled>
+                Account
+                <ChevronsUpDownIcon className="text-muted-foreground/60" />
+              </Button>
+            </TableHead>
+            {["Last Balance Assertion", "Holding", "Value"].map((label) => (
+              <TableHead key={label}>
+                <div className="text-right">
+                  <Button variant="ghost" size="sm" className="-mr-3" disabled>
+                    {label}
+                    <ChevronsUpDownIcon className="text-muted-foreground/60" />
+                  </Button>
+                </div>
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {SKELETON_ROWS.map((row) => (
+            <TableRow key={row} className="hover:bg-transparent">
+              <TableCell className="w-full py-2.5">
+                <Skeleton className="h-4 w-56" />
+              </TableCell>
+              <TableCell className="py-2.5">
+                <Skeleton className="ml-auto h-4 w-20" />
+              </TableCell>
+              <TableCell className="py-2.5">
+                <Skeleton className="ml-auto h-4 w-24" />
+              </TableCell>
+              <TableCell className="py-2.5">
+                <Skeleton className="ml-auto h-4 w-24" />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+    <div className={`mt-10 ${BAND_CLASS}`}>
+      <div className="text-xl font-semibold">Net</div>
+      <Skeleton className="h-5 w-32 self-center" />
+    </div>
   </div>
 );
 
@@ -272,7 +321,7 @@ export const BalanceSheetView: FC = () => {
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="mx-auto w-full max-w-4xl shrink-0 px-8 pt-16 pb-4">
         <h1 className="text-3xl font-semibold">Balance Sheet</h1>
-        {sections.length > 0 && (
+        {(sheet === null || sections.length > 0) && (
           <InputGroup className="mt-6">
             <InputGroupInput
               type="search"

--- a/packages/desktop/src/renderer/components/accountant24/balance-sheet-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/balance-sheet-view.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+// Full-page Balance Sheet view: `hledger bs` rendered as data — an Assets
+// and a Liabilities section (liabilities already sign-flipped positive by
+// hledger), each with hledger's own total, and the hledger-computed Net as
+// the classic bottom line. A pinned header carries the page title and a
+// search box filtering every section by account path. Each section is a
+// shadcn-style data table (TanStack Table): complete account paths in one
+// color, every native holding in a muted Holding column, the market value
+// (hledger's `-X` valuation in the base currency) in the Value column;
+// every column sorts, A-Z on the account path by default, independently per
+// section. All figures are hledger-computed; only the presentation happens
+// here. Data refreshes when the agent finishes a turn.
+
+import { useAuiState } from "@assistant-ui/react";
+import {
+  type Column,
+  type ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  type SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+import { ArrowDownIcon, ArrowUpIcon, ChevronsUpDownIcon, SearchIcon } from "lucide-react";
+import { type FC, useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/shadcn/button";
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@/components/shadcn/empty";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/shadcn/input-group";
+import { Skeleton } from "@/components/shadcn/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/shadcn/table";
+import { formatAmounts } from "@/lib/amountFormat";
+import { ledgerApi } from "@/rpc/api";
+import type { AccountBalance, BalanceSheet, BalanceSheetSection } from "@/rpc/types";
+
+/** null = first load in flight; no section rows = loaded but empty (no
+ *  journal yet or hledger failed — both render the empty state pointing at
+ *  the agent). */
+function useBalanceSheet(): BalanceSheet | null {
+  const [data, setData] = useState<BalanceSheet | null>(null);
+
+  const refresh = useCallback(() => {
+    let cancelled = false;
+    ledgerApi
+      .balanceSheet()
+      .then((d) => {
+        if (!cancelled) setData(d);
+      })
+      .catch(() => {
+        if (!cancelled) setData({ sections: [], net: { amounts: [], value: [] } });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => refresh(), [refresh]);
+
+  // Refetch on the running → idle edge (the finished turn may have posted
+  // transactions). Existing rows stay up while the refresh is in flight, so
+  // the list never flickers back to the skeleton. Same pattern as mentions.tsx.
+  const isRunning = useAuiState((s) => s.thread.isRunning);
+  const wasRunning = useRef(isRunning);
+  useEffect(() => {
+    const justFinished = wasRunning.current && !isRunning;
+    wasRunning.current = isRunning;
+    if (justFinished) return refresh();
+  }, [isRunning, refresh]);
+
+  return data;
+}
+
+/** Clickable column header driving the table's sorting; the icon mirrors
+ *  the current direction, neutral chevrons while the column is unsorted. */
+const SortHeader: FC<{ column: Column<AccountBalance>; label: string; className?: string }> = ({
+  column,
+  label,
+  className,
+}) => {
+  const sorted = column.getIsSorted();
+  const Icon = sorted === "asc" ? ArrowUpIcon : sorted === "desc" ? ArrowDownIcon : ChevronsUpDownIcon;
+  return (
+    <Button variant="ghost" size="sm" className={className} onClick={() => column.toggleSorting()}>
+      {label}
+      <Icon className={sorted ? undefined : "text-muted-foreground/60"} />
+    </Button>
+  );
+};
+
+/** The accounts data table columns. Sorting semantics:
+ *  - Account: A-Z on the full path (the table's default sort);
+ *  - Holding: by the primary native quantity — a plain number sort, so the
+ *    column reads monotonic (commodity grouping was tried and read as
+ *    disorder);
+ *  - Value: by market value.
+ *  Both money columns put the biggest figures first on the first click. */
+const columns: ColumnDef<AccountBalance>[] = [
+  {
+    id: "account",
+    accessorFn: (row) => row.name,
+    header: ({ column }) => <SortHeader column={column} label="Account" className="-ml-3" />,
+    cell: ({ row }) => row.original.name,
+  },
+  {
+    id: "holding",
+    accessorFn: (row) => row.amounts[0]?.quantity ?? 0,
+    sortDescFirst: true,
+    header: ({ column }) => (
+      <div className="text-right">
+        <SortHeader column={column} label="Holding" className="-mr-3" />
+      </div>
+    ),
+    cell: ({ row }) => formatAmounts(row.original.amounts, "native", navigator.language),
+  },
+  {
+    id: "value",
+    accessorFn: (row) => row.value[0]?.quantity ?? 0,
+    sortDescFirst: true,
+    header: ({ column }) => (
+      <div className="text-right">
+        <SortHeader column={column} label="Value" className="-mr-3" />
+      </div>
+    ),
+    cell: ({ row }) => formatAmounts(row.original.value, "value", navigator.language),
+  },
+];
+
+// py-2.5 keeps the pre-table row density; the stock p-3 cells read too airy
+// for this dense money list.
+const CELL_CLASS: Record<string, string> = {
+  account: "w-full py-2.5",
+  holding: "py-2.5 text-right tabular-nums",
+  value: "py-2.5 text-right tabular-nums",
+};
+
+const AccountsTable: FC<{ rows: AccountBalance[]; search: string; label: string }> = ({ rows, search, label }) => {
+  // A-Z on the account path until the user picks another column; a click
+  // always leaves some direction active (no unsorted third state).
+  const [sorting, setSorting] = useState<SortingState>([{ id: "account", desc: false }]);
+  const table = useReactTable({
+    data: rows,
+    columns,
+    state: { sorting, globalFilter: search },
+    onSortingChange: setSorting,
+    enableSortingRemoval: false,
+    // The account path is the only searchable field; substring match,
+    // case-insensitive.
+    globalFilterFn: (row, _columnId, value) => row.original.name.toLowerCase().includes(String(value).toLowerCase()),
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+  });
+
+  return (
+    <Table aria-label={label}>
+      {/* The header row is labels, not data — no hover highlight. */}
+      <TableHeader>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <TableRow key={headerGroup.id} className="hover:bg-transparent">
+            {headerGroup.headers.map((header) => (
+              <TableHead key={header.id} className={header.column.id === "account" ? "w-full" : undefined}>
+                {flexRender(header.column.columnDef.header, header.getContext())}
+              </TableHead>
+            ))}
+          </TableRow>
+        ))}
+      </TableHeader>
+      <TableBody>
+        {table.getRowModel().rows.length === 0 ? (
+          <TableRow>
+            <TableCell colSpan={columns.length} className="h-24 text-center text-muted-foreground">
+              No matching accounts
+            </TableCell>
+          </TableRow>
+        ) : (
+          table.getRowModel().rows.map((row) => (
+            <TableRow key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <TableCell
+                  key={cell.id}
+                  className={CELL_CLASS[cell.column.id]}
+                  title={cell.column.id === "account" ? row.original.name : undefined}
+                >
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))
+        )}
+      </TableBody>
+    </Table>
+  );
+};
+
+/** One `bs` section: its hledger name and total over its accounts table. */
+const SheetSection: FC<{ section: BalanceSheetSection; search: string }> = ({ section, search }) => (
+  <section>
+    <div className="flex items-baseline justify-between gap-8 px-8 pt-8 pb-2">
+      <h2 className="text-xl font-semibold">{section.name}</h2>
+      <div className="shrink-0 text-right text-lg font-semibold tabular-nums">
+        {formatAmounts(section.total.value, "value", navigator.language)}
+      </div>
+    </div>
+    {/* px-5: with the cells' own px-3, the table text lines up with the px-8
+        headings. */}
+    <div className="px-5">
+      <AccountsTable rows={section.rows} search={search} label={section.name} />
+    </div>
+  </section>
+);
+
+const SKELETON_ROWS = ["s1", "s2", "s3", "s4", "s5", "s6"];
+
+const SheetSkeleton: FC = () => (
+  <div role="status" aria-label="Loading accounts" className="flex flex-col gap-5 px-8 pt-8">
+    {SKELETON_ROWS.map((row) => (
+      <div key={row} className="flex items-center justify-between gap-8">
+        <Skeleton className="h-4 w-56" />
+        <Skeleton className="h-4 w-24" />
+      </div>
+    ))}
+  </div>
+);
+
+const SheetEmpty: FC = () => (
+  <Empty>
+    <EmptyHeader>
+      <EmptyTitle>No accounts yet</EmptyTitle>
+      <EmptyDescription>
+        Ask the agent to record your first transaction and your accounts will show up here
+      </EmptyDescription>
+    </EmptyHeader>
+  </Empty>
+);
+
+/** The Balance Sheet page, shown in place of the chat thread. Laid out like
+ *  a Claude-app content page: a centered column of capped width, a large
+ *  title sitting well below the window chrome (clear of the drag region and
+ *  the sidebar toggle), and the search box under it. Title and search are
+ *  pinned; the sections and the Net line scroll. */
+export const BalanceSheetView: FC = () => {
+  const sheet = useBalanceSheet();
+  const [search, setSearch] = useState("");
+  // hledger emits a section even when it has no accounts; an empty side
+  // renders nothing rather than a fabricated zero.
+  const sections = sheet?.sections.filter((s) => s.rows.length > 0) ?? [];
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="mx-auto w-full max-w-4xl shrink-0 px-8 pt-16 pb-4">
+        <h1 className="text-3xl font-semibold">Balance Sheet</h1>
+        {sections.length > 0 && (
+          <InputGroup className="mt-6">
+            <InputGroupInput
+              type="search"
+              placeholder="Search accounts"
+              aria-label="Search accounts"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+            <InputGroupAddon>
+              <SearchIcon />
+            </InputGroupAddon>
+          </InputGroup>
+        )}
+      </div>
+      {/* scroll-fade-t-6: content dissolves over 24px as it slides under the
+          pinned search field, same as the chat viewport's top fade. */}
+      <div className="scroll-fade-t scroll-fade-t-6 min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto w-full max-w-4xl pb-12">
+          {sheet === null ? (
+            <SheetSkeleton />
+          ) : sections.length === 0 ? (
+            <SheetEmpty />
+          ) : (
+            <>
+              {sections.map((section) => (
+                <SheetSection key={section.name} section={section} search={search} />
+              ))}
+              {/* The closing Net band, straight from hledger's own net — a
+                  soft muted panel like the app's other surfaces (search
+                  field, composer) instead of a bare rule. px-5 inside mx-3
+                  keeps the text on the px-8 line of the headings above. */}
+              <div className="mx-3 mt-10 flex items-baseline justify-between gap-8 rounded-xl bg-muted/50 px-5 py-4">
+                <div className="text-xl font-semibold">Net</div>
+                <div className="shrink-0 text-right text-lg font-semibold tabular-nums">
+                  {formatAmounts(sheet.net.value, "value", navigator.language)}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/desktop/src/renderer/components/accountant24/balance-sheet-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/balance-sheet-view.tsx
@@ -93,14 +93,30 @@ const SortHeader: FC<{ column: Column<AccountBalance>; label: string; className?
  *  - Holding: by the primary native quantity — a plain number sort, so the
  *    column reads monotonic (commodity grouping was tried and read as
  *    disorder);
+ *  - Last Balance Assertion: by date, most recent first on the first
+ *    click; never-asserted rows sink to the end;
  *  - Value: by market value.
- *  Both money columns put the biggest figures first on the first click. */
+ *  Money columns put the biggest figures first on the first click. */
 const columns: ColumnDef<AccountBalance>[] = [
   {
     id: "account",
     accessorFn: (row) => row.name,
     header: ({ column }) => <SortHeader column={column} label="Account" className="-ml-3" />,
     cell: ({ row }) => row.original.name,
+  },
+  {
+    id: "asserted",
+    accessorFn: (row) => row.assertedOn ?? "",
+    sortDescFirst: true,
+    header: ({ column }) => (
+      <div className="text-right">
+        <SortHeader column={column} label="Last Balance Assertion" className="-mr-3" />
+      </div>
+    ),
+    // The journal's own ISO date, verbatim — unambiguous, and what you see
+    // is literally what the column sorts by. An em dash marks accounts whose
+    // balance was never asserted.
+    cell: ({ row }) => row.original.assertedOn ?? "\u2014",
   },
   {
     id: "holding",
@@ -131,6 +147,7 @@ const columns: ColumnDef<AccountBalance>[] = [
 const CELL_CLASS: Record<string, string> = {
   account: "w-full py-2.5",
   holding: "py-2.5 text-right tabular-nums",
+  asserted: "py-2.5 text-right tabular-nums",
   value: "py-2.5 text-right tabular-nums",
 };
 

--- a/packages/desktop/src/renderer/components/accountant24/chat-layout.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/chat-layout.tsx
@@ -1,7 +1,7 @@
 import { AssistantRuntimeProvider, CompositeAttachmentAdapter } from "@assistant-ui/react";
 import { usePiRuntime } from "@assistant-ui/react-pi";
-import { SettingsIcon } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { LandmarkIcon, SettingsIcon } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Sidebar,
   SidebarContent,
@@ -23,6 +23,7 @@ import { agentBridge } from "@/runtime/agentBridge";
 import { createElectronPiClient } from "@/runtime/electronPiClient";
 import { ArchivingImageAttachmentAdapter, WorkspaceFileAttachmentAdapter } from "@/runtime/fileAttachmentAdapter";
 import { PiClientContext } from "@/runtime/modelsContext";
+import { BalanceSheetView } from "./balance-sheet-view";
 import { Settings } from "./settings/settings";
 import { loadSidebarWidth, SidebarResizeHandle } from "./sidebar-resize";
 import { Thread } from "./thread";
@@ -67,13 +68,20 @@ export function ChatLayout() {
   );
   const runtime = usePiRuntime({ client, adapters: { attachments } });
   const [settingsOpen, setSettingsOpen] = useState(false);
+  // Which view fills the inset. The chat is never unmounted (see below); the
+  // The Balance Sheet page mounts fresh on each open so it always shows current data.
+  const [view, setView] = useState<"chat" | "balance-sheet">("chat");
+  const showChat = useCallback(() => setView("chat"), []);
   // Non-null once an update is downloaded and staged; drives the footer banner.
   const updateVersion = useUpdateStatus();
   // Read once on mount; afterwards SidebarResizeHandle mutates the CSS var live.
   const [sidebarWidth] = useState(loadSidebarWidth);
 
   useKeyboardShortcuts({
-    newChat: () => void runtime.threads.switchToNewThread(),
+    newChat: () => {
+      setView("chat");
+      void runtime.threads.switchToNewThread();
+    },
     openSettings: () => setSettingsOpen(true),
   });
 
@@ -137,14 +145,23 @@ export function ChatLayout() {
             <SidebarHeader>
               {/* spacer + drag region so the header clears the overlaid traffic lights */}
               <div className="app-drag-region h-7" />
-              <ThreadListNew />
+              <ThreadListNew onSelect={showChat} />
             </SidebarHeader>
             <SidebarContent className="scroll-fade">
-              <ThreadList />
+              <ThreadList onSelectThread={showChat} />
             </SidebarContent>
             <SidebarFooter>
               {updateVersion && <UpdateBanner version={updateVersion} />}
               <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    isActive={view === "balance-sheet"}
+                    onClick={() => setView((v) => (v === "balance-sheet" ? "chat" : "balance-sheet"))}
+                  >
+                    <LandmarkIcon className="size-4" />
+                    Balance Sheet
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
                 <SidebarMenuItem>
                   <SidebarMenuButton onClick={() => setSettingsOpen(true)}>
                     <SettingsIcon className="size-4" />
@@ -158,7 +175,13 @@ export function ChatLayout() {
           <SidebarInset className="relative min-w-0">
             <div className="app-drag-region absolute inset-x-0 top-0 z-20 h-7" />
             <SidebarToggle />
-            <Thread />
+            {/* The chat stays mounted (display:none) while the Balance Sheet is open:
+                the composer's editor state, scroll position, and any in-flight
+                streaming all survive the round trip. */}
+            <div className={cn("flex min-h-0 flex-1 flex-col", view !== "chat" && "hidden")}>
+              <Thread />
+            </div>
+            {view === "balance-sheet" && <BalanceSheetView />}
           </SidebarInset>
           <Settings open={settingsOpen} onOpenChange={setSettingsOpen} />
         </SidebarProvider>

--- a/packages/desktop/src/renderer/components/accountant24/chat-layout.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/chat-layout.tsx
@@ -154,10 +154,7 @@ export function ChatLayout() {
               {updateVersion && <UpdateBanner version={updateVersion} />}
               <SidebarMenu>
                 <SidebarMenuItem>
-                  <SidebarMenuButton
-                    isActive={view === "balance-sheet"}
-                    onClick={() => setView((v) => (v === "balance-sheet" ? "chat" : "balance-sheet"))}
-                  >
+                  <SidebarMenuButton isActive={view === "balance-sheet"} onClick={() => setView("balance-sheet")}>
                     <LandmarkIcon className="size-4" />
                     Balance Sheet
                   </SidebarMenuButton>

--- a/packages/desktop/src/renderer/components/accountant24/chat-layout.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/chat-layout.tsx
@@ -23,6 +23,7 @@ import { agentBridge } from "@/runtime/agentBridge";
 import { createElectronPiClient } from "@/runtime/electronPiClient";
 import { ArchivingImageAttachmentAdapter, WorkspaceFileAttachmentAdapter } from "@/runtime/fileAttachmentAdapter";
 import { PiClientContext } from "@/runtime/modelsContext";
+import { NetWorthBadge } from "./net-worth-badge";
 import { NetWorthView } from "./net-worth-view";
 import { Settings } from "./settings/settings";
 import { loadSidebarWidth, SidebarResizeHandle } from "./sidebar-resize";
@@ -157,6 +158,7 @@ export function ChatLayout() {
                   <SidebarMenuButton isActive={view === "net-worth"} onClick={() => setView("net-worth")}>
                     <LandmarkIcon className="size-4" />
                     Net Worth
+                    <NetWorthBadge />
                   </SidebarMenuButton>
                 </SidebarMenuItem>
                 <SidebarMenuItem>

--- a/packages/desktop/src/renderer/components/accountant24/chat-layout.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/chat-layout.tsx
@@ -23,7 +23,7 @@ import { agentBridge } from "@/runtime/agentBridge";
 import { createElectronPiClient } from "@/runtime/electronPiClient";
 import { ArchivingImageAttachmentAdapter, WorkspaceFileAttachmentAdapter } from "@/runtime/fileAttachmentAdapter";
 import { PiClientContext } from "@/runtime/modelsContext";
-import { BalanceSheetView } from "./balance-sheet-view";
+import { NetWorthView } from "./net-worth-view";
 import { Settings } from "./settings/settings";
 import { loadSidebarWidth, SidebarResizeHandle } from "./sidebar-resize";
 import { Thread } from "./thread";
@@ -69,8 +69,8 @@ export function ChatLayout() {
   const runtime = usePiRuntime({ client, adapters: { attachments } });
   const [settingsOpen, setSettingsOpen] = useState(false);
   // Which view fills the inset. The chat is never unmounted (see below); the
-  // The Balance Sheet page mounts fresh on each open so it always shows current data.
-  const [view, setView] = useState<"chat" | "balance-sheet">("chat");
+  // The Net Worth page mounts fresh on each open so it always shows current data.
+  const [view, setView] = useState<"chat" | "net-worth">("chat");
   const showChat = useCallback(() => setView("chat"), []);
   // Non-null once an update is downloaded and staged; drives the footer banner.
   const updateVersion = useUpdateStatus();
@@ -148,15 +148,15 @@ export function ChatLayout() {
               <ThreadListNew onSelect={showChat} />
             </SidebarHeader>
             <SidebarContent className="scroll-fade">
-              <ThreadList onSelectThread={showChat} />
+              <ThreadList onSelectThread={showChat} highlightActive={view === "chat"} />
             </SidebarContent>
             <SidebarFooter>
               {updateVersion && <UpdateBanner version={updateVersion} />}
               <SidebarMenu>
                 <SidebarMenuItem>
-                  <SidebarMenuButton isActive={view === "balance-sheet"} onClick={() => setView("balance-sheet")}>
+                  <SidebarMenuButton isActive={view === "net-worth"} onClick={() => setView("net-worth")}>
                     <LandmarkIcon className="size-4" />
-                    Balance Sheet
+                    Net Worth
                   </SidebarMenuButton>
                 </SidebarMenuItem>
                 <SidebarMenuItem>
@@ -172,13 +172,13 @@ export function ChatLayout() {
           <SidebarInset className="relative min-w-0">
             <div className="app-drag-region absolute inset-x-0 top-0 z-20 h-7" />
             <SidebarToggle />
-            {/* The chat stays mounted (display:none) while the Balance Sheet is open:
+            {/* The chat stays mounted (display:none) while the Net Worth is open:
                 the composer's editor state, scroll position, and any in-flight
                 streaming all survive the round trip. */}
             <div className={cn("flex min-h-0 flex-1 flex-col", view !== "chat" && "hidden")}>
               <Thread />
             </div>
-            {view === "balance-sheet" && <BalanceSheetView />}
+            {view === "net-worth" && <NetWorthView />}
           </SidebarInset>
           <Settings open={settingsOpen} onOpenChange={setSettingsOpen} />
         </SidebarProvider>

--- a/packages/desktop/src/renderer/components/accountant24/net-worth-badge.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/net-worth-badge.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+// The sidebar's glanceable net worth: the trailing figure inside the Net
+// Worth menu button, fed by the same report as the page and refreshed when
+// the agent finishes a turn. Compact notation — the exact figure lives on
+// the page. Rendered inline (ml-auto in the button's own flex row) so it
+// always sits on the label's baseline; muted so the secondary figure never
+// competes with the label. Nothing renders while the report is loading or
+// empty.
+
+import type { FC } from "react";
+import { formatValueCompact } from "@/lib/amountFormat";
+import { useNetWorth } from "./use-net-worth";
+
+export const NetWorthBadge: FC = () => {
+  const sheet = useNetWorth();
+  if (sheet === null) return null;
+  const text = formatValueCompact(sheet.net, navigator.language);
+  if (!text) return null;
+  // aria-hidden keeps the button's accessible name a stable "Net Worth"
+  // instead of one that shifts with every ledger change.
+  return (
+    <span aria-hidden="true" className="ml-auto text-xs font-medium text-muted-foreground tabular-nums">
+      {text}
+    </span>
+  );
+};

--- a/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
@@ -309,7 +309,7 @@ const SheetSkeleton: FC = () => (
         </TableBody>
       </Table>
     </div>
-    <div className={`mt-10 ${BAND_CLASS}`}>
+    <div className={`mt-8 ${BAND_CLASS}`}>
       <div className="text-xl font-semibold">Net Worth</div>
       <Skeleton className="h-5 w-32 self-center" />
     </div>
@@ -372,7 +372,7 @@ export const NetWorthView: FC = () => {
                 <SheetSection key={section.name} section={section} search={search} />
               ))}
               {/* The closing Net band, straight from hledger's own net. */}
-              <div className={`mt-10 ${BAND_CLASS}`}>
+              <div className={`mt-8 ${BAND_CLASS}`}>
                 <div className="text-xl font-semibold">Net Worth</div>
                 <div className="shrink-0 text-right text-lg font-semibold tabular-nums">
                   {formatValue(sheet.net, navigator.language)}

--- a/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
@@ -12,7 +12,6 @@
 // section. All figures are hledger-computed; only the presentation happens
 // here. Data refreshes when the agent finishes a turn.
 
-import { useAuiState } from "@assistant-ui/react";
 import {
   type Column,
   type ColumnDef,
@@ -24,7 +23,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { ArrowDownIcon, ArrowUpIcon, ChevronsUpDownIcon, InfoIcon, SearchIcon } from "lucide-react";
-import { type FC, type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { type FC, type ReactNode, useState } from "react";
 import { Button } from "@/components/shadcn/button";
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@/components/shadcn/empty";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/shadcn/input-group";
@@ -32,45 +31,8 @@ import { Skeleton } from "@/components/shadcn/skeleton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/shadcn/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/tooltip";
 import { formatAmounts, formatValue } from "@/lib/amountFormat";
-import { ledgerApi } from "@/rpc/api";
-import type { AccountBalance, NetWorth, NetWorthSection } from "@/rpc/types";
-
-/** null = first load in flight; no section rows = loaded but empty (no
- *  journal yet or hledger failed — both render the empty state pointing at
- *  the agent). */
-function useNetWorth(): NetWorth | null {
-  const [data, setData] = useState<NetWorth | null>(null);
-
-  const refresh = useCallback(() => {
-    let cancelled = false;
-    ledgerApi
-      .netWorth()
-      .then((d) => {
-        if (!cancelled) setData(d);
-      })
-      .catch(() => {
-        if (!cancelled) setData({ sections: [], net: { amounts: [], value: [] } });
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  useEffect(() => refresh(), [refresh]);
-
-  // Refetch on the running → idle edge (the finished turn may have posted
-  // transactions). Existing rows stay up while the refresh is in flight, so
-  // the list never flickers back to the skeleton. Same pattern as mentions.tsx.
-  const isRunning = useAuiState((s) => s.thread.isRunning);
-  const wasRunning = useRef(isRunning);
-  useEffect(() => {
-    const justFinished = wasRunning.current && !isRunning;
-    wasRunning.current = isRunning;
-    if (justFinished) return refresh();
-  }, [isRunning, refresh]);
-
-  return data;
-}
+import type { AccountBalance, NetWorthSection } from "@/rpc/types";
+import { useNetWorth } from "./use-net-worth";
 
 /** Clickable column header driving the table's sorting; the icon mirrors
  *  the current direction, neutral chevrons while the column is unsorted. */

--- a/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-// Full-page Balance Sheet view: `hledger bs` rendered as data — an Assets
+// Full-page Net Worth view: `hledger bs` rendered as data — an Assets
 // and a Liabilities section (liabilities already sign-flipped positive by
 // hledger), each with hledger's own total, and the hledger-computed Net as
 // the classic bottom line. A pinned header carries the page title and a
@@ -23,27 +23,28 @@ import {
   type SortingState,
   useReactTable,
 } from "@tanstack/react-table";
-import { ArrowDownIcon, ArrowUpIcon, ChevronsUpDownIcon, SearchIcon } from "lucide-react";
-import { type FC, useCallback, useEffect, useRef, useState } from "react";
+import { ArrowDownIcon, ArrowUpIcon, ChevronsUpDownIcon, InfoIcon, SearchIcon } from "lucide-react";
+import { type FC, type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/shadcn/button";
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@/components/shadcn/empty";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/shadcn/input-group";
 import { Skeleton } from "@/components/shadcn/skeleton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/shadcn/table";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/tooltip";
 import { formatAmounts, formatValue } from "@/lib/amountFormat";
 import { ledgerApi } from "@/rpc/api";
-import type { AccountBalance, BalanceSheet, BalanceSheetSection } from "@/rpc/types";
+import type { AccountBalance, NetWorth, NetWorthSection } from "@/rpc/types";
 
 /** null = first load in flight; no section rows = loaded but empty (no
  *  journal yet or hledger failed — both render the empty state pointing at
  *  the agent). */
-function useBalanceSheet(): BalanceSheet | null {
-  const [data, setData] = useState<BalanceSheet | null>(null);
+function useNetWorth(): NetWorth | null {
+  const [data, setData] = useState<NetWorth | null>(null);
 
   const refresh = useCallback(() => {
     let cancelled = false;
     ledgerApi
-      .balanceSheet()
+      .netWorth()
       .then((d) => {
         if (!cancelled) setData(d);
       })
@@ -88,6 +89,61 @@ const SortHeader: FC<{ column: Column<AccountBalance>; label: string; className?
   );
 };
 
+/** What each money/meta column means, keyed by its label; shown behind the
+ *  little info marker next to the header (the Account column needs none). */
+const COLUMN_HELP: Record<string, ReactNode> = {
+  Holding:
+    "What the account actually holds: cash in its own currency, shares, or crypto. Exactly as recorded in the ledger, before any conversion.",
+  "Last Balance Assertion": (
+    <div>
+      <p>
+        When the ledger balance was last confirmed to match the real account balance. A dash means it was never
+        confirmed.
+      </p>
+      <p className="mt-1.5">
+        To confirm, tell the agent the actual account balance, for example: "My cash balance is 200 EUR."
+      </p>
+    </div>
+  ),
+  Value: (
+    <div>
+      <p>
+        What the holding is worth in your main currency, at the latest rate recorded in the ledger. A ~ means the value
+        was converted and is an estimate.
+      </p>
+      <p className="mt-1.5">
+        To update a rate, tell the agent what one unit of the holding is worth now in your main currency, for example:
+        "1 USD is 0.92 EUR."
+      </p>
+    </div>
+  ),
+};
+
+/** A visible little info marker; hovering it explains the column. A separate
+ *  target from the sort button, so the help is discoverable and sorting
+ *  stays a plain click. */
+const InfoTip: FC<{ label: string }> = ({ label }) => (
+  <TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={`About ${label}`}
+            className="size-5 text-muted-foreground/70 hover:text-foreground"
+          />
+        }
+      >
+        <InfoIcon className="size-3.5" />
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-60">
+        {COLUMN_HELP[label]}
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);
+
 /** The accounts data table columns. Sorting semantics:
  *  - Account: A-Z on the full path (the table's default sort);
  *  - Holding: by the primary native quantity — a plain number sort, so the
@@ -109,7 +165,8 @@ const columns: ColumnDef<AccountBalance>[] = [
     accessorFn: (row) => row.assertedOn ?? "",
     sortDescFirst: true,
     header: ({ column }) => (
-      <div className="text-right">
+      <div className="flex items-center justify-end">
+        <InfoTip label="Last Balance Assertion" />
         <SortHeader column={column} label="Last Balance Assertion" className="-mr-3" />
       </div>
     ),
@@ -123,7 +180,8 @@ const columns: ColumnDef<AccountBalance>[] = [
     accessorFn: (row) => row.amounts[0]?.quantity ?? 0,
     sortDescFirst: true,
     header: ({ column }) => (
-      <div className="text-right">
+      <div className="flex items-center justify-end">
+        <InfoTip label="Holding" />
         <SortHeader column={column} label="Holding" className="-mr-3" />
       </div>
     ),
@@ -134,7 +192,8 @@ const columns: ColumnDef<AccountBalance>[] = [
     accessorFn: (row) => row.value[0]?.quantity ?? 0,
     sortDescFirst: true,
     header: ({ column }) => (
-      <div className="text-right">
+      <div className="flex items-center justify-end">
+        <InfoTip label="Value" />
         <SortHeader column={column} label="Value" className="-mr-3" />
       </div>
     ),
@@ -216,7 +275,7 @@ const AccountsTable: FC<{ rows: AccountBalance[]; search: string; label: string 
 const BAND_CLASS = "mx-3 flex items-baseline justify-between gap-8 rounded-xl bg-muted/50 px-5 py-4";
 
 /** One `bs` section: its hledger name and total over its accounts table. */
-const SheetSection: FC<{ section: BalanceSheetSection; search: string }> = ({ section, search }) => (
+const SheetSection: FC<{ section: NetWorthSection; search: string }> = ({ section, search }) => (
   <section>
     <div className={`mt-8 mb-2 ${BAND_CLASS}`}>
       <h2 className="text-xl font-semibold">{section.name}</h2>
@@ -257,7 +316,8 @@ const SheetSkeleton: FC = () => (
             </TableHead>
             {["Last Balance Assertion", "Holding", "Value"].map((label) => (
               <TableHead key={label}>
-                <div className="text-right">
+                <div className="flex items-center justify-end">
+                  <InfoTip label={label} />
                   <Button variant="ghost" size="sm" className="-mr-3" disabled>
                     {label}
                     <ChevronsUpDownIcon className="text-muted-foreground/60" />
@@ -288,7 +348,7 @@ const SheetSkeleton: FC = () => (
       </Table>
     </div>
     <div className={`mt-10 ${BAND_CLASS}`}>
-      <div className="text-xl font-semibold">Net</div>
+      <div className="text-xl font-semibold">Net Worth</div>
       <Skeleton className="h-5 w-32 self-center" />
     </div>
   </div>
@@ -305,13 +365,13 @@ const SheetEmpty: FC = () => (
   </Empty>
 );
 
-/** The Balance Sheet page, shown in place of the chat thread. Laid out like
+/** The Net Worth page, shown in place of the chat thread. Laid out like
  *  a Claude-app content page: a centered column of capped width, a large
  *  title sitting well below the window chrome (clear of the drag region and
  *  the sidebar toggle), and the search box under it. Title and search are
  *  pinned; the sections and the Net line scroll. */
-export const BalanceSheetView: FC = () => {
-  const sheet = useBalanceSheet();
+export const NetWorthView: FC = () => {
+  const sheet = useNetWorth();
   const [search, setSearch] = useState("");
   // hledger emits a section even when it has no accounts; an empty side
   // renders nothing rather than a fabricated zero.
@@ -319,10 +379,10 @@ export const BalanceSheetView: FC = () => {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="mx-auto w-full max-w-4xl shrink-0 px-8 pt-16 pb-4">
-        <h1 className="text-3xl font-semibold">Balance Sheet</h1>
+      <div className="mx-auto flex w-full max-w-4xl shrink-0 items-center justify-between gap-8 px-8 pt-16 pb-4">
+        <h1 className="text-3xl font-semibold">Net Worth</h1>
         {(sheet === null || sections.length > 0) && (
-          <InputGroup className="mt-6">
+          <InputGroup className="w-64">
             <InputGroupInput
               type="search"
               placeholder="Search accounts"
@@ -351,7 +411,7 @@ export const BalanceSheetView: FC = () => {
               ))}
               {/* The closing Net band, straight from hledger's own net. */}
               <div className={`mt-10 ${BAND_CLASS}`}>
-                <div className="text-xl font-semibold">Net</div>
+                <div className="text-xl font-semibold">Net Worth</div>
                 <div className="shrink-0 text-right text-lg font-semibold tabular-nums">
                   {formatValue(sheet.net, navigator.language)}
                 </div>

--- a/packages/desktop/src/renderer/components/accountant24/thread-list.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/thread-list.tsx
@@ -20,6 +20,7 @@ import {
   SidebarMenuItem,
   SidebarMenuSkeleton,
 } from "@/components/shadcn/sidebar";
+import { cn } from "@/lib/utils";
 import { sessionsApi } from "@/rpc/api";
 
 /** The sidebar's primary action — lives in the SidebarHeader, outside the nav
@@ -38,15 +39,21 @@ export const ThreadListNew: FC<{ onSelect?: () => void }> = ({ onSelect }) => {
 };
 
 /** `onSelectThread` fires when a thread row is clicked, alongside the
- *  primitive's switch-to-thread action (not on the row's ••• actions). */
-export const ThreadList: FC<{ onSelectThread?: () => void }> = ({ onSelectThread }) => {
+ *  primitive's switch-to-thread action (not on the row's ••• actions).
+ *  `highlightActive` mutes the active-thread highlight while another sidebar
+ *  destination (the Net Worth) is the selected one — the runtime thread
+ *  stays active underneath, but the sidebar must not show two selections. */
+export const ThreadList: FC<{ onSelectThread?: () => void; highlightActive?: boolean }> = ({
+  onSelectThread,
+  highlightActive = true,
+}) => {
   return (
     <ThreadListPrimitive.Root data-slot="aui_thread-list-root" className="flex flex-col">
       <AuiIf condition={(s) => s.threads.isLoading}>
         <ThreadListSkeleton />
       </AuiIf>
       <AuiIf condition={(s) => !s.threads.isLoading}>
-        <ThreadListItemGroups onSelectThread={onSelectThread} />
+        <ThreadListItemGroups onSelectThread={onSelectThread} highlightActive={highlightActive} />
       </AuiIf>
     </ThreadListPrimitive.Root>
   );
@@ -91,15 +98,18 @@ function useSessionTimes(threadIds: readonly string[]): Map<string, number> {
   return times;
 }
 
-const ThreadListItemGroups: FC<{ onSelectThread?: () => void }> = ({ onSelectThread }) => {
+const ThreadListItemGroups: FC<{ onSelectThread?: () => void; highlightActive?: boolean }> = ({
+  onSelectThread,
+  highlightActive,
+}) => {
   const threadIds = useAuiState((s) => s.threads.threadIds);
   const times = useSessionTimes(threadIds);
 
   // ItemByIndex takes a component (not an element), so bind the callback once.
   const BoundThreadListItem = useMemo(() => {
-    const Bound: FC = () => <ThreadListItem onSelect={onSelectThread} />;
+    const Bound: FC = () => <ThreadListItem onSelect={onSelectThread} highlightActive={highlightActive} />;
     return Bound;
-  }, [onSelectThread]);
+  }, [onSelectThread, highlightActive]);
 
   const groups = useMemo<ThreadListGroup[] | null>(() => {
     if (times.size === 0) return null;
@@ -171,21 +181,31 @@ const ThreadListSkeleton: FC = () => {
   );
 };
 
-export const ThreadListItem: FC<{ onSelect?: () => void }> = ({ onSelect }) => {
+export const ThreadListItem: FC<{ onSelect?: () => void; highlightActive?: boolean }> = ({
+  onSelect,
+  highlightActive = true,
+}) => {
   return (
     <ThreadListItemPrimitive.Root asChild>
       <SidebarMenuItem data-slot="aui_thread-list-item" className="group/thread-list-item">
         <ThreadListItemPrimitive.Trigger asChild>
           {/* Active-thread highlight: aui marks the Root (the <li>) with
               data-active, so mirror the button's own data-active styles off
-              the parent. Same for an open "more" menu keeping the row lit.
-              group-hover: the ••• action is a sibling overlaying the row, so
-              the button's own :hover drops while the pointer is on it — key
-              the hover highlight off the whole row instead. */}
+              the parent — but only while the chat is the selected sidebar
+              destination (highlightActive); the runtime thread stays active
+              while the Net Worth is open, and the sidebar must not show
+              two selections. Same for an open "more" menu keeping the row
+              lit. group-hover: the ••• action is a sibling overlaying the
+              row, so the button's own :hover drops while the pointer is on
+              it — key the hover highlight off the whole row instead. */}
           <SidebarMenuButton
             data-slot="aui_thread-list-item-trigger"
             onClick={onSelect}
-            className="group-hover/menu-item:bg-sidebar-accent group-hover/menu-item:text-sidebar-accent-foreground group-data-active/menu-item:bg-sidebar-accent group-data-active/menu-item:text-sidebar-accent-foreground group-data-active/menu-item:font-medium group-has-data-popup-open/menu-item:bg-sidebar-accent"
+            className={cn(
+              "group-hover/menu-item:bg-sidebar-accent group-hover/menu-item:text-sidebar-accent-foreground group-has-data-popup-open/menu-item:bg-sidebar-accent",
+              highlightActive &&
+                "group-data-active/menu-item:bg-sidebar-accent group-data-active/menu-item:text-sidebar-accent-foreground group-data-active/menu-item:font-medium",
+            )}
           >
             <span data-slot="aui_thread-list-item-title" className="min-w-0 flex-1 truncate">
               <ThreadListItemPrimitive.Title fallback="New Chat" />

--- a/packages/desktop/src/renderer/components/accountant24/thread-list.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/thread-list.tsx
@@ -23,11 +23,13 @@ import {
 import { sessionsApi } from "@/rpc/api";
 
 /** The sidebar's primary action — lives in the SidebarHeader, outside the nav
- *  list, per the shadcn sidebar recipe (header = actions, content = nav). */
-export const ThreadListNew: FC = () => {
+ *  list, per the shadcn sidebar recipe (header = actions, content = nav).
+ *  `onSelect` fires alongside the primitive's new-thread action (the layout
+ *  uses it to bring the chat view back). */
+export const ThreadListNew: FC<{ onSelect?: () => void }> = ({ onSelect }) => {
   return (
     <ThreadListPrimitive.New asChild>
-      <Button variant="outline" data-slot="aui_thread-list-new" className="w-full">
+      <Button variant="outline" data-slot="aui_thread-list-new" className="w-full" onClick={onSelect}>
         <PlusIcon data-icon="inline-start" />
         New Chat
       </Button>
@@ -35,14 +37,16 @@ export const ThreadListNew: FC = () => {
   );
 };
 
-export const ThreadList: FC = () => {
+/** `onSelectThread` fires when a thread row is clicked, alongside the
+ *  primitive's switch-to-thread action (not on the row's ••• actions). */
+export const ThreadList: FC<{ onSelectThread?: () => void }> = ({ onSelectThread }) => {
   return (
     <ThreadListPrimitive.Root data-slot="aui_thread-list-root" className="flex flex-col">
       <AuiIf condition={(s) => s.threads.isLoading}>
         <ThreadListSkeleton />
       </AuiIf>
       <AuiIf condition={(s) => !s.threads.isLoading}>
-        <ThreadListItemGroups />
+        <ThreadListItemGroups onSelectThread={onSelectThread} />
       </AuiIf>
     </ThreadListPrimitive.Root>
   );
@@ -87,9 +91,15 @@ function useSessionTimes(threadIds: readonly string[]): Map<string, number> {
   return times;
 }
 
-const ThreadListItemGroups: FC = () => {
+const ThreadListItemGroups: FC<{ onSelectThread?: () => void }> = ({ onSelectThread }) => {
   const threadIds = useAuiState((s) => s.threads.threadIds);
   const times = useSessionTimes(threadIds);
+
+  // ItemByIndex takes a component (not an element), so bind the callback once.
+  const BoundThreadListItem = useMemo(() => {
+    const Bound: FC = () => <ThreadListItem onSelect={onSelectThread} />;
+    return Bound;
+  }, [onSelectThread]);
 
   const groups = useMemo<ThreadListGroup[] | null>(() => {
     if (times.size === 0) return null;
@@ -118,7 +128,7 @@ const ThreadListItemGroups: FC = () => {
       <SidebarGroup>
         <SidebarGroupContent>
           <SidebarMenu>
-            <ThreadListPrimitive.Items>{() => <ThreadListItem />}</ThreadListPrimitive.Items>
+            <ThreadListPrimitive.Items>{() => <BoundThreadListItem />}</ThreadListPrimitive.Items>
           </SidebarMenu>
         </SidebarGroupContent>
       </SidebarGroup>
@@ -131,7 +141,11 @@ const ThreadListItemGroups: FC = () => {
       <SidebarGroupContent>
         <SidebarMenu>
           {group.indices.map((index) => (
-            <ThreadListPrimitive.ItemByIndex key={threadIds[index]} index={index} components={{ ThreadListItem }} />
+            <ThreadListPrimitive.ItemByIndex
+              key={threadIds[index]}
+              index={index}
+              components={{ ThreadListItem: BoundThreadListItem }}
+            />
           ))}
         </SidebarMenu>
       </SidebarGroupContent>
@@ -157,7 +171,7 @@ const ThreadListSkeleton: FC = () => {
   );
 };
 
-export const ThreadListItem: FC = () => {
+export const ThreadListItem: FC<{ onSelect?: () => void }> = ({ onSelect }) => {
   return (
     <ThreadListItemPrimitive.Root asChild>
       <SidebarMenuItem data-slot="aui_thread-list-item" className="group/thread-list-item">
@@ -170,6 +184,7 @@ export const ThreadListItem: FC = () => {
               the hover highlight off the whole row instead. */}
           <SidebarMenuButton
             data-slot="aui_thread-list-item-trigger"
+            onClick={onSelect}
             className="group-hover/menu-item:bg-sidebar-accent group-hover/menu-item:text-sidebar-accent-foreground group-data-active/menu-item:bg-sidebar-accent group-data-active/menu-item:text-sidebar-accent-foreground group-data-active/menu-item:font-medium group-has-data-popup-open/menu-item:bg-sidebar-accent"
           >
             <span data-slot="aui_thread-list-item-title" className="min-w-0 flex-1 truncate">

--- a/packages/desktop/src/renderer/components/accountant24/use-net-worth.ts
+++ b/packages/desktop/src/renderer/components/accountant24/use-net-worth.ts
@@ -1,0 +1,45 @@
+"use client";
+
+// The net worth report feed, shared by the page and the sidebar badge.
+
+import { useAuiState } from "@assistant-ui/react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ledgerApi } from "@/rpc/api";
+import type { NetWorth } from "@/rpc/types";
+
+/** null = first load in flight; no section rows = loaded but empty (no
+ *  journal yet or hledger failed — both render the empty state pointing at
+ *  the agent). */
+export function useNetWorth(): NetWorth | null {
+  const [data, setData] = useState<NetWorth | null>(null);
+
+  const refresh = useCallback(() => {
+    let cancelled = false;
+    ledgerApi
+      .netWorth()
+      .then((d) => {
+        if (!cancelled) setData(d);
+      })
+      .catch(() => {
+        if (!cancelled) setData({ sections: [], net: { amounts: [], value: [] } });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => refresh(), [refresh]);
+
+  // Refetch on the running → idle edge (the finished turn may have posted
+  // transactions). Existing rows stay up while the refresh is in flight, so
+  // the list never flickers back to the skeleton. Same pattern as mentions.tsx.
+  const isRunning = useAuiState((s) => s.thread.isRunning);
+  const wasRunning = useRef(isRunning);
+  useEffect(() => {
+    const justFinished = wasRunning.current && !isRunning;
+    wasRunning.current = isRunning;
+    if (justFinished) return refresh();
+  }, [isRunning, refresh]);
+
+  return data;
+}

--- a/packages/desktop/src/renderer/components/shadcn/empty.tsx
+++ b/packages/desktop/src/renderer/components/shadcn/empty.tsx
@@ -1,0 +1,87 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "flex w-full min-w-0 flex-1 flex-col items-center justify-center gap-4 rounded-2xl border-dashed p-12 text-center text-balance",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div data-slot="empty-header" className={cn("flex max-w-sm flex-col items-center gap-2", className)} {...props} />
+  );
+}
+
+const emptyMediaVariants = cva(
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "flex size-10 shrink-0 items-center justify-center rounded-xl bg-muted text-foreground [&_svg:not([class*='size-'])]:size-5",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  );
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn("font-heading text-lg font-medium tracking-tight", className)}
+      {...props}
+    />
+  );
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn("flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance", className)}
+      {...props}
+    />
+  );
+}
+
+export { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle };

--- a/packages/desktop/src/renderer/components/shadcn/table.tsx
+++ b/packages/desktop/src/renderer/components/shadcn/table.tsx
@@ -1,0 +1,73 @@
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
+      <table data-slot="table" className={cn("w-full caption-bottom text-sm", className)} {...props} />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return <thead data-slot="table-header" className={cn("[&_tr]:border-b", className)} {...props} />;
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return <tbody data-slot="table-body" className={cn("[&_tr:last-child]:border-0", className)} {...props} />;
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn("border-t bg-muted/50 font-medium [&>tr]:last:border-b-0", className)}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-12 px-3 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn("p-3 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0", className)}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({ className, ...props }: React.ComponentProps<"caption">) {
+  return (
+    <caption data-slot="table-caption" className={cn("mt-4 text-sm text-muted-foreground", className)} {...props} />
+  );
+}
+
+export { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow };

--- a/packages/desktop/src/renderer/lib/__tests__/amountFormat.test.ts
+++ b/packages/desktop/src/renderer/lib/__tests__/amountFormat.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { LedgerAmount } from "@/rpc/types";
-import { formatAmount, formatAmounts, formatValue, isConverted } from "../amountFormat";
+import { formatAmount, formatAmounts, formatValue, formatValueCompact, isConverted } from "../amountFormat";
 
 // Spec for the Net Worth view's number presentation. Every commodity
 // reads the same way: locale-formatted number, commodity code as a suffix
@@ -154,5 +154,30 @@ describe("formatValue()", () => {
 
   it("should render an empty figure as an empty string", () => {
     expect(formatValue({ amounts: [], value: [] }, "en-US")).toBe("");
+  });
+});
+
+describe("formatValueCompact()", () => {
+  it("should render a converted figure as ~ plus the compact number and code", () => {
+    expect(
+      formatValueCompact({ amounts: [a("UAH", 1408.26), a("USD", 100)], value: [a("EUR", 333534.3)] }, "en-US"),
+    ).toBe("~334K EUR");
+  });
+
+  it("should render an exact figure compactly without the marker", () => {
+    expect(formatValueCompact({ amounts: [a("EUR", 2736)], value: [a("EUR", 2736)] }, "en-US")).toBe("2.7K EUR");
+  });
+
+  it("should keep a sub-thousand figure as a plain rounded number", () => {
+    expect(formatValueCompact({ amounts: [a("EUR", 988.54)], value: [a("EUR", 988.54)] }, "en-US")).toBe("989 EUR");
+  });
+
+  it("should comma-join a multi-commodity figure compactly", () => {
+    const amounts = [a("EUR", 1200), a("UAH", 5000)];
+    expect(formatValueCompact({ amounts, value: [a("EUR", 1200), a("UAH", 5000)] }, "en-US")).toBe("1.2K EUR, 5K UAH");
+  });
+
+  it("should render an empty figure as an empty string", () => {
+    expect(formatValueCompact({ amounts: [], value: [] }, "en-US")).toBe("");
   });
 });

--- a/packages/desktop/src/renderer/lib/__tests__/amountFormat.test.ts
+++ b/packages/desktop/src/renderer/lib/__tests__/amountFormat.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type { LedgerAmount } from "@/rpc/types";
+import { formatAmount, formatAmounts } from "../amountFormat";
+
+// Spec for the Balance Sheet view's number presentation. Every commodity
+// reads the same way: locale-formatted number, commodity code as a suffix
+// (hledger's own display convention). Locales are pinned per assertion so
+// the expectations are deterministic. hledger owns the numbers; this module
+// owns only how they read.
+
+const a = (commodity: string, quantity: number, precision = 2): LedgerAmount => ({ commodity, quantity, precision });
+
+describe("formatAmount()", () => {
+  it("should format every commodity the same way: number then code", () => {
+    expect(formatAmount(a("EUR", 123, 2), "value", "en-US")).toBe("123.00 EUR");
+    expect(formatAmount(a("UAH", 10, 2), "value", "en-US")).toBe("10.00 UAH");
+    expect(formatAmount(a("BTC", 1, 8), "native", "en-US")).toBe("1.00 BTC");
+    expect(formatAmount(a("SXR8", 22.45, 2), "native", "en-US")).toBe("22.45 SXR8");
+  });
+
+  describe("value mode (market value, money presentation)", () => {
+    it("should group digits and show 2 fraction digits", () => {
+      expect(formatAmount(a("EUR", 6145.5, 3), "value", "en-US")).toBe("6,145.50 EUR");
+    });
+
+    it("should round a value carried at higher precision to 2 digits", () => {
+      expect(formatAmount(a("EUR", 35185.862, 3), "value", "en-US")).toBe("35,185.86 EUR");
+    });
+
+    it("should format negative money with a leading minus", () => {
+      expect(formatAmount(a("EUR", -2000, 2), "value", "en-US")).toBe("-2,000.00 EUR");
+    });
+
+    it("should keep a whole-unit commodity whole", () => {
+      expect(formatAmount(a("GOOG", 24, 0), "value", "en-US")).toBe("24 GOOG");
+    });
+
+    it("should keep the own precision of a sub-1 quantity (unconverted crypto)", () => {
+      expect(formatAmount(a("BTC", 0.165, 3), "value", "en-US")).toBe("0.165 BTC");
+    });
+
+    it("should follow the locale for digit separators", () => {
+      // uk-UA: space-grouped digits, comma decimals (the exact space
+      // character varies by ICU version, so match loosely around it).
+      expect(formatAmount(a("EUR", 6145.5, 3), "value", "uk-UA")).toMatch(/^6.145,50 EUR$/);
+    });
+  });
+
+  describe("native mode (original holding, own precision)", () => {
+    it("should keep full crypto precision", () => {
+      expect(formatAmount(a("BTC", 1.23456789, 8), "native", "en-US")).toBe("1.23456789 BTC");
+    });
+
+    it("should trim trailing zeros beyond 2 digits", () => {
+      expect(formatAmount(a("ZEC", 0.37854, 8), "native", "en-US")).toBe("0.37854 ZEC");
+    });
+
+    it("should cap precision at 8 digits", () => {
+      expect(formatAmount(a("BTC", 0.123456789012, 12), "native", "en-US")).toBe("0.12345679 BTC");
+    });
+
+    it("should format fiat natively with 2-digit precision and grouping", () => {
+      expect(formatAmount(a("UAH", 1408.26, 2), "native", "en-US")).toBe("1,408.26 UAH");
+    });
+
+    it("should keep a whole share count whole", () => {
+      expect(formatAmount(a("GOOG", 24, 0), "native", "en-US")).toBe("24 GOOG");
+    });
+
+    it("should still group digits in large ticker quantities", () => {
+      expect(formatAmount(a("P500", 2500, 2), "native", "en-US")).toBe("2,500.00 P500");
+    });
+  });
+
+  it("should render a bare number when the commodity is empty", () => {
+    expect(formatAmount(a("", 5, 0), "native", "en-US")).toBe("5");
+  });
+});
+
+describe("formatAmounts()", () => {
+  it("should join a multi-commodity amount with commas on one line (hledger's convention)", () => {
+    expect(formatAmounts([a("EUR", 7796.25), a("UAH", 1000)], "value", "en-US")).toBe("7,796.25 EUR, 1,000.00 UAH");
+  });
+
+  it("should render a single amount without separators", () => {
+    expect(formatAmounts([a("EUR", 50)], "value", "en-US")).toBe("50.00 EUR");
+  });
+
+  it("should render an empty list as an empty string", () => {
+    expect(formatAmounts([], "value", "en-US")).toBe("");
+  });
+});

--- a/packages/desktop/src/renderer/lib/__tests__/amountFormat.test.ts
+++ b/packages/desktop/src/renderer/lib/__tests__/amountFormat.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { LedgerAmount } from "@/rpc/types";
 import { formatAmount, formatAmounts, formatValue, isConverted } from "../amountFormat";
 
-// Spec for the Balance Sheet view's number presentation. Every commodity
+// Spec for the Net Worth view's number presentation. Every commodity
 // reads the same way: locale-formatted number, commodity code as a suffix
 // (hledger's own display convention). Locales are pinned per assertion so
 // the expectations are deterministic. hledger owns the numbers; this module

--- a/packages/desktop/src/renderer/lib/__tests__/amountFormat.test.ts
+++ b/packages/desktop/src/renderer/lib/__tests__/amountFormat.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { LedgerAmount } from "@/rpc/types";
-import { formatAmount, formatAmounts } from "../amountFormat";
+import { formatAmount, formatAmounts, formatValue, isConverted } from "../amountFormat";
 
 // Spec for the Balance Sheet view's number presentation. Every commodity
 // reads the same way: locale-formatted number, commodity code as a suffix
@@ -88,5 +88,71 @@ describe("formatAmounts()", () => {
 
   it("should render an empty list as an empty string", () => {
     expect(formatAmounts([], "value", "en-US")).toBe("");
+  });
+});
+
+describe("isConverted()", () => {
+  it("should be false when the value equals the native amounts", () => {
+    expect(isConverted({ amounts: [a("EUR", 50)], value: [a("EUR", 50)] })).toBe(false);
+  });
+
+  it("should be false for an identical multi-commodity figure", () => {
+    const amounts = [a("EUR", 7796.25), a("UAH", 1000)];
+    expect(isConverted({ amounts, value: [a("EUR", 7796.25), a("UAH", 1000)] })).toBe(false);
+  });
+
+  it("should be true when valuation changed the quantity", () => {
+    expect(isConverted({ amounts: [a("UAH", 1000)], value: [a("UAH", 999)] })).toBe(true);
+  });
+
+  it("should be true when valuation changed the commodity", () => {
+    expect(isConverted({ amounts: [a("UAH", 1000)], value: [a("EUR", 19.58)] })).toBe(true);
+  });
+
+  it("should be true when valuation collapsed several commodities into one", () => {
+    expect(isConverted({ amounts: [a("UAH", 1408.26), a("USD", 100)], value: [a("EUR", 115.573, 3)] })).toBe(true);
+  });
+
+  it("should be false when both sides are empty", () => {
+    expect(isConverted({ amounts: [], value: [] })).toBe(false);
+  });
+
+  it("should be true when only one side is empty", () => {
+    expect(isConverted({ amounts: [a("EUR", 1)], value: [] })).toBe(true);
+    expect(isConverted({ amounts: [], value: [a("EUR", 1)] })).toBe(true);
+  });
+
+  it("should ignore display-precision differences (presentation metadata, not value)", () => {
+    expect(isConverted({ amounts: [a("EUR", 50, 3)], value: [a("EUR", 50, 2)] })).toBe(false);
+  });
+});
+
+describe("formatValue()", () => {
+  it("should prefix a converted figure with ~ (an estimate at the last recorded rate)", () => {
+    expect(formatValue({ amounts: [a("UAH", 1408.26), a("USD", 100)], value: [a("EUR", 115.573, 3)] }, "en-US")).toBe(
+      "~115.57 EUR",
+    );
+  });
+
+  it("should render an exact figure without the marker", () => {
+    expect(formatValue({ amounts: [a("EUR", 50)], value: [a("EUR", 50)] }, "en-US")).toBe("50.00 EUR");
+  });
+
+  it("should render an unconverted multi-commodity figure comma-joined and unmarked", () => {
+    const amounts = [a("EUR", 7796.25), a("UAH", 1000)];
+    expect(formatValue({ amounts, value: [a("EUR", 7796.25), a("UAH", 1000)] }, "en-US")).toBe(
+      "7,796.25 EUR, 1,000.00 UAH",
+    );
+  });
+
+  it("should mark a partially converted multi-commodity figure", () => {
+    // UAH got valued, the ticker stayed native: still an estimate overall.
+    expect(
+      formatValue({ amounts: [a("UAH", 1000), a("XYZ", 5)], value: [a("EUR", 19.58), a("XYZ", 5)] }, "en-US"),
+    ).toBe("~19.58 EUR, 5.00 XYZ");
+  });
+
+  it("should render an empty figure as an empty string", () => {
+    expect(formatValue({ amounts: [], value: [] }, "en-US")).toBe("");
   });
 });

--- a/packages/desktop/src/renderer/lib/amountFormat.ts
+++ b/packages/desktop/src/renderer/lib/amountFormat.ts
@@ -40,3 +40,26 @@ export function formatAmount(a: LedgerAmount, mode: "value" | "native", locale?:
 export function formatAmounts(amounts: LedgerAmount[], mode: "value" | "native", locale?: string): string {
   return amounts.map((a) => formatAmount(a, mode, locale)).join(", ");
 }
+
+/** A report figure: the native amounts paired with their market value. */
+export interface ValuedFigure {
+  amounts: LedgerAmount[];
+  value: LedgerAmount[];
+}
+
+/** True when hledger's valuation actually changed the figure — a different
+ *  commodity list or different quantities than the native amounts. Display
+ *  precision is ignored: it's presentation metadata, not value. */
+export function isConverted({ amounts, value }: ValuedFigure): boolean {
+  return (
+    amounts.length !== value.length ||
+    amounts.some((a, i) => a.quantity !== value[i]?.quantity || a.commodity !== value[i]?.commodity)
+  );
+}
+
+/** Format a figure's market-value line. Converted figures get a leading "~":
+ *  they are estimates at the last rate recorded in the ledger, not exact
+ *  balances. A figure the valuation left untouched renders without it. */
+export function formatValue(figure: ValuedFigure, locale?: string): string {
+  return `${isConverted(figure) ? "~" : ""}${formatAmounts(figure.value, "value", locale)}`;
+}

--- a/packages/desktop/src/renderer/lib/amountFormat.ts
+++ b/packages/desktop/src/renderer/lib/amountFormat.ts
@@ -63,3 +63,15 @@ export function isConverted({ amounts, value }: ValuedFigure): boolean {
 export function formatValue(figure: ValuedFigure, locale?: string): string {
   return `${isConverted(figure) ? "~" : ""}${formatAmounts(figure.value, "value", locale)}`;
 }
+
+/** The market-value line for tight chrome (the sidebar badge): the same "~"
+ *  semantics as formatValue, the number in Intl's compact notation
+ *  ("~334K EUR"). Empty when there is no value to show. */
+export function formatValueCompact(figure: ValuedFigure, locale?: string): string {
+  if (figure.value.length === 0) return "";
+  const compact = new Intl.NumberFormat(locale, { notation: "compact" });
+  const joined = figure.value
+    .map((a) => (a.commodity ? `${compact.format(a.quantity)} ${a.commodity}` : compact.format(a.quantity)))
+    .join(", ");
+  return `${isConverted(figure) ? "~" : ""}${joined}`;
+}

--- a/packages/desktop/src/renderer/lib/amountFormat.ts
+++ b/packages/desktop/src/renderer/lib/amountFormat.ts
@@ -1,4 +1,4 @@
-// Locale-aware presentation of hledger amounts for the Balance Sheet view.
+// Locale-aware presentation of hledger amounts for the Net Worth view.
 //
 // hledger computes the numbers; this module only decides how they read.
 // Every amount reads the same way — "1,234.56 EUR", "986.54 UAH",

--- a/packages/desktop/src/renderer/lib/amountFormat.ts
+++ b/packages/desktop/src/renderer/lib/amountFormat.ts
@@ -1,0 +1,42 @@
+// Locale-aware presentation of hledger amounts for the Balance Sheet view.
+//
+// hledger computes the numbers; this module only decides how they read.
+// Every amount reads the same way — "1,234.56 EUR", "986.54 UAH",
+// "0.02895303 BTC", "2.74 SXR8" — the number in the locale's digits and
+// separators with the commodity code as a suffix, which is also hledger's
+// own display convention. (Routing fiat through Intl's currency styles used
+// to mix symbol-first fiat, code-first crypto, and suffixed tickers on one
+// page.)
+
+import type { LedgerAmount } from "@/rpc/types";
+
+/** How many fraction digits an amount gets.
+ *  - "value" (market value): a money estimate — 2 digits, except whole-unit
+ *    commodities (share counts) stay whole and sub-1 quantities (crypto that
+ *    price data left unconverted) keep their own precision.
+ *  - "native" (original holding): the amount's own precision, capped at 8,
+ *    with at least 2 shown for fractional commodities. */
+function fractionDigits(a: LedgerAmount, mode: "value" | "native"): { min: number; max: number } {
+  if (a.precision === 0) return { min: 0, max: 0 };
+  if (mode === "value") {
+    if (Math.abs(a.quantity) < 1 && a.precision > 2) return { min: 2, max: Math.min(a.precision, 8) };
+    return { min: 2, max: 2 };
+  }
+  return { min: Math.min(a.precision, 2), max: Math.min(Math.max(a.precision, 2), 8) };
+}
+
+/** Format one amount for display. `locale` defaults to the runtime locale. */
+export function formatAmount(a: LedgerAmount, mode: "value" | "native", locale?: string): string {
+  const { min, max } = fractionDigits(a, mode);
+  const number = new Intl.NumberFormat(locale, {
+    minimumFractionDigits: min,
+    maximumFractionDigits: max,
+  }).format(a.quantity);
+  return a.commodity ? `${number} ${a.commodity}` : number;
+}
+
+/** Format a multi-commodity amount on one line, comma-separated — hledger's
+ *  own one-line convention ("7,796.25 EUR, 1,000.00 UAH"). */
+export function formatAmounts(amounts: LedgerAmount[], mode: "value" | "native", locale?: string): string {
+  return amounts.map((a) => formatAmount(a, mode, locale)).join(", ");
+}

--- a/packages/desktop/src/renderer/lib/tool-labels.ts
+++ b/packages/desktop/src/renderer/lib/tool-labels.ts
@@ -8,6 +8,8 @@
 export const TOOL_LABELS: Record<string, string> = {
   query: "Query Ledger",
   add_transactions: "Add Transactions",
+  add_balance_assertions: "Add Balance Assertions",
+  add_prices: "Add Prices",
   extract_text: "Extract Text",
   update_memory: "Update Memory",
   validate: "Validate Ledger",

--- a/packages/desktop/src/renderer/rpc/api.ts
+++ b/packages/desktop/src/renderer/rpc/api.ts
@@ -11,6 +11,7 @@ import type {
   AuthModels,
   AuthProviders,
   AuthStatus,
+  BalanceSheet,
   LedgerMentions,
   OllamaInfo,
   SessionAgentEvent,
@@ -126,6 +127,8 @@ export const settingsApi = {
 export const ledgerApi = {
   /** Fetch accounts/payees/tags for the @-mention picker. */
   mentions: () => api.invoke<LedgerMentions>("ledger_mentions"),
+  /** Fetch the `hledger bs` report (sections + net) for the Balance Sheet view. */
+  balanceSheet: () => api.invoke<BalanceSheet>("ledger_balance_sheet"),
 };
 
 export const skillsApi = {

--- a/packages/desktop/src/renderer/rpc/api.ts
+++ b/packages/desktop/src/renderer/rpc/api.ts
@@ -11,8 +11,8 @@ import type {
   AuthModels,
   AuthProviders,
   AuthStatus,
-  BalanceSheet,
   LedgerMentions,
+  NetWorth,
   OllamaInfo,
   SessionAgentEvent,
   SessionSummary,
@@ -127,8 +127,8 @@ export const settingsApi = {
 export const ledgerApi = {
   /** Fetch accounts/payees/tags for the @-mention picker. */
   mentions: () => api.invoke<LedgerMentions>("ledger_mentions"),
-  /** Fetch the `hledger bs` report (sections + net) for the Balance Sheet view. */
-  balanceSheet: () => api.invoke<BalanceSheet>("ledger_balance_sheet"),
+  /** Fetch the `hledger bs` report (sections + net) for the Net Worth view. */
+  netWorth: () => api.invoke<NetWorth>("ledger_net_worth"),
 };
 
 export const skillsApi = {

--- a/packages/desktop/src/renderer/rpc/types.ts
+++ b/packages/desktop/src/renderer/rpc/types.ts
@@ -8,11 +8,11 @@ import type { SkillInfo } from "../../shared/types";
 export type {
   AccountBalance,
   AppSettings,
-  BalanceSheet,
-  BalanceSheetSection,
-  BalanceSheetTotal,
   LedgerAmount,
   LedgerMentions,
+  NetWorth,
+  NetWorthSection,
+  NetWorthTotal,
   SkillAddRequest,
   SkillInfo,
 } from "../../shared/types";

--- a/packages/desktop/src/renderer/rpc/types.ts
+++ b/packages/desktop/src/renderer/rpc/types.ts
@@ -5,7 +5,17 @@
 
 import type { SkillInfo } from "../../shared/types";
 
-export type { AppSettings, LedgerMentions, SkillAddRequest, SkillInfo } from "../../shared/types";
+export type {
+  AccountBalance,
+  AppSettings,
+  BalanceSheet,
+  BalanceSheetSection,
+  BalanceSheetTotal,
+  LedgerAmount,
+  LedgerMentions,
+  SkillAddRequest,
+  SkillInfo,
+} from "../../shared/types";
 
 // ---- Models -------------------------------------------------------------
 

--- a/packages/desktop/src/shared/types.ts
+++ b/packages/desktop/src/shared/types.ts
@@ -45,7 +45,7 @@ export interface AccountBalance {
 
 /** A figure of the report that isn't an account row: a section total or the
  *  net line — native amounts paired with their market value like a row. */
-export interface BalanceSheetTotal {
+export interface NetWorthTotal {
   amounts: LedgerAmount[];
   value: LedgerAmount[];
 }
@@ -53,18 +53,18 @@ export interface BalanceSheetTotal {
 /** One `hledger bs` subreport: Assets or Liabilities, rows in hledger's
  *  order with hledger's own sign convention (liabilities positive) and the
  *  section's hledger-computed total. */
-export interface BalanceSheetSection {
+export interface NetWorthSection {
   /** hledger's section name ("Assets", "Liabilities"), verbatim. */
   name: string;
   rows: AccountBalance[];
-  total: BalanceSheetTotal;
+  total: NetWorthTotal;
 }
 
-/** The Balance Sheet view payload: `hledger bs` as data — sections plus the
+/** The Net Worth view payload: `hledger bs` as data — sections plus the
  *  hledger-computed net (assets minus liabilities). */
-export interface BalanceSheet {
-  sections: BalanceSheetSection[];
-  net: BalanceSheetTotal;
+export interface NetWorth {
+  sections: NetWorthSection[];
+  net: NetWorthTotal;
 }
 
 // ---- App settings (app-owned config in ~/Accountant24/app-settings.json) ---

--- a/packages/desktop/src/shared/types.ts
+++ b/packages/desktop/src/shared/types.ts
@@ -37,6 +37,10 @@ export interface AccountBalance {
    *  base-currency figure when hledger finds a price path, otherwise equal
    *  to `amounts`. This is the primary number the report views show. */
   value: LedgerAmount[];
+  /** ISO date of the account's most recent balance assertion in the journal
+   *  (the posting's own date when it has one) — when the balance was last
+   *  reconciled. Absent when the account has no assertions. */
+  assertedOn?: string;
 }
 
 /** A figure of the report that isn't an account row: a section total or the

--- a/packages/desktop/src/shared/types.ts
+++ b/packages/desktop/src/shared/types.ts
@@ -15,6 +15,54 @@ export interface LedgerMentions {
   tags: string[];
 }
 
+// ---- Ledger balances (Accounts view) --------------------------------------
+
+/** One commodity of a balance, as hledger computed it (exact numbers from the
+ *  JSON report; the renderer decides presentation). */
+export interface LedgerAmount {
+  quantity: number;
+  /** Commodity symbol ("EUR", "BTC", "SXR8"), unquoted. */
+  commodity: string;
+  /** Decimal places hledger carries for this amount (display precision). */
+  precision: number;
+}
+
+/** One account row of a balance report, in hledger's own order. */
+export interface AccountBalance {
+  /** Full account path ("assets:bank:checking"), verbatim. */
+  name: string;
+  /** The balance in its original commodities, one entry per commodity. */
+  amounts: LedgerAmount[];
+  /** The same balance at market value (`-X` valuation) — a single
+   *  base-currency figure when hledger finds a price path, otherwise equal
+   *  to `amounts`. This is the primary number the report views show. */
+  value: LedgerAmount[];
+}
+
+/** A figure of the report that isn't an account row: a section total or the
+ *  net line — native amounts paired with their market value like a row. */
+export interface BalanceSheetTotal {
+  amounts: LedgerAmount[];
+  value: LedgerAmount[];
+}
+
+/** One `hledger bs` subreport: Assets or Liabilities, rows in hledger's
+ *  order with hledger's own sign convention (liabilities positive) and the
+ *  section's hledger-computed total. */
+export interface BalanceSheetSection {
+  /** hledger's section name ("Assets", "Liabilities"), verbatim. */
+  name: string;
+  rows: AccountBalance[];
+  total: BalanceSheetTotal;
+}
+
+/** The Balance Sheet view payload: `hledger bs` as data — sections plus the
+ *  hledger-computed net (assets minus liabilities). */
+export interface BalanceSheet {
+  sections: BalanceSheetSection[];
+  net: BalanceSheetTotal;
+}
+
 // ---- App settings (app-owned config in ~/Accountant24/app-settings.json) ---
 
 /** The app's own settings schema (app-owned keys, distinct from pi's config,

--- a/packages/pi-extension/src/__tests__/extension.test.ts
+++ b/packages/pi-extension/src/__tests__/extension.test.ts
@@ -36,10 +36,10 @@ function createMockPi() {
 }
 
 describe("accountant24Extension()", () => {
-  test("should register 6 custom tools (built-ins are pi's own)", () => {
+  test("should register 8 custom tools (built-ins are pi's own)", () => {
     const pi = createMockPi();
     accountant24Extension(pi as any);
-    expect(pi.registerTool).toHaveBeenCalledTimes(6);
+    expect(pi.registerTool).toHaveBeenCalledTimes(8);
   });
 
   test("should register session_start and before_agent_start handlers", () => {

--- a/packages/pi-extension/src/extension.ts
+++ b/packages/pi-extension/src/extension.ts
@@ -5,6 +5,8 @@ import { getMemory } from "./memory";
 import { ensureScaffolded } from "./scaffold/scaffold";
 import { buildContextSection, buildToolsSection, patchBakedDate } from "./system-prompt";
 import {
+  addBalanceAssertionsTool,
+  addPricesTool,
   addTransactionsTool,
   commitAndPushTool,
   extractTextTool,
@@ -20,6 +22,8 @@ export function createAccountantExtension(pi: ExtensionAPI): void {
   // Register custom tools (pi registers its own built-in tools, bound to the agent
   // cwd, which the app sets to the workspace).
   pi.registerTool(queryTool);
+  pi.registerTool(addBalanceAssertionsTool);
+  pi.registerTool(addPricesTool);
   pi.registerTool(addTransactionsTool);
   pi.registerTool(commitAndPushTool);
   pi.registerTool(extractTextTool);

--- a/packages/pi-extension/src/ledger/__tests__/transactions.test.ts
+++ b/packages/pi-extension/src/ledger/__tests__/transactions.test.ts
@@ -21,7 +21,7 @@ function makeMockProc(exitCode: number, stdout = "", stderr = "") {
   return { exitCode, stdout, stderr };
 }
 
-const { addTransactions } = await import("../transactions.js");
+const { addTransactions, addBalanceAssertions, addPrices } = await import("../transactions.js");
 
 /** Helper: add a single transaction and return a flat result for backward-compatible test assertions. */
 async function addTransaction(params: any, signal?: AbortSignal) {
@@ -104,6 +104,186 @@ describe("addTransaction() input validation", () => {
     writeFileSync(join(LEDGER, "main.journal"), "");
     const result = await addTransaction(basicParams);
     expect(result.ledgerIsValid).toBe(true);
+  });
+});
+
+// ── Balance assertions (standalone checkpoints) ─────────────────────
+
+describe("addBalanceAssertions()", () => {
+  const checkpoint = {
+    date: "2026-03-15",
+    account: "Assets:Bank:Cash",
+    balance: { amount: 200, currency: "EUR" },
+  };
+
+  test("should save a standalone checkpoint entry", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    const result = await addBalanceAssertions([checkpoint]);
+    expect(result.ledgerIsValid).toBe(true);
+    expect(result.transactions).toHaveLength(1);
+  });
+
+  test("should format the canonical payee and hledger's `= balance` syntax, keeping the column alignment", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    const result = await addBalanceAssertions([checkpoint]);
+    const text = result.transactions[0].transactionText;
+    expect(text.split("\n")[0]).toBe("2026-03-15 * Balance Assertion");
+    const line = findLine(text, "Assets:Bank:Cash");
+    expect(line).toMatch(/0\.00 EUR = 200\.00 EUR$/);
+    // First digit stays at column 70 (1-indexed), like every other posting.
+    expect(line.indexOf("0.00 EUR")).toBe(69);
+  });
+
+  test("should format a negative confirmed balance", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    const result = await addBalanceAssertions([{ ...checkpoint, balance: { amount: -133.51, currency: "EUR" } }]);
+    expect(findLine(result.transactions[0].transactionText, "Assets:Bank:Cash")).toMatch(/0\.00 EUR = -133\.51 EUR$/);
+  });
+
+  test("should route the checkpoint to the monthly file of its date", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    const result = await addBalanceAssertions([checkpoint]);
+    expect(result.transactions[0].fullFilePath).toContain("2026/03.journal");
+  });
+
+  test("should write each assertion of a batch as its own journal entry", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    const result = await addBalanceAssertions([
+      checkpoint,
+      { date: "2026-03-15", account: "Assets:Bank:Checking", balance: { amount: 500, currency: "EUR" } },
+    ]);
+    expect(result.transactions).toHaveLength(2);
+    // Two standalone entries in the monthly file — never merged into one,
+    // even on the same date.
+    const file = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    expect(file.match(/^2026-03-15 \* Balance Assertion$/gm)).toHaveLength(2);
+    expect(findLine(file, "Assets:Bank:Checking")).toMatch(/0\.00 EUR = 500\.00 EUR$/);
+  });
+
+  test("should reject a date not in YYYY-MM-DD format", async () => {
+    await expect(addBalanceAssertions([{ ...checkpoint, date: "March 15" }])).rejects.toThrow("Invalid date format");
+  });
+
+  test("should reject a missing account", async () => {
+    await expect(addBalanceAssertions([{ ...checkpoint, account: "" }])).rejects.toThrow("missing an account");
+  });
+
+  test("should reject a balance without an amount", async () => {
+    await expect(addBalanceAssertions([{ ...checkpoint, balance: { currency: "EUR" } }] as any)).rejects.toThrow(
+      "missing the balance amount",
+    );
+  });
+
+  test("should reject a balance without a currency", async () => {
+    await expect(addBalanceAssertions([{ ...checkpoint, balance: { amount: 200 } }] as any)).rejects.toThrow(
+      "missing the balance currency",
+    );
+  });
+
+  test("should point at the offending assertion when a batch fails validation", async () => {
+    await expect(addBalanceAssertions([checkpoint, { ...checkpoint, account: "" }])).rejects.toThrow(
+      "Assertion 2: Balance assertion is missing an account.",
+    );
+  });
+
+  test("should surface hledger's error when the assertion does not hold", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    vi.mocked(spawnText).mockResolvedValue(makeMockProc(1, "", "balance assertion failed"));
+    await expect(addBalanceAssertions([checkpoint])).rejects.toThrow("balance assertion failed");
+  });
+});
+
+// ── Market prices (standalone P directives) ─────────────────────────
+
+describe("addPrices()", () => {
+  const rate = {
+    date: "2026-03-15",
+    commodity: "USD",
+    price: { amount: 0.87, currency: "EUR" },
+  };
+
+  test("should format the P directive verbatim", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    const result = await addPrices([rate]);
+    expect(result.ledgerIsValid).toBe(true);
+    expect(result.transactions[0].transactionText).toBe("P 2026-03-15 USD 0.87 EUR");
+  });
+
+  test("should double-quote a commodity containing digits, as hledger requires", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    const result = await addPrices([{ ...rate, commodity: "SOL2" }]);
+    expect(result.transactions[0].transactionText).toBe('P 2026-03-15 "SOL2" 0.87 EUR');
+  });
+
+  test("should double-quote a target currency containing digits", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    const result = await addPrices([{ ...rate, price: { amount: 0.87, currency: "SOL2" } }]);
+    expect(result.transactions[0].transactionText).toBe('P 2026-03-15 USD 0.87 "SOL2"');
+  });
+
+  test("should preserve the rate's full precision instead of rounding to 2 decimals", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    const result = await addPrices([{ ...rate, commodity: "UAH", price: { amount: 0.0205, currency: "EUR" } }]);
+    expect(result.transactions[0].transactionText).toBe("P 2026-03-15 UAH 0.0205 EUR");
+  });
+
+  test("should render a tiny rate in plain decimal, never exponential notation", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    const result = await addPrices([{ ...rate, commodity: "SAT", price: { amount: 0.0000005, currency: "EUR" } }]);
+    expect(result.transactions[0].transactionText).toBe("P 2026-03-15 SAT 0.0000005 EUR");
+  });
+
+  test("should route each price of a batch to the monthly file of its date", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    await addPrices([rate, { date: "2026-04-02", commodity: "BTC", price: { amount: 55000, currency: "EUR" } }]);
+    expect(readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8")).toContain("P 2026-03-15 USD 0.87 EUR");
+    expect(readFileSync(join(LEDGER, "2026", "04.journal"), "utf-8")).toContain("P 2026-04-02 BTC 55000 EUR");
+  });
+
+  test("should declare both sides of the price as commodities when missing", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    await addPrices([{ ...rate, commodity: "BTC" }]);
+    const commodities = readFileSync(join(LEDGER, "commodities.journal"), "utf-8");
+    expect(commodities).toContain("commodity BTC");
+    expect(commodities).toContain("commodity EUR");
+  });
+
+  test("should reject a date not in YYYY-MM-DD format", async () => {
+    await expect(addPrices([{ ...rate, date: "March 15" }])).rejects.toThrow("Invalid date format");
+  });
+
+  test("should reject a missing commodity", async () => {
+    await expect(addPrices([{ ...rate, commodity: "" }])).rejects.toThrow("missing a commodity");
+  });
+
+  test("should reject a price without an amount", async () => {
+    await expect(addPrices([{ ...rate, price: { currency: "EUR" } }] as any)).rejects.toThrow("missing the amount");
+  });
+
+  test("should reject a zero price", async () => {
+    await expect(addPrices([{ ...rate, price: { amount: 0, currency: "EUR" } }])).rejects.toThrow("must be positive");
+  });
+
+  test("should reject a negative price", async () => {
+    await expect(addPrices([{ ...rate, price: { amount: -0.87, currency: "EUR" } }])).rejects.toThrow(
+      "must be positive",
+    );
+  });
+
+  test("should reject a price without a currency", async () => {
+    await expect(addPrices([{ ...rate, price: { amount: 0.87 } }] as any)).rejects.toThrow("missing the currency");
+  });
+
+  test("should point at the offending price when a batch fails validation", async () => {
+    await expect(addPrices([rate, { ...rate, commodity: "" }])).rejects.toThrow(
+      "Price 2: Price is missing a commodity.",
+    );
+  });
+
+  test("should surface hledger's error when the write does not validate", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    vi.mocked(spawnText).mockResolvedValue(makeMockProc(1, "", "commodity check failed"));
+    await expect(addPrices([rate])).rejects.toThrow("commodity check failed");
   });
 });
 

--- a/packages/pi-extension/src/ledger/index.ts
+++ b/packages/pi-extension/src/ledger/index.ts
@@ -2,5 +2,5 @@ export { listAccounts } from "./accounts";
 export { listPayees } from "./payees";
 export { type QueryLedgerResult, queryLedger } from "./query";
 export { listTags } from "./tags";
-export { type AddTransactionsResult, addTransactions } from "./transactions";
+export { type AddTransactionsResult, addBalanceAssertions, addPrices, addTransactions } from "./transactions";
 export { type ValidateLedgerResult, validateLedger } from "./validate";

--- a/packages/pi-extension/src/ledger/transactions.ts
+++ b/packages/pi-extension/src/ledger/transactions.ts
@@ -19,6 +19,22 @@ export interface AddTransactionParams {
   tags?: Array<{ name: string; value?: string }>;
 }
 
+/** A standalone balance checkpoint: hledger's balance assertion, always its
+ *  own journal entry (never attached to a regular transaction). */
+export interface AddBalanceAssertionParams {
+  date: string;
+  account: string;
+  balance: { amount: number; currency: string };
+}
+
+/** A market price: hledger's P directive, stating what one unit of a
+ *  commodity was worth on a date. */
+export interface AddPriceParams {
+  date: string;
+  commodity: string;
+  price: { amount: number; currency: string };
+}
+
 export interface AddTransactionsResult {
   transactions: Array<{ transactionText: string; fullFilePath: string }>;
   ledgerIsValid: boolean;
@@ -37,12 +53,47 @@ export async function addTransactions(
   paramsList: AddTransactionParams[],
   signal?: AbortSignal,
 ): Promise<AddTransactionsResult> {
-  validateAll(paramsList);
-  const formatted = formatAll(paramsList);
+  validateEach(paramsList, validateInputs, "Transaction");
+  const formatted = paramsList.map((params) => routeByMonth(params.date, formatTransaction(params)));
+  const currencies = paramsList.flatMap((params) => params.postings.map((p) => p.currency));
+  return persistFormatted(formatted, currencies, signal);
+}
+
+/** Record standalone balance checkpoints: one journal entry per assertion,
+ *  each a single zero-amount posting asserting the account's actual balance.
+ *  Routed to the monthly files like any transaction; `hledger check --strict`
+ *  then proves every assertion or rejects the write with hledger's own
+ *  error. */
+export async function addBalanceAssertions(
+  paramsList: AddBalanceAssertionParams[],
+  signal?: AbortSignal,
+): Promise<AddTransactionsResult> {
+  validateEach(paramsList, validateAssertionInputs, "Assertion");
+  const formatted = paramsList.map((params) => routeByMonth(params.date, formatBalanceAssertion(params)));
+  const currencies = paramsList.map((params) => params.balance.currency);
+  return persistFormatted(formatted, currencies, signal);
+}
+
+/** Record market prices as standalone P directives, routed to the monthly
+ *  file of each date. Both sides of every price are declared as commodities,
+ *  and `hledger check --strict` validates the write; the Net Worth
+ *  report values every holding at its latest recorded price. */
+export async function addPrices(paramsList: AddPriceParams[], signal?: AbortSignal): Promise<AddTransactionsResult> {
+  validateEach(paramsList, validatePriceInputs, "Price");
+  const formatted = paramsList.map((params) => routeByMonth(params.date, formatPrice(params)));
+  const currencies = paramsList.flatMap((params) => [params.commodity, params.price.currency]);
+  return persistFormatted(formatted, currencies, signal);
+}
+
+async function persistFormatted(
+  formatted: FormattedEntry[],
+  currencies: string[],
+  signal?: AbortSignal,
+): Promise<AddTransactionsResult> {
   const byFile = groupByFile(formatted);
   const fileContents = writeMonthlyFiles(byFile);
   updateMainJournal(byFile);
-  declareMissingCommodities(paramsList);
+  declareMissingCommodities(currencies);
   await validateLedger(formatted, signal);
   const diffs = buildDiffs(byFile, fileContents);
   const transactions = formatted.map((f) => ({ transactionText: f.text, fullFilePath: f.fullFilePath }));
@@ -51,25 +102,25 @@ export async function addTransactions(
 
 // ── Pipeline steps ─────────────────────────────────────────────────
 
-function validateAll(paramsList: AddTransactionParams[]): void {
+/** Validate every item, prefixing errors with the item's position (as
+ *  `label`) so batch failures point at the offending entry. */
+function validateEach<T>(paramsList: T[], validate: (params: T) => void, label: string): void {
   for (let i = 0; i < paramsList.length; i++) {
     try {
-      validateInputs(paramsList[i]);
+      validate(paramsList[i]);
     } catch (e) {
       if (paramsList.length > 1 && e instanceof Error) {
-        throw new Error(`Transaction ${i + 1}: ${e.message}`);
+        throw new Error(`${label} ${i + 1}: ${e.message}`);
       }
       throw e;
     }
   }
 }
 
-function formatAll(paramsList: AddTransactionParams[]): FormattedEntry[] {
-  return paramsList.map((params) => {
-    const [year, month] = params.date.split("-");
-    const fullFilePath = resolveSafePath(`${year}/${month}.journal`, LEDGER_DIR);
-    return { text: formatTransaction(params), fileKey: `${year}/${month}`, fullFilePath };
-  });
+/** Every entry lives in the monthly journal of its date. */
+function routeByMonth(date: string, text: string): FormattedEntry {
+  const [year, month] = date.split("-");
+  return { text, fileKey: `${year}/${month}`, fullFilePath: resolveSafePath(`${year}/${month}.journal`, LEDGER_DIR) };
 }
 
 function groupByFile(formatted: FormattedEntry[]): Map<string, FormattedEntry[]> {
@@ -145,13 +196,8 @@ function updateMainJournal(byFile: Map<string, FormattedEntry[]>): void {
   }
 }
 
-function declareMissingCommodities(paramsList: AddTransactionParams[]): void {
-  const allCurrencies = new Set<string>();
-  for (const params of paramsList) {
-    for (const p of params.postings) {
-      allCurrencies.add(p.currency);
-    }
-  }
+function declareMissingCommodities(currencies: string[]): void {
+  const allCurrencies = new Set<string>(currencies);
 
   const commoditiesPath = resolveSafePath("commodities.journal", LEDGER_DIR);
   const commoditiesContent = existsSync(commoditiesPath) ? readFileSync(commoditiesPath, "utf-8") : "";
@@ -216,6 +262,39 @@ function validateInputs(params: Pick<AddTransactionParams, "date" | "postings">)
   }
 }
 
+function validateAssertionInputs(params: AddBalanceAssertionParams): void {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(params.date)) {
+    throw new Error(`Invalid date format: ${params.date}. Expected YYYY-MM-DD.`);
+  }
+  if (!params.account) {
+    throw new Error("Balance assertion is missing an account.");
+  }
+  if (params.balance?.amount == null) {
+    throw new Error(`Balance assertion for ${params.account} is missing the balance amount.`);
+  }
+  if (!params.balance.currency) {
+    throw new Error(`Balance assertion for ${params.account} is missing the balance currency.`);
+  }
+}
+
+function validatePriceInputs(params: AddPriceParams): void {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(params.date)) {
+    throw new Error(`Invalid date format: ${params.date}. Expected YYYY-MM-DD.`);
+  }
+  if (!params.commodity) {
+    throw new Error("Price is missing a commodity.");
+  }
+  if (params.price?.amount == null) {
+    throw new Error(`Price for ${params.commodity} is missing the amount.`);
+  }
+  if (!(params.price.amount > 0)) {
+    throw new Error(`Price for ${params.commodity} must be positive.`);
+  }
+  if (!params.price.currency) {
+    throw new Error(`Price for ${params.commodity} is missing the currency.`);
+  }
+}
+
 function formatTransaction(params: AddTransactionParams): string {
   const header = params.description
     ? `${params.date} * ${params.payee} | ${params.description}`
@@ -249,4 +328,40 @@ function formatTransaction(params: AddTransactionParams): string {
   }
 
   return lines.join("\n");
+}
+
+/** Every checkpoint carries the same canonical payee, so assertions are easy
+ *  to spot (and query) in the journal. */
+const BALANCE_ASSERTION_PAYEE = "Balance Assertion";
+
+function formatBalanceAssertion(params: AddBalanceAssertionParams): string {
+  const header = `${params.date} * ${BALANCE_ASSERTION_PAYEE}`;
+  // A zero-amount posting moves no money and balances on its own; hledger's
+  // `= balance` after the amount is the assertion being checked.
+  const amountStr = `0.00 ${params.balance.currency}`;
+  const prefix = `    ${params.account}`;
+  const pad = Math.max(2, 69 - prefix.length);
+  const assertion = ` = ${params.balance.amount.toFixed(2)} ${params.balance.currency}`;
+  return `${header}\n${prefix}${" ".repeat(pad)}${amountStr}${assertion}`;
+}
+
+/** hledger requires double quotes around a commodity symbol containing
+ *  anything besides letters or currency signs (digits, spaces, punctuation)
+ *  — e.g. a ticker like "SOL2". */
+function quoteCommodity(commodity: string): string {
+  return /^[\p{L}\p{Sc}]+$/u.test(commodity) ? commodity : `"${commodity}"`;
+}
+
+/** Plain decimal rendering preserving the given precision — market rates
+ *  carry meaning in their decimals (0.0205), so no fixed rounding; tiny
+ *  rates must never fall into exponential notation. */
+function formatPriceAmount(amount: number): string {
+  const plain = String(amount);
+  if (!plain.toLowerCase().includes("e")) return plain;
+  return amount.toFixed(20).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+function formatPrice(params: AddPriceParams): string {
+  const amount = `${formatPriceAmount(params.price.amount)} ${quoteCommodity(params.price.currency)}`;
+  return `P ${params.date} ${quoteCommodity(params.commodity)} ${amount}`;
 }

--- a/packages/pi-extension/src/system-prompt/system.md
+++ b/packages/pi-extension/src/system-prompt/system.md
@@ -61,8 +61,9 @@ These rules are absolute. Do not violate them.
 - Handle multiple transactions independently — add complete ones; clarify incomplete ones.
 - Watch for potential duplicates. Flag them rather than silently adding or skipping.
 - Memory is for user-stated facts, preferences, categorization rules, and recurring arrangements. Not for transaction-specific context (belongs in description/tags) or payee-to-account mappings (query the ledger).
-- When the user states an actual balance, verify it against the ledger and add an assertion. Investigate discrepancies before suggesting a reconciliation transaction.
-- Prefer purpose-built tools (query, add_transactions, validate, extract_text, update_memory, commit_and_push) over file tools (read, edit, write, grep, find, ls). Use bash only as a last resort when no other tool can achieve the goal.
+- When the user states an actual balance (for example "My cash balance is 200 EUR"), verify it against the ledger and record a checkpoint with `add_balance_assertions`; investigate discrepancies before anything else.
+- When the user states a market rate or asset price (for example "1 USD is 0.92 EUR" or "BTC is 60,000 EUR"), record it with `add_prices`; the latest prices drive the Net Worth valuation.
+- Prefer purpose-built tools (query, add_transactions, add_balance_assertions, add_prices, validate, extract_text, update_memory, commit_and_push) over file tools (read, edit, write, grep, find, ls). Use bash only as a last resort when no other tool can achieve the goal.
 
 </heuristics>
 

--- a/packages/pi-extension/src/tool-labels.ts
+++ b/packages/pi-extension/src/tool-labels.ts
@@ -5,6 +5,8 @@
 export const TOOL_LABELS: Record<string, string> = {
   query: "Query Ledger",
   add_transactions: "Add Transactions",
+  add_balance_assertions: "Add Balance Assertions",
+  add_prices: "Add Prices",
   extract_text: "Extract Text",
   update_memory: "Update Memory",
   validate: "Validate Ledger",

--- a/packages/pi-extension/src/tools/__tests__/add-balance-assertions.test.ts
+++ b/packages/pi-extension/src/tools/__tests__/add-balance-assertions.test.ts
@@ -1,0 +1,79 @@
+import { afterAll, beforeEach, expect, test, vi } from "vitest";
+import { spawnText } from "../../spawn";
+
+vi.mock("../../spawn");
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const BASE = mkdtempSync(join(tmpdir(), "accountant24-add-ba-"));
+const LEDGER = join(BASE, "ledger");
+
+vi.mock("../../config.js", () => ({
+  ACCOUNTANT24_HOME: BASE,
+  LEDGER_DIR: LEDGER,
+  MEMORY_PATH: join(BASE, "memory.md"),
+  setBaseDir: () => {},
+}));
+
+// Mock at spawnText level so real hledger.ts functions execute for coverage.
+
+function makeMockProc(exitCode: number, stdout = "", stderr = "") {
+  return { exitCode, stdout, stderr };
+}
+
+const { addBalanceAssertionsTool } = await import("../add-balance-assertions.js");
+
+afterAll(() => {
+  rmSync(BASE, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  vi.mocked(spawnText).mockImplementation(async () => makeMockProc(0));
+  rmSync(LEDGER, { recursive: true, force: true });
+  mkdirSync(LEDGER, { recursive: true });
+});
+
+const run = (params: any) =>
+  addBalanceAssertionsTool.execute("test", params, undefined, undefined, undefined as any) as Promise<any>;
+
+const checkpoint = {
+  date: "2026-03-15",
+  account: "Assets:Bank:Cash",
+  balance: { amount: 200, currency: "EUR" },
+};
+
+test("saves a standalone checkpoint and reports the entry text", async () => {
+  writeFileSync(join(LEDGER, "main.journal"), "");
+  const result = await run({ assertions: [checkpoint] });
+  const text = result.content[0].text;
+  expect(text).toContain("Balance assertion saved to");
+  expect(text).toContain("2026-03-15 * Balance Assertion");
+  expect(text).toMatch(/Assets:Bank:Cash\s+0\.00 EUR = 200\.00 EUR/);
+});
+
+test("routes the entry to ledger/YYYY/MM.journal and returns diffs in details", async () => {
+  writeFileSync(join(LEDGER, "main.journal"), "");
+  const result = await run({ assertions: [checkpoint] });
+  const filePath = join(LEDGER, "2026", "03.journal");
+  expect(existsSync(filePath)).toBe(true);
+  expect(readFileSync(filePath, "utf-8")).toContain("Balance Assertion");
+  expect(result.details.diffs).toHaveLength(1);
+  expect(result.details.diffs[0].diff).toContain("= 200.00 EUR");
+});
+
+test("reports a numbered list when several assertions are saved at once", async () => {
+  writeFileSync(join(LEDGER, "main.journal"), "");
+  const result = await run({
+    assertions: [
+      checkpoint,
+      { date: "2026-03-15", account: "Assets:Bank:Checking", balance: { amount: 500, currency: "EUR" } },
+    ],
+  });
+  const text = result.content[0].text;
+  expect(text).toContain("2 balance assertions saved");
+  expect(text).toContain("1. ");
+  expect(text).toContain("2. ");
+  expect(text).toMatch(/Assets:Bank:Checking\s+0\.00 EUR = 500\.00 EUR/);
+});

--- a/packages/pi-extension/src/tools/__tests__/add-prices.test.ts
+++ b/packages/pi-extension/src/tools/__tests__/add-prices.test.ts
@@ -1,0 +1,75 @@
+import { afterAll, beforeEach, expect, test, vi } from "vitest";
+import { spawnText } from "../../spawn";
+
+vi.mock("../../spawn");
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const BASE = mkdtempSync(join(tmpdir(), "accountant24-add-prices-"));
+const LEDGER = join(BASE, "ledger");
+
+vi.mock("../../config.js", () => ({
+  ACCOUNTANT24_HOME: BASE,
+  LEDGER_DIR: LEDGER,
+  MEMORY_PATH: join(BASE, "memory.md"),
+  setBaseDir: () => {},
+}));
+
+// Mock at spawnText level so real hledger.ts functions execute for coverage.
+
+function makeMockProc(exitCode: number, stdout = "", stderr = "") {
+  return { exitCode, stdout, stderr };
+}
+
+const { addPricesTool } = await import("../add-prices.js");
+
+afterAll(() => {
+  rmSync(BASE, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  vi.mocked(spawnText).mockImplementation(async () => makeMockProc(0));
+  rmSync(LEDGER, { recursive: true, force: true });
+  mkdirSync(LEDGER, { recursive: true });
+});
+
+const run = (params: any) =>
+  addPricesTool.execute("test", params, undefined, undefined, undefined as any) as Promise<any>;
+
+const rate = {
+  date: "2026-03-15",
+  commodity: "USD",
+  price: { amount: 0.87, currency: "EUR" },
+};
+
+test("saves a P directive and reports its text", async () => {
+  writeFileSync(join(LEDGER, "main.journal"), "");
+  const result = await run({ prices: [rate] });
+  const text = result.content[0].text;
+  expect(text).toContain("Price saved to");
+  expect(text).toContain("P 2026-03-15 USD 0.87 EUR");
+});
+
+test("routes the directive to ledger/YYYY/MM.journal and returns diffs in details", async () => {
+  writeFileSync(join(LEDGER, "main.journal"), "");
+  const result = await run({ prices: [rate] });
+  const filePath = join(LEDGER, "2026", "03.journal");
+  expect(existsSync(filePath)).toBe(true);
+  expect(readFileSync(filePath, "utf-8")).toContain("P 2026-03-15 USD 0.87 EUR");
+  expect(result.details.diffs).toHaveLength(1);
+  expect(result.details.diffs[0].diff).toContain("P 2026-03-15 USD 0.87 EUR");
+});
+
+test("reports a numbered list when several prices are saved at once", async () => {
+  writeFileSync(join(LEDGER, "main.journal"), "");
+  const result = await run({
+    prices: [rate, { date: "2026-03-15", commodity: "BTC", price: { amount: 55000, currency: "EUR" } }],
+  });
+  const text = result.content[0].text;
+  expect(text).toContain("2 prices saved");
+  expect(text).toContain("1. ");
+  expect(text).toContain("2. ");
+  expect(text).toContain("P 2026-03-15 BTC 55000 EUR");
+});

--- a/packages/pi-extension/src/tools/add-balance-assertions.ts
+++ b/packages/pi-extension/src/tools/add-balance-assertions.ts
@@ -1,0 +1,53 @@
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { type AddTransactionsResult, addBalanceAssertions } from "../ledger";
+import { TOOL_LABELS } from "../tool-labels";
+
+const Assertion = Type.Object({
+  date: Type.String({ description: "Assertion date in YYYY-MM-DD format, usually today" }),
+  account: Type.String({ description: "Account whose balance the user confirmed, e.g. Assets:Bank:Checking" }),
+  balance: Type.Object(
+    {
+      amount: Type.Number({ description: "The confirmed total balance of the account" }),
+      currency: Type.String({ description: "Currency code of the balance, e.g. USD, EUR" }),
+    },
+    { description: "The account's actual balance, as stated by the user" },
+  ),
+});
+
+const Params = Type.Object({
+  assertions: Type.Array(Assertion, { minItems: 1, description: "One or more balance assertions to record" }),
+});
+
+export const addBalanceAssertionsTool: ToolDefinition<typeof Params, AddTransactionsResult> = {
+  name: "add_balance_assertions",
+  label: TOOL_LABELS.add_balance_assertions,
+  description:
+    "Record balance assertions: standalone checkpoint entries stating each account's confirmed balance. " +
+    "hledger verifies them on save and rejects the write when the ledger disagrees.",
+  promptSnippet: "Record balance checkpoints when the user confirms an account's actual balance",
+  promptGuidelines: [
+    "Before calling add_balance_assertions, compare each stated balance with the ledger's balance for that account (query).",
+    "A balance assertion is always a standalone entry — never attach it to a regular transaction.",
+    "Record an assertion only once the ledger matches reality; hledger rejects an assertion that does not hold.",
+  ],
+  parameters: Params,
+
+  async execute(_id, params, signal) {
+    const result = await addBalanceAssertions(params.assertions, signal);
+
+    let text: string;
+    if (result.transactions.length === 1) {
+      const tx = result.transactions[0];
+      text = `Balance assertion saved to ${tx.fullFilePath}:\n\n${tx.transactionText}`;
+    } else {
+      const parts = result.transactions.map((tx, i) => `${i + 1}. ${tx.fullFilePath}:\n\n${tx.transactionText}`);
+      text = `${result.transactions.length} balance assertions saved:\n\n${parts.join("\n\n")}`;
+    }
+
+    return {
+      content: [{ type: "text", text }],
+      details: result,
+    };
+  },
+};

--- a/packages/pi-extension/src/tools/add-prices.ts
+++ b/packages/pi-extension/src/tools/add-prices.ts
@@ -1,0 +1,54 @@
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { type AddTransactionsResult, addPrices } from "../ledger";
+import { TOOL_LABELS } from "../tool-labels";
+
+const Price = Type.Object({
+  date: Type.String({ description: "Date the rate was observed, in YYYY-MM-DD format, usually today" }),
+  commodity: Type.String({ description: "Commodity being priced, e.g. USD, BTC, AAPL" }),
+  price: Type.Object(
+    {
+      amount: Type.Number({ description: "Price of one unit of the commodity" }),
+      currency: Type.String({ description: "Currency the price is quoted in, e.g. EUR" }),
+    },
+    { description: "The market price of one unit of the commodity" },
+  ),
+});
+
+const Params = Type.Object({
+  prices: Type.Array(Price, { minItems: 1, description: "One or more market prices to record" }),
+});
+
+export const addPricesTool: ToolDefinition<typeof Params, AddTransactionsResult> = {
+  name: "add_prices",
+  label: TOOL_LABELS.add_prices,
+  description:
+    "Record market prices (hledger P directives): what one unit of a commodity was worth on a date. " +
+    "Auto-routes to the correct monthly files and validates.",
+  promptSnippet: "Record market prices when the user states a current rate or asset price",
+  promptGuidelines: [
+    "Record prices toward the user's main currency; the Net Worth report values every holding at its latest recorded price.",
+    "A price is a standalone P directive, not a transaction. Record one when the user states a rate; purchases already imply prices through their cost.",
+  ],
+  parameters: Params,
+
+  async execute(_id, params, signal) {
+    const result = await addPrices(params.prices, signal);
+
+    let text: string;
+    if (result.transactions.length === 1) {
+      const price = result.transactions[0];
+      text = `Price saved to ${price.fullFilePath}:\n\n${price.transactionText}`;
+    } else {
+      const parts = result.transactions.map(
+        (price, i) => `${i + 1}. ${price.fullFilePath}:\n\n${price.transactionText}`,
+      );
+      text = `${result.transactions.length} prices saved:\n\n${parts.join("\n\n")}`;
+    }
+
+    return {
+      content: [{ type: "text", text }],
+      details: result,
+    };
+  },
+};

--- a/packages/pi-extension/src/tools/index.ts
+++ b/packages/pi-extension/src/tools/index.ts
@@ -1,3 +1,5 @@
+export { addBalanceAssertionsTool } from "./add-balance-assertions";
+export { addPricesTool } from "./add-prices";
 export { addTransactionsTool } from "./add-transactions";
 export { commitAndPushTool } from "./commit-and-push";
 export { extractTextTool } from "./extract-text";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -66,10 +66,10 @@ export default defineConfig({
       // Kept just under the current effective baseline so the gate is honest
       // (green today) and each new test suite raises it.
       thresholds: {
-        statements: 97.5,
-        branches: 92,
-        functions: 97.5,
-        lines: 98.5,
+        statements: 97.7,
+        branches: 92.1,
+        functions: 97.7,
+        lines: 98.8,
       },
     },
   },


### PR DESCRIPTION
Re-opens #28: it was merged before the last two commits landed; the merge was reverted on main (4ab36d1) and this PR carries the complete branch.

## What

A Net Worth page in the sidebar, plus the agent tools to keep it current.

- The classic report from `hledger bs -O json`: Assets and Liabilities data tables (sortable, searchable) with hledger's own totals and the Net Worth line at the bottom.
- Valued in the journal's own base currency, derived from the latest recorded price (no hardcoded EUR); `~` marks converted values, which are estimates.
- A Last Balance Assertion column shows when each account was last reconciled, and (i) tooltips explain every column and teach the phrases the agent understands ("My cash balance is 200 EUR", "1 USD is 0.92 EUR").
- New agent tools: `add_balance_assertions` (standalone balance checkpoints, batched) and `add_prices` (market prices as P directives), wired into the system prompt.
- The sidebar entry shows the compact net worth ("~333K EUR"), refreshed after every agent turn.

## Tests

Unit, component, integration, and e2e specs for the page, parsers, and tools. Full verify passes (1879 tests, coverage gates met).