### PR TITLE
feat: keep journal files date-sorted and consistently formatted

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,14 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
   "files": {
-    "includes": ["packages/pi-extension/**", "packages/desktop/**", "*.json", "*.ts", "!**/*.css"]
+    "includes": [
+      "packages/pi-extension/**",
+      "packages/desktop/**",
+      "packages/hledger-journal/**",
+      "*.json",
+      "*.ts",
+      "!**/*.css"
+    ]
   },
   "vcs": {
     "enabled": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,10 @@
       "resolved": "packages/desktop",
       "link": true
     },
+    "node_modules/@accountant24/hledger-journal": {
+      "resolved": "packages/hledger-journal",
+      "link": true
+    },
     "node_modules/@accountant24/pi-extension": {
       "resolved": "packages/pi-extension",
       "link": true
@@ -18718,9 +18722,13 @@
         "node": ">=14.17"
       }
     },
+    "packages/hledger-journal": {
+      "name": "@accountant24/hledger-journal"
+    },
     "packages/pi-extension": {
       "name": "@accountant24/pi-extension",
       "dependencies": {
+        "@accountant24/hledger-journal": "*",
         "@earendil-works/pi-coding-agent": "0.79.8",
         "file-type": "22.0.1",
         "typebox": "1.1.38"

--- a/packages/hledger-journal/package.json
+++ b/packages/hledger-journal/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@accountant24/hledger-journal",
+  "private": true,
+  "type": "module",
+  "description": "hledger journal file parsing, formatting, and conservative editing (pure text in/out).",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/hledger-journal/src/__tests__/doc.test.ts
+++ b/packages/hledger-journal/src/__tests__/doc.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, test } from "vitest";
+import { JournalDoc } from "../doc";
+
+const TX_MARCH_1 = "2026-03-01 * Old | Existing\n    Expenses:X    10.00 USD\n    Assets:Y\n";
+const TX_MARCH_20 = "2026-03-20 * Late | Rent\n    Expenses:Rent    900.00 USD\n    Assets:Y\n";
+const NEW_ENTRY =
+  "2026-03-15 * Whole Foods | Groceries\n    Assets:Checking    -45.00 USD\n    Expenses:Food    45.00 USD";
+
+describe("JournalDoc", () => {
+  describe("open() + serialize()", () => {
+    test("should round-trip a mixed journal byte-for-byte", () => {
+      const text = `; header\n\ninclude accounts.journal\n\n${TX_MARCH_1}\n${TX_MARCH_20}`;
+      expect(JournalDoc.open(text).serialize()).toBe(text);
+    });
+
+    test("should round-trip CRLF content byte-for-byte", () => {
+      const text = "2026-03-01 * Old\r\n    Expenses:X    10.00 USD\r\n    Assets:Y\r\n";
+      expect(JournalDoc.open(text).serialize()).toBe(text);
+    });
+
+    test("should round-trip a file without a trailing newline byte-for-byte", () => {
+      const text = "include accounts.journal\n\n2026-03-01 * Old\n    Expenses:X    10.00 USD\n    Assets:Y";
+      expect(JournalDoc.open(text).serialize()).toBe(text);
+    });
+
+    test("should round-trip an empty file", () => {
+      expect(JournalDoc.open("").serialize()).toBe("");
+    });
+  });
+
+  describe("entries()", () => {
+    test("should list dated transaction and price blocks in file order with their indices", () => {
+      const doc = JournalDoc.open(`; header\n\n${TX_MARCH_1}\nP 2026-03-10 USD 0.87 EUR\n\n${TX_MARCH_20}`);
+      expect(doc.entries()).toMatchObject([
+        { index: 2, date: "2026-03-01" },
+        { index: 4, date: "2026-03-10" },
+        { index: 6, date: "2026-03-20" },
+      ]);
+    });
+
+    test("should exclude blocks whose date is unparseable", () => {
+      const doc = JournalDoc.open(
+        "2026-13-05 * Broken\n    A    1.00 USD\n\n2026-03-01 * Ok\n    A    1.00 USD\n    B\n",
+      );
+      expect(doc.entries()).toMatchObject([{ date: "2026-03-01" }]);
+    });
+  });
+
+  describe("insertEntry()", () => {
+    test("should write just the entry into an empty doc", () => {
+      const doc = JournalDoc.open("");
+      doc.insertEntry(NEW_ENTRY, "2026-03-15");
+      expect(doc.serialize()).toBe(`${NEW_ENTRY}\n`);
+    });
+
+    test("should append after all entries with exactly one blank line, matching the historical append bytes", () => {
+      const doc = JournalDoc.open(TX_MARCH_1);
+      doc.insertEntry(NEW_ENTRY, "2026-03-15");
+      // Historical behavior (writeMonthlyFiles): `${oldContent}\n${entry}\n`.
+      expect(doc.serialize()).toBe(`${TX_MARCH_1}\n${NEW_ENTRY}\n`);
+    });
+
+    test("should terminate a file lacking a trailing newline before appending", () => {
+      const doc = JournalDoc.open(TX_MARCH_1.trimEnd());
+      doc.insertEntry(NEW_ENTRY, "2026-03-15");
+      // Historical behavior: `${oldContent}\n\n${entry}\n`.
+      expect(doc.serialize()).toBe(`${TX_MARCH_1.trimEnd()}\n\n${NEW_ENTRY}\n`);
+    });
+
+    test("should insert between entries in date order with one blank line on each side", () => {
+      const doc = JournalDoc.open(`${TX_MARCH_1}\n${TX_MARCH_20}`);
+      doc.insertEntry(NEW_ENTRY, "2026-03-15");
+      expect(doc.serialize()).toBe(`${TX_MARCH_1}\n${NEW_ENTRY}\n\n${TX_MARCH_20}`);
+    });
+
+    test("should insert before all entries when the date is earliest", () => {
+      const doc = JournalDoc.open(TX_MARCH_20);
+      doc.insertEntry(NEW_ENTRY, "2026-03-15");
+      expect(doc.serialize()).toBe(`${NEW_ENTRY}\n\n${TX_MARCH_20}`);
+    });
+
+    test("should insert a same-date entry after the existing entries of that date", () => {
+      const first = "2026-03-15 * First\n    A    1.00 USD\n    B\n";
+      const doc = JournalDoc.open(`${first}\n${TX_MARCH_20}`);
+      doc.insertEntry(NEW_ENTRY, "2026-03-15");
+      expect(doc.serialize()).toBe(`${first}\n${NEW_ENTRY}\n\n${TX_MARCH_20}`);
+    });
+
+    test("should insert after the last on-or-before entry even when the file is unsorted", () => {
+      const doc = JournalDoc.open(`${TX_MARCH_20}\n${TX_MARCH_1}`);
+      doc.insertEntry(NEW_ENTRY, "2026-03-15");
+      expect(doc.serialize()).toBe(`${TX_MARCH_20}\n${TX_MARCH_1}\n${NEW_ENTRY}\n`);
+    });
+
+    test("should insert a P directive among transactions by date", () => {
+      const doc = JournalDoc.open(`${TX_MARCH_1}\n${TX_MARCH_20}`);
+      doc.insertEntry("P 2026-03-10 USD 0.87 EUR", "2026-03-10");
+      expect(doc.serialize()).toBe(`${TX_MARCH_1}\nP 2026-03-10 USD 0.87 EUR\n\n${TX_MARCH_20}`);
+    });
+
+    test("should not separate a comment glued to the following transaction", () => {
+      const doc = JournalDoc.open(`${TX_MARCH_1}; about rent\n${TX_MARCH_20}`);
+      doc.insertEntry(NEW_ENTRY, "2026-03-15");
+      expect(doc.serialize()).toBe(`${TX_MARCH_1}\n${NEW_ENTRY}\n\n; about rent\n${TX_MARCH_20}`);
+    });
+
+    test("should keep a blank-separated comment with its following transaction", () => {
+      const doc = JournalDoc.open(`${TX_MARCH_1}\n; about rent\n${TX_MARCH_20}`);
+      doc.insertEntry(NEW_ENTRY, "2026-03-15");
+      expect(doc.serialize()).toBe(`${TX_MARCH_1}\n${NEW_ENTRY}\n\n; about rent\n${TX_MARCH_20}`);
+    });
+
+    test("should insert after a trailing comment that has no following transaction", () => {
+      const doc = JournalDoc.open(`${TX_MARCH_1}; trailing note\n`);
+      doc.insertEntry(NEW_ENTRY, "2026-03-15");
+      expect(doc.serialize()).toBe(`${TX_MARCH_1}; trailing note\n\n${NEW_ENTRY}\n`);
+    });
+
+    test("should insert above a comment glued to the first transaction when the date is earliest", () => {
+      const doc = JournalDoc.open(`; about rent\n${TX_MARCH_20}`);
+      doc.insertEntry(NEW_ENTRY, "2026-03-15");
+      expect(doc.serialize()).toBe(`${NEW_ENTRY}\n\n; about rent\n${TX_MARCH_20}`);
+    });
+
+    test("should append at EOF when the file has no dated entries", () => {
+      const doc = JournalDoc.open("; monthly file header\n");
+      doc.insertEntry(NEW_ENTRY, "2026-03-15");
+      expect(doc.serialize()).toBe(`; monthly file header\n\n${NEW_ENTRY}\n`);
+    });
+
+    test("should render the new entry with CRLF in a CRLF file and keep old bytes untouched", () => {
+      const crlf = "2026-03-01 * Old\r\n    Expenses:X    10.00 USD\r\n    Assets:Y\r\n";
+      const doc = JournalDoc.open(crlf);
+      doc.insertEntry("2026-03-15 * New\n    A    1.00 USD\n    B", "2026-03-15");
+      expect(doc.serialize()).toBe(`${crlf}\r\n2026-03-15 * New\r\n    A    1.00 USD\r\n    B\r\n`);
+    });
+
+    test("should anchor on the last dated entry, ignoring unparseable-date blocks", () => {
+      const broken = "2026-13-05 * Broken\n    A    1.00 USD\n";
+      const doc = JournalDoc.open(`${TX_MARCH_1}\n${broken}`);
+      doc.insertEntry(NEW_ENTRY, "2026-03-15");
+      expect(doc.serialize()).toBe(`${TX_MARCH_1}\n${NEW_ENTRY}\n\n${broken}`);
+    });
+
+    test("should reject a date not in YYYY-MM-DD format", () => {
+      expect(() => JournalDoc.open("").insertEntry(NEW_ENTRY, "2026-3-15")).toThrow("Invalid date format");
+    });
+
+    test("should reject entry text that is not a transaction or P directive", () => {
+      expect(() => JournalDoc.open("").insertEntry("include a.journal", "2026-03-15")).toThrow(
+        "must be a single transaction or P directive",
+      );
+    });
+
+    test("should reject entry text spanning multiple blocks", () => {
+      const two = "2026-03-15 * A\n    X    1.00 USD\n    Y\n\n2026-03-16 * B\n    X    1.00 USD\n    Y\n";
+      expect(() => JournalDoc.open("").insertEntry(two, "2026-03-15")).toThrow("exactly one block");
+    });
+
+    test("should reject a date that is not a real calendar day", () => {
+      expect(() => JournalDoc.open("").insertEntry(NEW_ENTRY, "2026-02-31")).toThrow(
+        "That calendar day does not exist",
+      );
+    });
+
+    test("should reject entry text whose own date differs from the given date", () => {
+      expect(() => JournalDoc.open("").insertEntry(NEW_ENTRY, "2026-03-16")).toThrow("does not match");
+    });
+
+    test("should accept a non-canonical text date that names the same day", () => {
+      const doc = JournalDoc.open("");
+      doc.insertEntry("2026/3/15 * New\n    A    1.00 EUR\n    B", "2026-03-15");
+      expect(doc.serialize()).toBe("2026/3/15 * New\n    A    1.00 EUR\n    B\n");
+    });
+
+    test("should keep a missing final newline when inserting before the last block", () => {
+      const doc = JournalDoc.open(TX_MARCH_20.trimEnd());
+      doc.insertEntry(NEW_ENTRY, "2026-03-15");
+      expect(doc.serialize()).toBe(`${NEW_ENTRY}\n\n${TX_MARCH_20.trimEnd()}`);
+    });
+
+    test("should normalize CRLF entry text into an LF document", () => {
+      const doc = JournalDoc.open(TX_MARCH_1);
+      doc.insertEntry("2026-03-15 * New\r\n    A    1.00 USD\r\n    B", "2026-03-15");
+      expect(doc.serialize()).toBe(`${TX_MARCH_1}\n2026-03-15 * New\n    A    1.00 USD\n    B\n`);
+    });
+  });
+
+  describe("replaceBlock()", () => {
+    test("should replace one block and keep every other byte", () => {
+      const text = `; header\n\n${TX_MARCH_1}\n${TX_MARCH_20}`;
+      const doc = JournalDoc.open(text);
+      doc.replaceBlock(2, "2026-03-01 * Renamed\n    Expenses:X    10.00 USD\n    Assets:Y");
+      expect(doc.serialize()).toBe(
+        `; header\n\n2026-03-01 * Renamed\n    Expenses:X    10.00 USD\n    Assets:Y\n\n${TX_MARCH_20}`,
+      );
+    });
+
+    test("should reject an out-of-range index", () => {
+      expect(() => JournalDoc.open(TX_MARCH_1).replaceBlock(5, "; x")).toThrow("out of range");
+    });
+  });
+
+  describe("appendBlock()", () => {
+    test("should append with a blank-line separator", () => {
+      const doc = JournalDoc.open(TX_MARCH_1);
+      doc.appendBlock("include 2026/04.journal");
+      expect(doc.serialize()).toBe(`${TX_MARCH_1}\ninclude 2026/04.journal\n`);
+    });
+
+    test("should append to an empty document without a separator", () => {
+      const doc = JournalDoc.open("");
+      doc.appendBlock("include 2026/04.journal");
+      expect(doc.serialize()).toBe("include 2026/04.journal\n");
+    });
+  });
+
+  describe("blocks", () => {
+    test("should renumber line spans after an insertion", () => {
+      const doc = JournalDoc.open(`${TX_MARCH_1}\n${TX_MARCH_20}`);
+      doc.insertEntry(NEW_ENTRY, "2026-03-15");
+      const spans = doc.blocks.map((b) => [b.startLine, b.endLine]);
+      expect(spans).toEqual([
+        [1, 3], // March 1 transaction
+        [4, 4], // blank
+        [5, 7], // inserted entry
+        [8, 8], // blank
+        [9, 11], // March 20 transaction
+      ]);
+    });
+  });
+});

--- a/packages/hledger-journal/src/__tests__/format.test.ts
+++ b/packages/hledger-journal/src/__tests__/format.test.ts
@@ -1,0 +1,357 @@
+import { describe, expect, test } from "vitest";
+import {
+  BALANCE_ASSERTION_PAYEE,
+  formatBalanceAssertion,
+  formatPrice,
+  formatPriceAmount,
+  formatTransaction,
+  quoteCommodity,
+  renderPrice,
+  renderTransaction,
+} from "../format";
+import type { Transaction } from "../types";
+
+const basicParams = {
+  date: "2026-03-15",
+  payee: "Whole Foods",
+  description: "Groceries",
+  postings: [
+    { account: "Assets:Checking", amount: -45, currency: "USD" },
+    { account: "Expenses:Food:Groceries", amount: 45, currency: "USD" },
+  ],
+};
+
+function findLine(text: string, search: string): string {
+  const line = text.split("\n").find((l) => l.includes(search));
+  if (!line) throw new Error(`Line containing "${search}" not found in:\n${text}`);
+  return line;
+}
+
+describe("formatTransaction()", () => {
+  test("should format the full transaction byte-exactly", () => {
+    expect(formatTransaction(basicParams)).toBe(
+      [
+        "2026-03-15 * Whole Foods | Groceries",
+        `    Assets:Checking${" ".repeat(49)}-45.00 USD`,
+        `    Expenses:Food:Groceries${" ".repeat(42)}45.00 USD`,
+      ].join("\n"),
+    );
+  });
+
+  test("should format header without pipe when description is omitted", () => {
+    const { description: _, ...noDesc } = basicParams;
+    const text = formatTransaction(noDesc);
+    expect(text.split("\n")[0]).toBe("2026-03-15 * Whole Foods");
+    expect(text).not.toContain("|");
+  });
+
+  test("should align first digit of positive amount at column 70 and sign at 69", () => {
+    const text = formatTransaction(basicParams);
+    const negativeLine = findLine(text, "-45.00");
+    const positiveLine = findLine(text, " 45.00");
+    expect(negativeLine[69]).toBe("4");
+    expect(negativeLine[68]).toBe("-");
+    expect(positiveLine[69]).toBe("4");
+  });
+
+  test("should order negative amounts before positive", () => {
+    const text = formatTransaction({
+      ...basicParams,
+      postings: [
+        { account: "Expenses:Food", amount: 30, currency: "USD" },
+        { account: "Assets:Savings", amount: -30, currency: "USD" },
+      ],
+    });
+    const postingLines = text.split("\n").slice(1);
+    expect(postingLines[0]).toContain("Assets:Savings");
+    expect(postingLines[1]).toContain("Expenses:Food");
+  });
+
+  test("should preserve input order within same sign group", () => {
+    const text = formatTransaction({
+      ...basicParams,
+      postings: [
+        { account: "Expenses:Food", amount: 20, currency: "USD" },
+        { account: "Expenses:Transport", amount: 10, currency: "USD" },
+        { account: "Assets:Checking", amount: -30, currency: "USD" },
+      ],
+    });
+    const postingLines = text.split("\n").slice(1);
+    expect(postingLines[0]).toContain("Assets:Checking");
+    expect(postingLines[1]).toContain("Expenses:Food");
+    expect(postingLines[2]).toContain("Expenses:Transport");
+  });
+
+  test("should group zero amount with positives, not negatives", () => {
+    const text = formatTransaction({
+      ...basicParams,
+      postings: [
+        { account: "Expenses:Food", amount: 0, currency: "USD" },
+        { account: "Assets:Checking", amount: -10, currency: "USD" },
+        { account: "Assets:Savings", amount: 10, currency: "USD" },
+      ],
+    });
+    const postingLines = text.split("\n").slice(1);
+    expect(postingLines[0]).toContain("Assets:Checking");
+    expect(postingLines[1]).toContain("Expenses:Food");
+    expect(postingLines[2]).toContain("Assets:Savings");
+  });
+
+  test("should render zero amount as 0.00 without sign", () => {
+    const text = formatTransaction({
+      ...basicParams,
+      postings: [
+        { account: "Expenses:Food", amount: 0, currency: "USD" },
+        { account: "Assets:Checking", amount: -0, currency: "USD" },
+      ],
+    });
+    expect(findLine(text, "Expenses:Food")).toMatch(/Expenses:Food\s+0\.00 USD$/);
+    expect(text).not.toContain("-0.00");
+  });
+
+  test("should use minimum 2-space gap when account name is very long", () => {
+    const longAccount = "Expenses:Food:Groceries:Organic:Vegetables:Imported:Premium:Extra";
+    const text = formatTransaction({
+      ...basicParams,
+      postings: [
+        { account: longAccount, amount: 45, currency: "USD" },
+        { account: "Assets:Checking", amount: -45, currency: "USD" },
+      ],
+    });
+    expect(findLine(text, longAccount)).toBe(`    ${longAccount}  45.00 USD`);
+  });
+
+  test("should align amounts consistently regardless of magnitude", () => {
+    const text = formatTransaction({
+      ...basicParams,
+      postings: [
+        { account: "Expenses:Small", amount: 0.01, currency: "USD" },
+        { account: "Expenses:Large", amount: 99999.99, currency: "USD" },
+        { account: "Assets:Checking", amount: -100000, currency: "USD" },
+      ],
+    });
+    expect(findLine(text, "Expenses:Small")[69]).toBe("0");
+    expect(findLine(text, "Expenses:Large")[69]).toBe("9");
+  });
+
+  test("should place each tag on its own line before postings", () => {
+    const text = formatTransaction({ ...basicParams, tags: [{ name: "groceries" }] });
+    const lines = text.split("\n");
+    expect(lines[1]).toBe("    ; groceries:");
+    expect(lines[2]).toContain("Assets:Checking");
+  });
+
+  test("should sort tags case-insensitively by name", () => {
+    const text = formatTransaction({
+      ...basicParams,
+      tags: [{ name: "Zebra" }, { name: "alpha" }, { name: "Middle" }],
+    });
+    const tagLines = text.split("\n").filter((l) => l.trimStart().startsWith(";"));
+    expect(tagLines).toEqual(["    ; alpha:", "    ; Middle:", "    ; Zebra:"]);
+  });
+
+  test("should render tags with values as key-value comments", () => {
+    const text = formatTransaction({
+      ...basicParams,
+      tags: [
+        { name: "source", value: "manual" },
+        { name: "ref", value: "123" },
+      ],
+    });
+    expect(text).toContain("    ; ref: 123");
+    expect(text).toContain("    ; source: manual");
+  });
+
+  test("should allow duplicate tag names with different values", () => {
+    const text = formatTransaction({
+      ...basicParams,
+      tags: [
+        { name: "related_file", value: "files/receipt1.pdf" },
+        { name: "related_file", value: "files/receipt2.pdf" },
+      ],
+    });
+    const relatedLines = text.split("\n").filter((l) => l.includes("; related_file:"));
+    expect(relatedLines).toEqual(["    ; related_file: files/receipt1.pdf", "    ; related_file: files/receipt2.pdf"]);
+  });
+
+  test("should apply a custom indent and alignment column", () => {
+    const text = formatTransaction(basicParams, { indent: "  ", alignColumn: 30 });
+    expect(findLine(text, "Assets:Checking")).toBe(`  Assets:Checking${" ".repeat(12)}-45.00 USD`);
+    expect(findLine(text, "Assets:Checking")[30]).toBe("4");
+  });
+});
+
+describe("formatBalanceAssertion()", () => {
+  const checkpoint = {
+    date: "2026-03-15",
+    account: "Assets:Bank:Cash",
+    balance: { amount: 200, currency: "EUR" },
+  };
+
+  test("should format the canonical payee and hledger's `= balance` syntax, keeping the column alignment", () => {
+    const text = formatBalanceAssertion(checkpoint);
+    expect(text).toBe(`2026-03-15 * Balance Assertion\n    Assets:Bank:Cash${" ".repeat(49)}0.00 EUR = 200.00 EUR`);
+    expect(findLine(text, "Assets:Bank:Cash").indexOf("0.00 EUR")).toBe(69);
+  });
+
+  test("should format a negative confirmed balance", () => {
+    const text = formatBalanceAssertion({ ...checkpoint, balance: { amount: -133.51, currency: "EUR" } });
+    expect(findLine(text, "Assets:Bank:Cash")).toMatch(/0\.00 EUR = -133\.51 EUR$/);
+  });
+
+  test("should use the canonical payee constant by default and accept an override", () => {
+    expect(BALANCE_ASSERTION_PAYEE).toBe("Balance Assertion");
+    const text = formatBalanceAssertion({ ...checkpoint, payee: "Monthly Checkpoint" });
+    expect(text.split("\n")[0]).toBe("2026-03-15 * Monthly Checkpoint");
+  });
+});
+
+describe("formatPrice()", () => {
+  test("should format the P directive verbatim", () => {
+    expect(formatPrice({ date: "2026-03-15", commodity: "USD", price: { amount: 0.87, currency: "EUR" } })).toBe(
+      "P 2026-03-15 USD 0.87 EUR",
+    );
+  });
+
+  test("should double-quote a commodity containing digits, as hledger requires", () => {
+    expect(formatPrice({ date: "2026-03-15", commodity: "SOL2", price: { amount: 0.87, currency: "EUR" } })).toBe(
+      'P 2026-03-15 "SOL2" 0.87 EUR',
+    );
+  });
+
+  test("should double-quote a target currency containing digits", () => {
+    expect(formatPrice({ date: "2026-03-15", commodity: "USD", price: { amount: 0.87, currency: "SOL2" } })).toBe(
+      'P 2026-03-15 USD 0.87 "SOL2"',
+    );
+  });
+
+  test("should preserve the rate's full precision instead of rounding to 2 decimals", () => {
+    expect(formatPrice({ date: "2026-03-15", commodity: "UAH", price: { amount: 0.0205, currency: "EUR" } })).toBe(
+      "P 2026-03-15 UAH 0.0205 EUR",
+    );
+  });
+
+  test("should render a tiny rate in plain decimal, never exponential notation", () => {
+    expect(formatPrice({ date: "2026-03-15", commodity: "SAT", price: { amount: 0.0000005, currency: "EUR" } })).toBe(
+      "P 2026-03-15 SAT 0.0000005 EUR",
+    );
+  });
+});
+
+describe("formatPriceAmount()", () => {
+  test("should keep plain decimals untouched", () => {
+    expect(formatPriceAmount(0.0205)).toBe("0.0205");
+    expect(formatPriceAmount(55000)).toBe("55000");
+  });
+
+  test("should expand exponential notation to plain decimal", () => {
+    expect(formatPriceAmount(0.0000005)).toBe("0.0000005");
+    expect(formatPriceAmount(1e-8)).toBe("0.00000001");
+  });
+});
+
+describe("quoteCommodity()", () => {
+  test("should leave letter-only and currency-sign commodities unquoted", () => {
+    expect(quoteCommodity("EUR")).toBe("EUR");
+    expect(quoteCommodity("€")).toBe("€");
+  });
+
+  test("should quote commodities containing digits, spaces, or punctuation", () => {
+    expect(quoteCommodity("SOL2")).toBe('"SOL2"');
+    expect(quoteCommodity("My Fund")).toBe('"My Fund"');
+  });
+});
+
+describe("renderTransaction()", () => {
+  test("should render a full parsed transaction preserving verbatim parts", () => {
+    const tx: Transaction = {
+      date: "2026-01-05",
+      status: "*",
+      description: "Shop | weekly",
+      payee: "Shop",
+      note: "weekly",
+      headerComment: "; seen: bank",
+      commentLines: ["; note: hello"],
+      tags: [{ name: "note", value: "hello" }],
+      postings: [
+        { account: "Expenses:Food", amount: 45.5, amountText: "45.5", currency: "EUR" },
+        { account: "Assets:Cash", comment: "; why" },
+      ],
+    };
+    expect(renderTransaction(tx)).toBe(
+      [
+        "2026-01-05 * Shop | weekly  ; seen: bank",
+        "    ; note: hello",
+        `    Expenses:Food${" ".repeat(52)}45.5 EUR`,
+        "    Assets:Cash  ; why",
+      ].join("\n"),
+    );
+  });
+
+  test("should render an unmarked transaction without a status marker", () => {
+    const tx: Transaction = {
+      date: "2026-02-01",
+      description: "Corner Store",
+      payee: "Corner Store",
+      commentLines: [],
+      tags: [],
+      postings: [
+        { account: "Expenses:Misc", amount: 1, amountText: "1.00", currency: "USD" },
+        { account: "Assets:Cash", amount: -1, amountText: "-1.00", currency: "USD" },
+      ],
+    };
+    expect(renderTransaction(tx).split("\n")[0]).toBe("2026-02-01 Corner Store");
+  });
+
+  test("should render status code, virtual parentheses, and balance assertions", () => {
+    const tx: Transaction = {
+      date: "2026-02-01",
+      status: "!",
+      code: "42",
+      description: "Bank",
+      payee: "Bank",
+      commentLines: [],
+      tags: [],
+      postings: [
+        { account: "Forecast", virtual: true, amount: -10, amountText: "-10.00", currency: "USD" },
+        {
+          account: "Assets:Bank",
+          amount: 0,
+          amountText: "0.00",
+          currency: "EUR",
+          assertion: { amount: 200, amountText: "200.00", currency: "EUR" },
+        },
+      ],
+    };
+    expect(renderTransaction(tx)).toBe(
+      [
+        "2026-02-01 ! (42) Bank",
+        `    (Forecast)${" ".repeat(54)}-10.00 USD`,
+        `    Assets:Bank${" ".repeat(54)}0.00 EUR = 200.00 EUR`,
+      ].join("\n"),
+    );
+  });
+
+  test("should quote a non-letter commodity when re-rendering", () => {
+    const tx: Transaction = {
+      date: "2026-02-01",
+      description: "Broker",
+      payee: "Broker",
+      commentLines: [],
+      tags: [],
+      postings: [
+        { account: "Assets:Broker", amount: 2, amountText: "2", currency: "SOL2" },
+        { account: "Assets:Cash", amount: -100, amountText: "-100.00", currency: "USD" },
+      ],
+    };
+    expect(findLine(renderTransaction(tx), "Assets:Broker")).toMatch(/2 "SOL2"$/);
+  });
+});
+
+describe("renderPrice()", () => {
+  test("should render a parsed P directive preserving the written amount", () => {
+    expect(
+      renderPrice({ date: "2026-03-15", commodity: "SOL2", amount: 0.87, amountText: "0.870", currency: "EUR" }),
+    ).toBe('P 2026-03-15 "SOL2" 0.870 EUR');
+  });
+});

--- a/packages/hledger-journal/src/__tests__/parse.test.ts
+++ b/packages/hledger-journal/src/__tests__/parse.test.ts
@@ -1,0 +1,429 @@
+import { describe, expect, test } from "vitest";
+import { JournalParseError } from "../errors";
+import { formatTransaction, renderPrice, renderTransaction } from "../format";
+import { parsePriceBlock, parseTransactionBlock } from "../parse";
+import { segment } from "../segment";
+import type { Block } from "../types";
+
+function block(text: string, index = 0): Block {
+  return segment(text)[index];
+}
+
+function parseError(fn: () => unknown): JournalParseError {
+  try {
+    fn();
+  } catch (e) {
+    expect(e).toBeInstanceOf(JournalParseError);
+    return e as JournalParseError;
+  }
+  throw new Error("expected a JournalParseError to be thrown");
+}
+
+describe("parseTransactionBlock()", () => {
+  test("should parse the canonical app-written transaction", () => {
+    const text = formatTransaction({
+      date: "2026-03-15",
+      payee: "Whole Foods",
+      description: "Groceries",
+      postings: [
+        { account: "Assets:Checking", amount: -45, currency: "USD" },
+        { account: "Expenses:Food:Groceries", amount: 45, currency: "USD" },
+      ],
+      tags: [{ name: "source", value: "manual" }],
+    });
+    const tx = parseTransactionBlock(block(text));
+    expect(tx).toMatchObject({
+      date: "2026-03-15",
+      status: "*",
+      description: "Whole Foods | Groceries",
+      payee: "Whole Foods",
+      note: "Groceries",
+      commentLines: ["; source: manual"],
+      tags: [{ name: "source", value: "manual" }],
+    });
+    expect(tx.postings).toEqual([
+      { account: "Assets:Checking", amount: -45, amountText: "-45.00", currency: "USD" },
+      { account: "Expenses:Food:Groceries", amount: 45, amountText: "45.00", currency: "USD" },
+    ]);
+  });
+
+  test("should parse an unmarked transaction without status or note", () => {
+    const tx = parseTransactionBlock(
+      block("2026-01-05 Corner Store\n    Expenses:Misc    1.00 USD\n    Assets:Cash\n"),
+    );
+    expect(tx.status).toBeUndefined();
+    expect(tx.payee).toBe("Corner Store");
+    expect(tx.note).toBeUndefined();
+    expect(tx.postings[1]).toEqual({ account: "Assets:Cash" });
+  });
+
+  test("should parse a pending status and a transaction code", () => {
+    const tx = parseTransactionBlock(block("2026-01-05 ! (42) Bank\n    A    1.00 USD\n    B\n"));
+    expect(tx.status).toBe("!");
+    expect(tx.code).toBe("42");
+    expect(tx.payee).toBe("Bank");
+  });
+
+  test("should keep the header comment verbatim", () => {
+    const tx = parseTransactionBlock(block("2026-01-05 * Shop  ; seen: bank\n    A    1.00 USD\n    B\n"));
+    expect(tx.description).toBe("Shop");
+    expect(tx.headerComment).toBe("; seen: bank");
+  });
+
+  test("should preserve amount text exactly as written", () => {
+    const tx = parseTransactionBlock(block("2026-01-05 * Shop\n    A    45.5 EUR\n    B    -45.500 EUR\n"));
+    expect(tx.postings[0]).toMatchObject({ amount: 45.5, amountText: "45.5" });
+    expect(tx.postings[1]).toMatchObject({ amount: -45.5, amountText: "-45.500" });
+  });
+
+  test("should parse a balance assertion after the amount", () => {
+    const tx = parseTransactionBlock(
+      block("2026-01-05 * Balance Assertion\n    Assets:Bank    0.00 EUR = 200.00 EUR\n"),
+    );
+    expect(tx.postings[0]).toEqual({
+      account: "Assets:Bank",
+      amount: 0,
+      amountText: "0.00",
+      currency: "EUR",
+      assertion: { amount: 200, amountText: "200.00", currency: "EUR" },
+    });
+  });
+
+  test("should parse a trailing posting comment verbatim", () => {
+    const tx = parseTransactionBlock(block("2026-01-05 * Shop\n    A    1.00 USD  ; note: x\n    B\n"));
+    expect(tx.postings[0].comment).toBe("; note: x");
+  });
+
+  test("should parse a comment on an amountless posting", () => {
+    const tx = parseTransactionBlock(block("2026-01-05 * Shop\n    A    1.00 USD\n    B  ; why\n"));
+    expect(tx.postings[1]).toEqual({ account: "B", comment: "; why" });
+  });
+
+  test("should parse a parenthesized posting as virtual", () => {
+    const tx = parseTransactionBlock(block("2026-01-05 * Shop\n    (Forecast)    1.00 USD\n"));
+    expect(tx.postings[0]).toMatchObject({ account: "Forecast", virtual: true });
+  });
+
+  test("should keep single spaces inside account names", () => {
+    const tx = parseTransactionBlock(
+      block("2026-01-05 * Opening\n    Equity:Opening Balances    -1.00 EUR\n    Assets:Cash    1.00 EUR\n"),
+    );
+    expect(tx.postings[0].account).toBe("Equity:Opening Balances");
+  });
+
+  test("should unquote a quoted commodity", () => {
+    const tx = parseTransactionBlock(block('2026-01-05 * Broker\n    Assets:Broker    2 "SOL2"\n    Assets:Cash\n'));
+    expect(tx.postings[0]).toMatchObject({ amount: 2, currency: "SOL2" });
+  });
+
+  test("should collect plain comment lines without deriving tags", () => {
+    const tx = parseTransactionBlock(
+      block("2026-01-05 * Shop\n    ; just a note\n    ; ref: 123\n    A    1.00 USD\n"),
+    );
+    expect(tx.commentLines).toEqual(["; just a note", "; ref: 123"]);
+    expect(tx.tags).toEqual([{ name: "ref", value: "123" }]);
+  });
+
+  test("should derive a value-less tag from a bare tag line", () => {
+    const tx = parseTransactionBlock(block("2026-01-05 * Shop\n    ; groceries:\n    A    1.00 USD\n"));
+    expect(tx.tags).toEqual([{ name: "groceries" }]);
+  });
+
+  test("should reject a non-transaction block", () => {
+    const error = parseError(() => parseTransactionBlock(block("include a.journal\n")));
+    expect(error.reason).toContain("expected a transaction block");
+  });
+
+  test("should reject an impossible calendar date", () => {
+    const error = parseError(() => parseTransactionBlock(block("2026-02-31 * Shop\n    A    1.00 USD\n")));
+    expect(error.reason).toContain("not a valid calendar date");
+  });
+
+  test("should reject secondary dates", () => {
+    const error = parseError(() => parseTransactionBlock(block("2026-01-05=2026-01-07 * Shop\n    A    1.00 USD\n")));
+    expect(error.reason).toContain("secondary dates");
+  });
+
+  test("should reject a posting status marker", () => {
+    const error = parseError(() => parseTransactionBlock(block("2026-01-05 * Shop\n    * A    1.00 USD\n")));
+    expect(error.reason).toContain("posting status markers");
+  });
+
+  test("should reject balanced virtual postings", () => {
+    const error = parseError(() => parseTransactionBlock(block("2026-01-05 * Shop\n    [Budget]    1.00 USD\n")));
+    expect(error.reason).toContain("balanced virtual");
+  });
+
+  test("should reject unbalanced parentheses in an account", () => {
+    const error = parseError(() => parseTransactionBlock(block("2026-01-05 * Shop\n    (Forecast    1.00 USD\n")));
+    expect(error.reason).toContain("unbalanced parentheses");
+  });
+
+  test("should reject a comment separated by a single space", () => {
+    const error = parseError(() => parseTransactionBlock(block("2026-01-05 * Shop\n    Assets:Cash ; note\n")));
+    expect(error.reason).toContain("2+ spaces");
+  });
+
+  test("should reject a balance assignment without an amount", () => {
+    const error = parseError(() =>
+      parseTransactionBlock(block("2026-01-05 * Shop\n    Assets:Cash    = 100.00 EUR\n")),
+    );
+    expect(error.reason).toContain("balance assignments");
+  });
+
+  test("should reject a double-equals assertion", () => {
+    const error = parseError(() =>
+      parseTransactionBlock(block("2026-01-05 * Shop\n    Assets:Cash    0.00 EUR == 100.00 EUR\n")),
+    );
+    expect(error.reason).toContain("only simple balance assertions");
+  });
+
+  test("should reject cost notation", () => {
+    const error = parseError(() =>
+      parseTransactionBlock(block("2026-01-05 * Shop\n    Assets:X    1 BTC @ 55000 EUR\n")),
+    );
+    expect(error.reason).toContain("cost notation");
+  });
+
+  test("should reject thousands separators in amounts", () => {
+    const error = parseError(() => parseTransactionBlock(block("2026-01-05 * Shop\n    Assets:X    1,000.00 USD\n")));
+    expect(error.reason).toContain("unsupported amount format");
+  });
+
+  test("should reject a currency-symbol-first amount", () => {
+    const error = parseError(() => parseTransactionBlock(block("2026-01-05 * Shop\n    Assets:X    $100\n")));
+    expect(error.reason).toContain("unsupported amount format");
+  });
+
+  test("should reject an amount without a commodity", () => {
+    const error = parseError(() => parseTransactionBlock(block("2026-01-05 * Shop\n    Assets:X    45.00\n")));
+    expect(error.reason).toContain("unsupported amount format");
+  });
+
+  test("should reject comment lines between postings", () => {
+    const error = parseError(() =>
+      parseTransactionBlock(block("2026-01-05 * Shop\n    A    1.00 USD\n    ; late comment\n    B\n")),
+    );
+    expect(error.reason).toContain("between or after postings");
+  });
+
+  test("should reject an empty quoted commodity", () => {
+    const error = parseError(() => parseTransactionBlock(block('2026-01-05 * Shop\n    Assets:X    1 ""\n')));
+    expect(error.reason).toContain("empty quoted commodity");
+  });
+
+  test("should point the error at the offending line within the file", () => {
+    const text = "include a.journal\n\n2026-01-05 * Shop\n    A    1.00 USD\n    B    $5\n";
+    const error = parseError(() => parseTransactionBlock(block(text, 2)));
+    expect(error.line).toBe(5);
+    expect(error.message).toBe('Line 5: unsupported amount format: "$5"');
+  });
+});
+
+describe("parsePriceBlock()", () => {
+  test("should parse a plain P directive", () => {
+    expect(parsePriceBlock(block("P 2026-03-15 USD 0.87 EUR\n"))).toEqual({
+      date: "2026-03-15",
+      commodity: "USD",
+      amount: 0.87,
+      amountText: "0.87",
+      currency: "EUR",
+    });
+  });
+
+  test("should unquote quoted commodities on both sides", () => {
+    expect(parsePriceBlock(block('P 2026-03-15 "SOL2" 145.30 "USD2"\n'))).toMatchObject({
+      commodity: "SOL2",
+      currency: "USD2",
+    });
+  });
+
+  test("should preserve the written amount text", () => {
+    expect(parsePriceBlock(block("P 2026-03-15 SAT 0.0000005 EUR\n"))).toMatchObject({
+      amount: 0.0000005,
+      amountText: "0.0000005",
+    });
+  });
+
+  test("should reject a non-price block", () => {
+    const error = parseError(() => parsePriceBlock(block("2026-01-05 * Shop\n    A    1.00 USD\n")));
+    expect(error.reason).toContain("expected a price block");
+  });
+
+  test("should reject an impossible price date", () => {
+    const error = parseError(() => parsePriceBlock(block("P 2026-13-05 USD 0.87 EUR\n")));
+    expect(error.reason).toContain("not a valid calendar date");
+  });
+
+  test("should reject indented lines under a P directive", () => {
+    const error = parseError(() => parsePriceBlock(block("P 2026-03-15 USD 0.87 EUR\n    stray\n")));
+    expect(error.reason).toContain("unexpected indented lines");
+    expect(error.line).toBe(2);
+  });
+
+  test("should reject a P directive with missing parts", () => {
+    const error = parseError(() => parsePriceBlock(block("P 2026-03-15 USD\n")));
+    expect(error.reason).toContain("unsupported P directive format");
+  });
+
+  test("should reject a P directive with extra trailing tokens", () => {
+    const error = parseError(() => parsePriceBlock(block("P 2026-03-15 USD 0.87 EUR extra\n")));
+    expect(error.reason).toContain("unsupported P directive format");
+  });
+});
+
+// ── Header edge cases ───────────────────────────────────────────────
+
+describe("parseTransactionBlock() header edge cases", () => {
+  test("should split payee and note at the FIRST pipe, as hledger does", () => {
+    // Verified against hledger: `hledger payees` on "Alpha | Beta | Gamma" reports "Alpha".
+    const tx = parseTransactionBlock(block("2026-01-05 * Alpha | Beta | Gamma\n    A    1.00 EUR\n    B\n"));
+    expect(tx.payee).toBe("Alpha");
+    expect(tx.note).toBe("Beta | Gamma");
+  });
+
+  test("should derive payee and note from a pipe without surrounding spaces, preserving the description", () => {
+    const tx = parseTransactionBlock(block("2026-01-05 * Alpha|Beta\n    A    1.00 EUR\n    B\n"));
+    expect(tx.description).toBe("Alpha|Beta");
+    expect(tx.payee).toBe("Alpha");
+    expect(tx.note).toBe("Beta");
+  });
+
+  test("should parse a header that is only a date", () => {
+    const tx = parseTransactionBlock(block("2026-01-05\n    A    1.00 EUR\n    B\n"));
+    expect(tx.status).toBeUndefined();
+    expect(tx.description).toBe("");
+    expect(tx.payee).toBe("");
+  });
+
+  test("should parse a header with a status but no description", () => {
+    const tx = parseTransactionBlock(block("2026-01-05 *\n    A    1.00 EUR\n    B\n"));
+    expect(tx.status).toBe("*");
+    expect(tx.description).toBe("");
+  });
+
+  test("should parse a code without a status", () => {
+    const tx = parseTransactionBlock(block("2026-01-05 (42) Shop\n    A    1.00 EUR\n    B\n"));
+    expect(tx.status).toBeUndefined();
+    expect(tx.code).toBe("42");
+    expect(tx.payee).toBe("Shop");
+  });
+
+  test("should not derive a note from a pipe inside the header comment", () => {
+    const tx = parseTransactionBlock(block("2026-01-05 * Shop  ; see | this\n    A    1.00 EUR\n    B\n"));
+    expect(tx.note).toBeUndefined();
+    expect(tx.headerComment).toBe("; see | this");
+  });
+
+  test("should parse a transaction whose header sits behind a UTF-8 BOM", () => {
+    const tx = parseTransactionBlock(block("\uFEFF2026-01-05 * Shop\n    A    1.00 EUR\n    B\n"));
+    expect(tx.date).toBe("2026-01-05");
+    expect(tx.payee).toBe("Shop");
+  });
+});
+
+// ── Posting edge cases ──────────────────────────────────────────────
+
+describe("parseTransactionBlock() posting edge cases", () => {
+  test("should allow @ inside a posting comment", () => {
+    const tx = parseTransactionBlock(block("2026-01-05 * Shop\n    A    1.00 USD  ; was @ 1.1\n    B\n"));
+    expect(tx.postings[0]).toMatchObject({ amount: 1, comment: "; was @ 1.1" });
+  });
+
+  test("should allow = inside a posting comment", () => {
+    const tx = parseTransactionBlock(block("2026-01-05 * Shop\n    A    1.00 USD  ; verified = true\n    B\n"));
+    expect(tx.postings[0]).toMatchObject({ amount: 1, comment: "; verified = true" });
+  });
+
+  test("should reject a plus-signed amount", () => {
+    const error = parseError(() => parseTransactionBlock(block("2026-01-05 * Shop\n    A    +45.00 EUR\n")));
+    expect(error.reason).toContain("unsupported amount format");
+  });
+
+  test("should reject an amount without a leading digit", () => {
+    const error = parseError(() => parseTransactionBlock(block("2026-01-05 * Shop\n    A    .50 EUR\n")));
+    expect(error.reason).toContain("unsupported amount format");
+  });
+});
+
+// ── Tag derivation (verified against hledger's own `ttags`) ─────────
+
+describe("parseTransactionBlock() tag derivation", () => {
+  function tagsOf(commentLine: string) {
+    return parseTransactionBlock(block(`2026-01-05 * Shop\n    ${commentLine}\n    A    1.00 EUR\n`)).tags;
+  }
+
+  test("should split comma-separated tags on one line", () => {
+    expect(tagsOf("; a: 1, b: 2")).toEqual([
+      { name: "a", value: "1" },
+      { name: "b", value: "2" },
+    ]);
+  });
+
+  test("should derive a tag when there is no space after the colon", () => {
+    expect(tagsOf("; ref:123")).toEqual([{ name: "ref", value: "123" }]);
+  });
+
+  test("should derive a tag from a word:value in the middle of comment text", () => {
+    expect(tagsOf("; paid via card: visa")).toEqual([{ name: "card", value: "visa" }]);
+  });
+
+  test("should treat a URL as a tag, exactly as hledger does", () => {
+    expect(tagsOf("; https://example.com")).toEqual([{ name: "https", value: "//example.com" }]);
+  });
+
+  test("should extend a tag value to the end of line, swallowing inner colons", () => {
+    expect(tagsOf("; x: a b: c")).toEqual([{ name: "x", value: "a b: c" }]);
+  });
+
+  test("should treat an empty value before a comma as a value-less tag", () => {
+    expect(tagsOf("; empty:, second: v")).toEqual([{ name: "empty" }, { name: "second", value: "v" }]);
+  });
+
+  test("should derive tags from the header comment too", () => {
+    const tx = parseTransactionBlock(block("2026-01-05 * Shop  ; seen: bank\n    A    1.00 EUR\n    B\n"));
+    expect(tx.tags).toEqual([{ name: "seen", value: "bank" }]);
+  });
+});
+
+// ── parse → render fixpoint ─────────────────────────────────────────
+
+// Rendering a parsed entry and parsing it back must yield the same objects:
+// this is the property that makes canonical re-rendering (tidy) safe.
+describe("parse → render fixpoint", () => {
+  const FIXTURES: Array<[string, string]> = [
+    [
+      "canonical app transaction",
+      formatTransaction({
+        date: "2026-03-15",
+        payee: "Whole Foods",
+        description: "Groceries",
+        postings: [
+          { account: "Assets:Checking", amount: -45, currency: "USD" },
+          { account: "Expenses:Food:Groceries", amount: 45, currency: "USD" },
+        ],
+        tags: [{ name: "source", value: "manual" }],
+      }),
+    ],
+    [
+      "kitchen sink",
+      "2026-01-05 ! (42) Alpha | Beta  ; seen: bank\n  ; a: 1, b: 2\n  (Forecast)  -10.5 USD\n  Assets:Bank  0.00 EUR = 200.00 EUR  ; ok\n  Equity:Opening Balances\n",
+    ],
+    ["quoted commodity price", 'P 2026-03-15 "SOL2" 0.870 EUR\n'],
+    ["unmarked date-only header", "2026-01-05\n    A    1 EUR\n    B\n"],
+    ["BOM transaction", "\uFEFF2026-01-05 * Shop\n    A    1.00 EUR\n    B\n"],
+  ];
+
+  for (const [name, text] of FIXTURES) {
+    test(`should reach a fixpoint for the ${name}`, () => {
+      const original = block(text);
+      if (original.kind === "price") {
+        const parsed = parsePriceBlock(original);
+        expect(parsePriceBlock(block(`${renderPrice(parsed)}\n`))).toEqual(parsed);
+      } else {
+        const parsed = parseTransactionBlock(original);
+        expect(parseTransactionBlock(block(`${renderTransaction(parsed)}\n`))).toEqual(parsed);
+      }
+    });
+  }
+});

--- a/packages/hledger-journal/src/__tests__/segment.test.ts
+++ b/packages/hledger-journal/src/__tests__/segment.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "vitest";
+import { segment } from "../segment";
+import type { Block } from "../types";
+
+/** Every segmentation must reproduce the input byte-for-byte. */
+function segmentRoundTrip(text: string): Block[] {
+  const blocks = segment(text);
+  expect(blocks.map((b) => b.raw).join("")).toBe(text);
+  return blocks;
+}
+
+function kinds(blocks: Block[]): string[] {
+  return blocks.map((b) => b.kind);
+}
+
+describe("segment()", () => {
+  test("should return no blocks when text is empty", () => {
+    expect(segmentRoundTrip("")).toEqual([]);
+  });
+
+  test("should segment a mixed journal into comment, directive, blank, and transaction blocks", () => {
+    const text = [
+      "; Accountant24",
+      "",
+      "include commodities.journal",
+      "include accounts.journal",
+      "",
+      "2026-01-05 * Shop | weekly",
+      "    Expenses:Food    45.00 EUR",
+      "    Assets:Cash",
+      "",
+      "P 2026-01-06 USD 0.87 EUR",
+      "",
+    ].join("\n");
+    const blocks = segmentRoundTrip(text);
+    expect(kinds(blocks)).toEqual([
+      "comment",
+      "blank",
+      "directive",
+      "directive",
+      "blank",
+      "transaction",
+      "blank",
+      "price",
+    ]);
+    expect(blocks[5]).toMatchObject({ startLine: 6, endLine: 8, date: "2026-01-05" });
+    expect(blocks[5].raw).toBe("2026-01-05 * Shop | weekly\n    Expenses:Food    45.00 EUR\n    Assets:Cash\n");
+    expect(blocks[7]).toMatchObject({ startLine: 10, endLine: 10, date: "2026-01-06" });
+  });
+
+  test("should keep a single line without trailing newline as one block", () => {
+    const blocks = segmentRoundTrip("include accounts.journal");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ kind: "directive", raw: "include accounts.journal", startLine: 1, endLine: 1 });
+  });
+
+  test("should keep a transaction that ends at EOF without a trailing newline intact", () => {
+    const text = "2026-01-05 * Shop\n    Expenses:Food    45.00 EUR\n    Assets:Cash";
+    const blocks = segmentRoundTrip(text);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].kind).toBe("transaction");
+    expect(blocks[0].endLine).toBe(3);
+  });
+
+  test("should preserve CRLF terminators in raw while classifying normally", () => {
+    const text = "2026-01-05 * Shop\r\n    Expenses:Food    45.00 EUR\r\n    Assets:Cash\r\n\r\n";
+    const blocks = segmentRoundTrip(text);
+    expect(kinds(blocks)).toEqual(["transaction", "blank"]);
+    expect(blocks[0].raw).toContain("\r\n");
+    expect(blocks[0].date).toBe("2026-01-05");
+  });
+
+  test("should merge consecutive blank lines into one block", () => {
+    const blocks = segmentRoundTrip("include a.journal\n\n\n\ninclude b.journal\n");
+    expect(kinds(blocks)).toEqual(["directive", "blank", "directive"]);
+    expect(blocks[1].raw).toBe("\n\n\n");
+  });
+
+  test("should merge consecutive column-0 comment lines into one block", () => {
+    const blocks = segmentRoundTrip("; one\n; two\n# three\n* four\n");
+    expect(kinds(blocks)).toEqual(["comment"]);
+    expect(blocks[0].endLine).toBe(4);
+  });
+
+  test("should split comment runs at blank lines", () => {
+    const blocks = segmentRoundTrip("; one\n\n; two\n");
+    expect(kinds(blocks)).toEqual(["comment", "blank", "comment"]);
+  });
+
+  test("should attach indented sub-directives to their directive block", () => {
+    const text = "commodity USD\n  format 1,000.00 USD\n\naccount Assets:Cash\n";
+    const blocks = segmentRoundTrip(text);
+    expect(kinds(blocks)).toEqual(["directive", "blank", "directive"]);
+    expect(blocks[0].raw).toBe("commodity USD\n  format 1,000.00 USD\n");
+  });
+
+  test("should treat a comment/end comment region as one opaque block", () => {
+    const text = "; head\n\ncomment\n2026-01-05 not a real transaction\nend comment\ninclude a.journal\n";
+    const blocks = segmentRoundTrip(text);
+    expect(kinds(blocks)).toEqual(["comment", "blank", "other", "directive"]);
+    expect(blocks[2].raw).toBe("comment\n2026-01-05 not a real transaction\nend comment\n");
+  });
+
+  test("should extend an unterminated comment block to EOF", () => {
+    const blocks = segmentRoundTrip("comment\nanything\ngoes\n");
+    expect(kinds(blocks)).toEqual(["other"]);
+    expect(blocks[0].endLine).toBe(3);
+  });
+
+  test("should collect orphan indented lines at file start into an opaque block", () => {
+    const blocks = segmentRoundTrip("    Expenses:Food    45.00 EUR\n    Assets:Cash\ninclude a.journal\n");
+    expect(kinds(blocks)).toEqual(["other", "directive"]);
+    expect(blocks[0].endLine).toBe(2);
+  });
+
+  test("should collect indented lines after a blank line into an opaque block", () => {
+    const blocks = segmentRoundTrip("2026-01-05 * Shop\n    Expenses:Food    45.00 EUR\n\n    Assets:Cash\n");
+    expect(kinds(blocks)).toEqual(["transaction", "blank", "other"]);
+  });
+
+  test("should normalize slash and dot dates with single digits to ISO", () => {
+    const blocks = segmentRoundTrip(
+      "2026/3/5 * A\n    X    1.00 EUR\n    Y\n\n2026.03.05 * B\n    X    1.00 EUR\n    Y\n",
+    );
+    expect(blocks[0].date).toBe("2026-03-05");
+    expect(blocks[2].date).toBe("2026-03-05");
+  });
+
+  test("should use the primary date when a secondary date is present", () => {
+    const blocks = segmentRoundTrip("2026-01-05=2026-01-07 * Shop\n    X    1.00 EUR\n    Y\n");
+    expect(blocks[0]).toMatchObject({ kind: "transaction", date: "2026-01-05" });
+  });
+
+  test("should leave date undefined when the month is impossible", () => {
+    const blocks = segmentRoundTrip("2026-13-05 * Shop\n    X    1.00 EUR\n    Y\n");
+    expect(blocks[0]).toMatchObject({ kind: "transaction", date: undefined });
+  });
+
+  test("should leave date undefined when the day does not exist in the month", () => {
+    const blocks = segmentRoundTrip("2026-02-31 * Shop\n    X    1.00 EUR\n    Y\n");
+    expect(blocks[0]).toMatchObject({ kind: "transaction", date: undefined });
+  });
+
+  test("should leave price date undefined when malformed", () => {
+    const blocks = segmentRoundTrip("P 2026-13-05 USD 0.87 EUR\n");
+    expect(blocks[0]).toMatchObject({ kind: "price", date: undefined });
+  });
+
+  test("should not mistake a mixed-separator date for a transaction", () => {
+    const blocks = segmentRoundTrip("2026-03/15 something\n");
+    expect(kinds(blocks)).toEqual(["directive"]);
+  });
+
+  test("should classify a digit-leading non-date line as a directive", () => {
+    const blocks = segmentRoundTrip("2026 report\n");
+    expect(kinds(blocks)).toEqual(["directive"]);
+  });
+
+  test("should treat a whitespace-only line as blank, ending the transaction", () => {
+    const blocks = segmentRoundTrip("2026-01-05 * A\n    X    1.00 EUR\n   \n    Y\n");
+    expect(kinds(blocks)).toEqual(["transaction", "blank", "other"]);
+    expect(blocks[1].raw).toBe("   \n");
+  });
+
+  test("should attach tab-indented continuation lines to their transaction", () => {
+    const blocks = segmentRoundTrip("2026-01-05 * A\n\tExpenses:X\t1.00 EUR\n\tAssets:Y\n");
+    expect(kinds(blocks)).toEqual(["transaction"]);
+    expect(blocks[0].endLine).toBe(3);
+  });
+
+  test("should merge an indented continuation into the preceding comment block", () => {
+    const blocks = segmentRoundTrip("; head\n    continued\ninclude a.journal\n");
+    expect(kinds(blocks)).toEqual(["comment", "directive"]);
+    expect(blocks[0].endLine).toBe(2);
+  });
+
+  test("should recognize a transaction behind a UTF-8 BOM, keeping the BOM in raw", () => {
+    // hledger accepts BOM-prefixed journals, so the segmenter must too.
+    const blocks = segmentRoundTrip("\uFEFF2026-01-05 * Shop\n    Expenses:X    1.00 EUR\n    Assets:Y\n");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({ kind: "transaction", date: "2026-01-05" });
+    expect(blocks[0].raw.startsWith("\uFEFF")).toBe(true);
+  });
+});

--- a/packages/hledger-journal/src/__tests__/tidy.test.ts
+++ b/packages/hledger-journal/src/__tests__/tidy.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "vitest";
+import { tidyJournal } from "../tidy";
+
+// Sloppy 2-space-indent inputs and their canonical renderings.
+const RENT = "2026-03-20 * Rent\n  Expenses:Rent  900.00 USD\n  Assets:Bank\n";
+const SHOP = "2026-03-05 * Shop\n  Expenses:Food  45.00 USD\n  Assets:Cash\n";
+const CANON_RENT = `2026-03-20 * Rent\n    Expenses:Rent${" ".repeat(52)}900.00 USD\n    Assets:Bank\n`;
+const CANON_SHOP = `2026-03-05 * Shop\n    Expenses:Food${" ".repeat(52)}45.00 USD\n    Assets:Cash\n`;
+
+describe("tidyJournal()", () => {
+  test("should sort entries by date and re-render them canonically", () => {
+    const result = tidyJournal(`${RENT}\n${SHOP}`);
+    expect(result.text).toBe(`${CANON_SHOP}\n${CANON_RENT}`);
+    expect(result.skippedBlocks).toEqual([]);
+  });
+
+  test("should keep same-date entries in their original relative order", () => {
+    const first = "2026-03-05 * First\n  Expenses:A  1.00 USD\n  Assets:Cash\n";
+    const second = "2026-03-05 * Second\n  Expenses:B  2.00 USD\n  Assets:Cash\n";
+    const result = tidyJournal(`${first}\n${second}`);
+    const firstIdx = result.text.indexOf("First");
+    const secondIdx = result.text.indexOf("Second");
+    expect(firstIdx).toBeGreaterThanOrEqual(0);
+    expect(firstIdx).toBeLessThan(secondIdx);
+  });
+
+  test("should move a glued comment together with its entry", () => {
+    const result = tidyJournal(`${RENT}\n; food note\n${SHOP}`);
+    expect(result.text).toBe(`; food note\n${CANON_SHOP}\n${CANON_RENT}`);
+  });
+
+  test("should not sort entries across a directive barrier", () => {
+    const result = tidyJournal(`${RENT}\ninclude other.journal\n\n${SHOP}`);
+    expect(result.text).toBe(`${CANON_RENT}\ninclude other.journal\n\n${CANON_SHOP}`);
+  });
+
+  test("should keep an unparseable entry verbatim as a barrier and report it", () => {
+    const weird = "2026-03-10 * Weird\n    Assets:X    1 BTC @ 55000 EUR\n";
+    const result = tidyJournal(`${RENT}\n${weird}\n${SHOP}`);
+    expect(result.text).toBe(`${CANON_RENT}\n${weird}\n${CANON_SHOP}`);
+    expect(result.skippedBlocks).toEqual([{ startLine: 5, reason: "cost notation (@) is not supported" }]);
+  });
+
+  test("should keep a glued comment verbatim together with its unparseable entry", () => {
+    const weird = "2026-03-10 * Weird\n    Assets:X    1 BTC @ 55000 EUR\n";
+    const result = tidyJournal(`${RENT}\n; note for weird\n${weird}\n${SHOP}`);
+    expect(result.text).toBe(`${CANON_RENT}\n; note for weird\n${weird}\n${CANON_SHOP}`);
+    expect(result.skippedBlocks).toEqual([{ startLine: 6, reason: "cost notation (@) is not supported" }]);
+  });
+
+  test("should normalize multiple blank lines between entries to one", () => {
+    const result = tidyJournal(`${SHOP}\n\n\n${RENT}`);
+    expect(result.text).toBe(`${CANON_SHOP}\n${CANON_RENT}`);
+  });
+
+  test("should preserve the prologue byte-for-byte, including adjacent directives", () => {
+    const prologue = "; Accountant24\n\ninclude commodities.journal\ninclude accounts.journal\n";
+    const result = tidyJournal(`${prologue}\n${SHOP}`);
+    expect(result.text).toBe(`${prologue}\n${CANON_SHOP}`);
+  });
+
+  test("should keep a trailing standalone comment at the end of the file", () => {
+    const result = tidyJournal(`${RENT}\n${SHOP}\n\n; end of month\n`);
+    expect(result.text).toBe(`${CANON_SHOP}\n${CANON_RENT}\n; end of month\n`);
+  });
+
+  test("should sort P directives among transactions by date", () => {
+    const result = tidyJournal(`${RENT}\nP 2026-03-10 USD 0.87 EUR\n`);
+    expect(result.text).toBe(`P 2026-03-10 USD 0.87 EUR\n\n${CANON_RENT}`);
+  });
+
+  test("should be idempotent", () => {
+    const once = tidyJournal(`${RENT}\n; food note\n${SHOP}\n\n\ninclude other.journal\n`);
+    const twice = tidyJournal(once.text);
+    expect(twice.text).toBe(once.text);
+    expect(twice.skippedBlocks).toEqual([]);
+  });
+
+  test("should return empty output for an empty file", () => {
+    expect(tidyJournal("")).toEqual({ text: "", skippedBlocks: [] });
+  });
+
+  test("should render sorted entries with CRLF when the file uses CRLF", () => {
+    const crlf = `${RENT}\n${SHOP}`.replace(/\n/g, "\r\n");
+    const result = tidyJournal(crlf);
+    expect(result.text).toBe(`${CANON_SHOP}\n${CANON_RENT}`.replace(/\n/g, "\r\n"));
+  });
+
+  test("should add a trailing newline when the file lacks one", () => {
+    const result = tidyJournal(SHOP.trimEnd());
+    expect(result.text).toBe(CANON_SHOP);
+  });
+
+  test("should move a glued comment together with its P directive", () => {
+    const result = tidyJournal(`${RENT}\n; fx note\nP 2026-03-10 USD 0.87 EUR\n`);
+    expect(result.text).toBe(`; fx note\nP 2026-03-10 USD 0.87 EUR\n\n${CANON_RENT}`);
+  });
+
+  test("should drop leading blank lines", () => {
+    expect(tidyJournal(`\n\n${SHOP}`).text).toBe(CANON_SHOP);
+  });
+
+  test("should produce empty output for a blanks-only file", () => {
+    expect(tidyJournal("\n\n\n")).toEqual({ text: "", skippedBlocks: [] });
+  });
+
+  test("should keep same-date entries in order even when interleaved with other dates", () => {
+    const a1 = "2026-03-05 * First\n  Expenses:A  1.00 USD\n  Assets:Cash\n";
+    const a2 = "2026-03-05 * Second\n  Expenses:B  2.00 USD\n  Assets:Cash\n";
+    const b = "2026-03-10 * Middle\n  Expenses:C  3.00 USD\n  Assets:Cash\n";
+    const result = tidyJournal(`${RENT}\n${a1}\n${b}\n${a2}`);
+    const order = ["First", "Second", "Middle", "Rent"].map((payee) => result.text.indexOf(payee));
+    expect(order).toEqual([...order].sort((x, y) => x - y));
+    expect(order.every((idx) => idx >= 0)).toBe(true);
+  });
+
+  test("should stay idempotent when skipped blocks and glued comments are present", () => {
+    const weird = "2026-03-10 * Weird\n    Assets:X    1 BTC @ 55000 EUR\n";
+    const once = tidyJournal(`${RENT}\n; note\n${weird}\n${SHOP}`);
+    const twice = tidyJournal(once.text);
+    expect(twice.text).toBe(once.text);
+    expect(twice.skippedBlocks.map((s) => s.reason)).toEqual(["cost notation (@) is not supported"]);
+  });
+
+  test("should normalize a BOM-prefixed journal, dropping the BOM", () => {
+    // hledger accepts the BOM; the canonical form simply does not carry one.
+    const result = tidyJournal(`\uFEFF${SHOP}`);
+    expect(result.text).toBe(CANON_SHOP);
+    expect(result.skippedBlocks).toEqual([]);
+  });
+});

--- a/packages/hledger-journal/src/dates.ts
+++ b/packages/hledger-journal/src/dates.ts
@@ -1,0 +1,16 @@
+/** Zero-pad a parsed date to ISO and reject impossible calendar dates. */
+export function normalizeDate(year: string, month: string, day: string): string | undefined {
+  const y = Number(year);
+  const m = Number(month);
+  const d = Number(day);
+  const check = new Date(Date.UTC(y, m - 1, d));
+  if (check.getUTCFullYear() !== y || check.getUTCMonth() !== m - 1 || check.getUTCDate() !== d) return undefined;
+  return `${year}-${String(m).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+}
+
+/** True when `iso` (strictly YYYY-MM-DD) names a real calendar day. */
+export function isValidCalendarDate(iso: string): boolean {
+  const match = iso.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return false;
+  return normalizeDate(match[1], match[2], match[3]) !== undefined;
+}

--- a/packages/hledger-journal/src/doc.ts
+++ b/packages/hledger-journal/src/doc.ts
@@ -1,0 +1,164 @@
+import { isValidCalendarDate } from "./dates";
+import { segment } from "./segment";
+import type { Block } from "./types";
+
+export interface DatedEntry {
+  /** Index of the block in `blocks`. */
+  index: number;
+  date: string;
+  block: Block;
+}
+
+/**
+ * A journal file as an ordered list of blocks, edited conservatively: blocks
+ * that are never touched keep their exact original bytes through `serialize()`.
+ * Only inserted or replaced blocks are rendered — so a gap in the parser can
+ * at worst refuse an edit, never corrupt content it did not understand.
+ */
+export class JournalDoc {
+  private items: Block[];
+  private readonly eol: string;
+
+  private constructor(text: string) {
+    this.items = segment(text);
+    this.eol = text.includes("\r\n") ? "\r\n" : "\n";
+  }
+
+  static open(text: string): JournalDoc {
+    return new JournalDoc(text);
+  }
+
+  get blocks(): readonly Block[] {
+    return this.items;
+  }
+
+  /** Dated entries (transactions and P directives) in file order. */
+  entries(): DatedEntry[] {
+    const result: DatedEntry[] = [];
+    for (let i = 0; i < this.items.length; i++) {
+      const block = this.items[i];
+      if ((block.kind === "transaction" || block.kind === "price") && block.date) {
+        result.push({ index: i, date: block.date, block });
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Insert a rendered entry (transaction or P directive) in date order: after
+   * the last entry dated on or before `date`. A comment block sitting directly
+   * above a transaction travels with that transaction and is never separated
+   * from it. Blocks other than the insertion seam keep their exact bytes.
+   */
+  insertEntry(entryText: string, date: string): void {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      throw new Error(`Invalid date format: ${date}. Expected YYYY-MM-DD.`);
+    }
+    if (!isValidCalendarDate(date)) {
+      throw new Error(`Invalid date: ${date}. That calendar day does not exist.`);
+    }
+    const block = this.toBlock(entryText);
+    if (block.kind !== "transaction" && block.kind !== "price") {
+      throw new Error(`Entry text must be a single transaction or P directive, got a ${block.kind} block.`);
+    }
+    if (block.date !== date) {
+      throw new Error(`The entry text is dated ${block.date ?? "unparseably"}, which does not match ${date}.`);
+    }
+    this.spliceIn(this.insertionIndex(date), block);
+  }
+
+  /** Replace one block's text in place (no seam handling). */
+  replaceBlock(index: number, text: string): void {
+    if (index < 0 || index >= this.items.length) {
+      throw new Error(`Block index ${index} is out of range (0..${this.items.length - 1}).`);
+    }
+    this.items[index] = this.toBlock(text);
+    this.renumber();
+  }
+
+  /** Append a block at the end of the file, blank-line separated. */
+  appendBlock(text: string): void {
+    this.spliceIn(this.items.length, this.toBlock(text));
+  }
+
+  /** Concatenation of all block bytes; untouched blocks are byte-identical. */
+  serialize(): string {
+    return this.items.map((b) => b.raw).join("");
+  }
+
+  // ── Internals ─────────────────────────────────────────────────────
+
+  /** Render text in the doc's newline style, with a trailing terminator, and
+   *  require it to be exactly one block. */
+  private toBlock(text: string): Block {
+    let rendered = text.replace(/\r?\n/g, this.eol);
+    if (!rendered.endsWith(this.eol)) rendered += this.eol;
+    const segments = segment(rendered);
+    if (segments.length !== 1) {
+      throw new Error(`Block text must segment to exactly one block, got ${segments.length}.`);
+    }
+    return segments[0];
+  }
+
+  private insertionIndex(date: string): number {
+    const dated = this.entries();
+    if (dated.length === 0) return this.items.length;
+
+    let anchor: DatedEntry | undefined;
+    for (const entry of dated) {
+      if (entry.date <= date) anchor = entry;
+    }
+
+    if (!anchor) {
+      // Earlier than everything: before the first entry, and before a comment
+      // block glued to it (no blank line in between).
+      let index = dated[0].index;
+      if (index > 0 && this.items[index - 1].kind === "comment") index -= 1;
+      return index;
+    }
+
+    let index = anchor.index + 1;
+    const next = this.items[index];
+    if (next?.kind === "comment") {
+      // A comment glued under the anchor: it belongs to the next transaction
+      // when it directly touches one, otherwise it trails the anchor.
+      const after = this.items[index + 1];
+      const belongsToNext = after !== undefined && (after.kind === "transaction" || after.kind === "price");
+      if (!belongsToNext) index += 1;
+    }
+    return index;
+  }
+
+  /** Splice a block in, normalizing only the seams: a missing terminator on the
+   *  previous block is completed, and exactly one blank line separates the new
+   *  block from non-blank neighbours. */
+  private spliceIn(index: number, block: Block): void {
+    const previous = this.items[index - 1];
+    if (previous && !previous.raw.endsWith("\n")) {
+      previous.raw += this.eol;
+    }
+
+    const inserted: Block[] = [block];
+    if (previous && previous.kind !== "blank") {
+      inserted.unshift({ kind: "blank", raw: this.eol, startLine: 0, endLine: 0 });
+    }
+    const following = this.items[index];
+    if (following && following.kind !== "blank") {
+      inserted.push({ kind: "blank", raw: this.eol, startLine: 0, endLine: 0 });
+    }
+
+    this.items.splice(index, 0, ...inserted);
+    this.renumber();
+  }
+
+  private renumber(): void {
+    let line = 1;
+    for (const block of this.items) {
+      const newlines = (block.raw.match(/\n/g) ?? []).length;
+      const count = block.raw.endsWith("\n") ? newlines : newlines + 1;
+      block.startLine = line;
+      block.endLine = line + count - 1;
+      line += count;
+    }
+  }
+}

--- a/packages/hledger-journal/src/errors.ts
+++ b/packages/hledger-journal/src/errors.ts
@@ -1,0 +1,14 @@
+/** A journal block (or line) the strict parser refuses to interpret. The block is
+ *  never guessed at — callers must leave its text untouched. */
+export class JournalParseError extends Error {
+  /** 1-indexed line in the source file the error points at. */
+  readonly line: number;
+  readonly reason: string;
+
+  constructor(reason: string, line: number) {
+    super(`Line ${line}: ${reason}`);
+    this.name = "JournalParseError";
+    this.line = line;
+    this.reason = reason;
+  }
+}

--- a/packages/hledger-journal/src/format.ts
+++ b/packages/hledger-journal/src/format.ts
@@ -1,0 +1,133 @@
+import type { FormatConfig, PriceDirective, Tag, Transaction } from "./types";
+
+export const DEFAULT_FORMAT: FormatConfig = { indent: "    ", alignColumn: 69 };
+
+/** Every checkpoint carries the same canonical payee, so assertions are easy
+ *  to spot (and query) in the journal. */
+export const BALANCE_ASSERTION_PAYEE = "Balance Assertion";
+
+export interface TransactionInput {
+  date: string;
+  payee: string;
+  description?: string;
+  postings: Array<{ account: string; amount: number; currency: string }>;
+  tags?: Tag[];
+}
+
+export interface BalanceAssertionInput {
+  date: string;
+  account: string;
+  balance: { amount: number; currency: string };
+  payee?: string;
+}
+
+export interface PriceInput {
+  date: string;
+  commodity: string;
+  price: { amount: number; currency: string };
+}
+
+/** hledger requires double quotes around a commodity symbol containing
+ *  anything besides letters or currency signs (digits, spaces, punctuation)
+ *  — e.g. a ticker like "SOL2". */
+export function quoteCommodity(commodity: string): string {
+  return /^[\p{L}\p{Sc}]+$/u.test(commodity) ? commodity : `"${commodity}"`;
+}
+
+/** Plain decimal rendering preserving the given precision — market rates
+ *  carry meaning in their decimals (0.0205), so no fixed rounding; tiny
+ *  rates must never fall into exponential notation. */
+export function formatPriceAmount(amount: number): string {
+  const plain = String(amount);
+  if (!plain.toLowerCase().includes("e")) return plain;
+  return amount.toFixed(20).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+export function formatTransaction(params: TransactionInput, config: FormatConfig = DEFAULT_FORMAT): string {
+  const header = params.description
+    ? `${params.date} * ${params.payee} | ${params.description}`
+    : `${params.date} * ${params.payee}`;
+
+  const lines = [header];
+
+  if (params.tags?.length) {
+    const sortedTags = [...params.tags].sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+    );
+    for (const tag of sortedTags) {
+      lines.push(tag.value != null ? `${config.indent}; ${tag.name}: ${tag.value}` : `${config.indent}; ${tag.name}:`);
+    }
+  }
+
+  const sortedPostings = [...params.postings].sort((a, b) => {
+    const groupA = a.amount < 0 ? 0 : 1;
+    const groupB = b.amount < 0 ? 0 : 1;
+    return groupA - groupB;
+  });
+
+  for (const p of sortedPostings) {
+    const sign = p.amount < 0 ? "-" : "";
+    const amountStr = `${sign}${Math.abs(p.amount).toFixed(2)} ${p.currency}`;
+    lines.push(alignAmount(`${config.indent}${p.account}`, amountStr, sign.length, config));
+  }
+
+  return lines.join("\n");
+}
+
+export function formatBalanceAssertion(params: BalanceAssertionInput, config: FormatConfig = DEFAULT_FORMAT): string {
+  const header = `${params.date} * ${params.payee ?? BALANCE_ASSERTION_PAYEE}`;
+  // A zero-amount posting moves no money and balances on its own; hledger's
+  // `= balance` after the amount is the assertion being checked.
+  const amountStr = `0.00 ${params.balance.currency}`;
+  const assertion = ` = ${params.balance.amount.toFixed(2)} ${params.balance.currency}`;
+  return `${header}\n${alignAmount(`${config.indent}${params.account}`, amountStr, 0, config)}${assertion}`;
+}
+
+export function formatPrice(params: PriceInput): string {
+  const amount = `${formatPriceAmount(params.price.amount)} ${quoteCommodity(params.price.currency)}`;
+  return `P ${params.date} ${quoteCommodity(params.commodity)} ${amount}`;
+}
+
+// ── Canonical re-rendering of parsed entries (used by tidy) ─────────
+
+/** Render a parsed transaction canonically. Layout only: descriptions, comments,
+ *  amount texts, and the order of tags/postings are preserved verbatim, so the
+ *  entry's meaning to hledger cannot change — only indentation and alignment do. */
+export function renderTransaction(tx: Transaction, config: FormatConfig = DEFAULT_FORMAT): string {
+  let header = tx.date;
+  if (tx.status) header += ` ${tx.status}`;
+  if (tx.code != null) header += ` (${tx.code})`;
+  if (tx.description) header += ` ${tx.description}`;
+  if (tx.headerComment) header += `  ${tx.headerComment}`;
+
+  const lines = [header];
+  for (const comment of tx.commentLines) {
+    lines.push(`${config.indent}${comment}`);
+  }
+
+  for (const p of tx.postings) {
+    const account = p.virtual ? `(${p.account})` : p.account;
+    let line = `${config.indent}${account}`;
+    if (p.amountText != null && p.currency != null) {
+      const signLength = p.amountText.startsWith("-") ? 1 : 0;
+      line = alignAmount(line, `${p.amountText} ${quoteCommodity(p.currency)}`, signLength, config);
+      if (p.assertion) line += ` = ${p.assertion.amountText} ${quoteCommodity(p.assertion.currency)}`;
+    }
+    if (p.comment) line += `  ${p.comment}`;
+    lines.push(line);
+  }
+
+  return lines.join("\n");
+}
+
+/** Render a parsed P directive canonically, preserving the written amount. */
+export function renderPrice(price: PriceDirective): string {
+  return `P ${price.date} ${quoteCommodity(price.commodity)} ${price.amountText} ${quoteCommodity(price.currency)}`;
+}
+
+/** Pad so the amount's first digit lands at `alignColumn` (its sign hangs one
+ *  column left), with a minimum 2-space gap for very long account names. */
+function alignAmount(prefix: string, amountStr: string, signLength: number, config: FormatConfig): string {
+  const pad = Math.max(2, config.alignColumn - signLength - prefix.length);
+  return `${prefix}${" ".repeat(pad)}${amountStr}`;
+}

--- a/packages/hledger-journal/src/index.ts
+++ b/packages/hledger-journal/src/index.ts
@@ -1,0 +1,21 @@
+export { isValidCalendarDate } from "./dates";
+export { type DatedEntry, JournalDoc } from "./doc";
+export { JournalParseError } from "./errors";
+export {
+  BALANCE_ASSERTION_PAYEE,
+  type BalanceAssertionInput,
+  DEFAULT_FORMAT,
+  formatBalanceAssertion,
+  formatPrice,
+  formatPriceAmount,
+  formatTransaction,
+  type PriceInput,
+  quoteCommodity,
+  renderPrice,
+  renderTransaction,
+  type TransactionInput,
+} from "./format";
+export { parsePriceBlock, parseTransactionBlock } from "./parse";
+export { segment } from "./segment";
+export { type SkippedBlock, type TidyResult, tidyJournal } from "./tidy";
+export type { Block, BlockKind, FormatConfig, Posting, PriceDirective, Tag, Transaction } from "./types";

--- a/packages/hledger-journal/src/parse.ts
+++ b/packages/hledger-journal/src/parse.ts
@@ -1,0 +1,231 @@
+import { JournalParseError } from "./errors";
+import type { Block, Posting, PriceDirective, Tag, Transaction } from "./types";
+
+// A number (no thousands separators) followed by a commodity: either quoted or
+// a run of letters/currency signs. Anything else is outside the app-written
+// subset and must fail typed — a best-effort parse that guesses would be the
+// one way this library could corrupt a journal.
+const AMOUNT_RE = /^(-?\d+(?:\.\d+)?)\s+("[^"]*"|[\p{L}\p{Sc}]+)$/u;
+
+// hledger's tag rule, verified against `hledger print -O json`: anywhere in a
+// comment, a word immediately followed by ":" starts a tag; its value runs to
+// the next comma or the end of the line (swallowing any inner colons).
+const TAG_SCAN_RE = /(?:^|[\s,])([^\s:,;]+):([^,]*)/g;
+
+/**
+ * Parse a transaction block into objects, strictly. Every verbatim field
+ * (description, comments, amount texts) is preserved so a canonical re-render
+ * can never change what hledger sees — only layout. Anything outside the
+ * supported subset throws a JournalParseError pointing at the offending line;
+ * callers must then leave the block's text untouched.
+ */
+export function parseTransactionBlock(block: Block): Transaction {
+  if (block.kind !== "transaction") {
+    throw new JournalParseError(`expected a transaction block, got "${block.kind}"`, block.startLine);
+  }
+  if (!block.date) {
+    throw new JournalParseError("the transaction date is not a valid calendar date", block.startLine);
+  }
+
+  const lines = blockLines(block);
+  const { status, code, description, headerComment } = parseHeader(lines[0], block.startLine);
+
+  const commentLines: string[] = [];
+  const tags: Tag[] = headerComment ? deriveTags(headerComment) : [];
+  const postings: Posting[] = [];
+
+  for (let idx = 1; idx < lines.length; idx++) {
+    const lineNo = block.startLine + idx;
+    const text = lines[idx].trim();
+    if (text.startsWith(";")) {
+      // hledger attaches comment lines below a posting to that posting; re-rendering
+      // them at transaction level would silently move their tags. Refuse instead.
+      if (postings.length > 0) {
+        throw new JournalParseError("comment lines between or after postings are not supported", lineNo);
+      }
+      commentLines.push(text);
+      tags.push(...deriveTags(text));
+      continue;
+    }
+    postings.push(parsePosting(text, lineNo));
+  }
+
+  const pipe = description.indexOf("|");
+  const payee = (pipe >= 0 ? description.slice(0, pipe) : description).trim();
+  const note = pipe >= 0 ? description.slice(pipe + 1).trim() : undefined;
+
+  return { date: block.date, status, code, description, payee, note, headerComment, commentLines, tags, postings };
+}
+
+/** Parse a P directive block. The written amount is preserved verbatim. */
+export function parsePriceBlock(block: Block): PriceDirective {
+  if (block.kind !== "price") {
+    throw new JournalParseError(`expected a price block, got "${block.kind}"`, block.startLine);
+  }
+  if (!block.date) {
+    throw new JournalParseError("the price date is not a valid calendar date", block.startLine);
+  }
+  const lines = blockLines(block);
+  if (lines.length > 1) {
+    throw new JournalParseError("unexpected indented lines under a P directive", block.startLine + 1);
+  }
+  const match = lines[0]
+    .trimEnd()
+    .match(/^P\s+\S+\s+("[^"]*"|[\p{L}\p{Sc}]+)\s+(-?\d+(?:\.\d+)?)\s+("[^"]*"|[\p{L}\p{Sc}]+)$/u);
+  if (!match) {
+    throw new JournalParseError(`unsupported P directive format: "${lines[0].trim()}"`, block.startLine);
+  }
+  return {
+    date: block.date,
+    commodity: unquote(match[1], block.startLine),
+    amount: Number(match[2]),
+    amountText: match[2],
+    currency: unquote(match[3], block.startLine),
+  };
+}
+
+// ── Internals ───────────────────────────────────────────────────────
+
+/** The block's physical lines without terminators. Blocks never contain blank
+ *  lines (the segmenter splits on them), so the only empty artifact is the one
+ *  after a trailing newline. */
+function blockLines(block: Block): string[] {
+  const lines = block.raw.split("\n").map((line) => line.replace(/\r$/, ""));
+  if (lines[lines.length - 1] === "") lines.pop();
+  return lines;
+}
+
+/** Tags of one comment (verbatim text starting with ";"), per hledger's rule. */
+function deriveTags(comment: string): Tag[] {
+  const body = comment.replace(/^;\s*/, "");
+  const tags: Tag[] = [];
+  for (const match of body.matchAll(TAG_SCAN_RE)) {
+    const value = match[2].trim();
+    tags.push(value === "" ? { name: match[1] } : { name: match[1], value });
+  }
+  return tags;
+}
+
+function parseHeader(
+  header: string,
+  lineNo: number,
+): { status?: "*" | "!"; code?: string; description: string; headerComment?: string } {
+  const clean = header.replace(/^\uFEFF/, "");
+  const date = clean.match(/^\d{4}[-/.]\d{1,2}[-/.]\d{1,2}/);
+  let rest = clean.trimEnd().slice(date ? date[0].length : 0);
+  if (rest.startsWith("=")) {
+    throw new JournalParseError("secondary dates (DATE=DATE2) are not supported", lineNo);
+  }
+  rest = rest.trimStart();
+
+  let status: "*" | "!" | undefined;
+  if (/^[*!](\s|$)/.test(rest)) {
+    status = rest[0] as "*" | "!";
+    rest = rest.slice(1).trimStart();
+  }
+
+  let code: string | undefined;
+  const codeMatch = rest.match(/^\(([^)]*)\)\s*/);
+  if (codeMatch) {
+    code = codeMatch[1];
+    rest = rest.slice(codeMatch[0].length);
+  }
+
+  let headerComment: string | undefined;
+  const commentIdx = rest.indexOf(";");
+  if (commentIdx >= 0) {
+    headerComment = rest.slice(commentIdx).trimEnd();
+    rest = rest.slice(0, commentIdx);
+  }
+
+  return { status, code, description: rest.trim(), headerComment };
+}
+
+function parsePosting(text: string, lineNo: number): Posting {
+  if (/^[*!]\s/.test(text)) {
+    throw new JournalParseError("posting status markers are not supported", lineNo);
+  }
+  if (text.startsWith("[")) {
+    throw new JournalParseError("balanced virtual postings ([...]) are not supported", lineNo);
+  }
+
+  // hledger separates a posting's account from its amount with 2+ spaces or a tab.
+  const sep = text.match(/ {2,}|\t+/);
+  let accountText = sep ? text.slice(0, sep.index) : text;
+  const rest = sep ? text.slice((sep.index as number) + sep[0].length).trim() : undefined;
+
+  if (accountText.includes(";")) {
+    throw new JournalParseError("a posting comment must be separated from the account by 2+ spaces", lineNo);
+  }
+
+  let virtual = false;
+  if (accountText.startsWith("(")) {
+    if (!accountText.endsWith(")")) {
+      throw new JournalParseError(`unbalanced parentheses in account "${accountText}"`, lineNo);
+    }
+    virtual = true;
+    accountText = accountText.slice(1, -1);
+  }
+  if (accountText === "") {
+    throw new JournalParseError("a posting is missing its account", lineNo);
+  }
+
+  const posting: Posting = { account: accountText };
+  if (virtual) posting.virtual = true;
+  if (rest === undefined || rest === "") return posting;
+
+  if (rest.startsWith(";")) {
+    posting.comment = rest;
+    return posting;
+  }
+  if (rest.startsWith("=")) {
+    throw new JournalParseError("balance assignments (account = amount) are not supported", lineNo);
+  }
+
+  let amountPart = rest;
+  const commentIdx = amountPart.indexOf(";");
+  if (commentIdx >= 0) {
+    posting.comment = amountPart.slice(commentIdx);
+    amountPart = amountPart.slice(0, commentIdx).trimEnd();
+  }
+  if (amountPart.includes("@")) {
+    throw new JournalParseError("cost notation (@) is not supported", lineNo);
+  }
+
+  const eq = amountPart.indexOf("=");
+  let assertionPart: string | undefined;
+  if (eq >= 0) {
+    if (amountPart[eq + 1] === "=" || amountPart[eq + 1] === "*") {
+      throw new JournalParseError("only simple balance assertions (=) are supported", lineNo);
+    }
+    assertionPart = amountPart.slice(eq + 1).trim();
+    amountPart = amountPart.slice(0, eq).trimEnd();
+  }
+
+  const amount = parseAmount(amountPart, lineNo);
+  posting.amount = amount.value;
+  posting.amountText = amount.text;
+  posting.currency = amount.currency;
+  if (assertionPart !== undefined) {
+    const assertion = parseAmount(assertionPart, lineNo);
+    posting.assertion = { amount: assertion.value, amountText: assertion.text, currency: assertion.currency };
+  }
+  return posting;
+}
+
+function parseAmount(text: string, lineNo: number): { value: number; text: string; currency: string } {
+  const match = text.match(AMOUNT_RE);
+  if (!match) {
+    throw new JournalParseError(`unsupported amount format: "${text}"`, lineNo);
+  }
+  return { value: Number(match[1]), text: match[1], currency: unquote(match[2], lineNo) };
+}
+
+function unquote(commodity: string, lineNo: number): string {
+  if (!commodity.startsWith('"')) return commodity;
+  const inner = commodity.slice(1, -1);
+  if (inner === "") {
+    throw new JournalParseError("an empty quoted commodity is not supported", lineNo);
+  }
+  return inner;
+}

--- a/packages/hledger-journal/src/segment.ts
+++ b/packages/hledger-journal/src/segment.ts
@@ -1,0 +1,89 @@
+import { normalizeDate } from "./dates";
+import type { Block, BlockKind } from "./types";
+
+// A transaction header starts with a date; the separator must be consistent
+// (backreference) and the token must end before whitespace, "=", or EOL.
+const DATE_START_RE = /^(\d{4})([-/.])(\d{1,2})\2(\d{1,2})(?=[\s=]|$)/;
+const DATE_TOKEN_RE = /^(\d{4})([-/.])(\d{1,2})\2(\d{1,2})$/;
+
+type LineClass = "blank" | "indented" | "comment" | "comment-block" | "date" | "price" | "directive";
+
+/**
+ * Split journal text into an ordered list of blocks. Purely structural: a block
+ * is a column-0 line plus its indented continuation lines; nothing inside a
+ * block is interpreted beyond the leading date token. The invariant
+ * `segment(text).map(b => b.raw).join("") === text` holds for any input —
+ * segmentation never loses a byte.
+ */
+export function segment(text: string): Block[] {
+  const lines = text.match(/[^\n]*\n|[^\n]+/g) ?? [];
+  const blocks: Block[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const start = i;
+    const cls = classify(lines[i]);
+    let kind: BlockKind;
+    let date: string | undefined;
+
+    if (cls === "blank") {
+      while (i < lines.length && classify(lines[i]) === "blank") i++;
+      kind = "blank";
+    } else if (cls === "comment") {
+      i++;
+      while (i < lines.length && ["comment", "indented"].includes(classify(lines[i]))) i++;
+      kind = "comment";
+    } else if (cls === "indented") {
+      // Indented lines with no preceding column-0 opener (e.g. at file start or
+      // after a blank line) are invalid hledger; preserve them verbatim.
+      while (i < lines.length && classify(lines[i]) === "indented") i++;
+      kind = "other";
+    } else if (cls === "comment-block") {
+      i++;
+      while (i < lines.length && !/^end comment(\s|$)/.test(content(lines[i]))) i++;
+      if (i < lines.length) i++;
+      kind = "other";
+    } else {
+      i++;
+      while (i < lines.length && classify(lines[i]) === "indented") i++;
+      if (cls === "date") {
+        kind = "transaction";
+        const match = content(lines[start]).match(DATE_START_RE);
+        date = match ? normalizeDate(match[1], match[3], match[4]) : undefined;
+      } else if (cls === "price") {
+        kind = "price";
+        date = priceDate(content(lines[start]));
+      } else {
+        kind = "directive";
+      }
+    }
+
+    blocks.push({ kind, raw: lines.slice(start, i).join(""), startLine: start + 1, endLine: i, date });
+  }
+
+  return blocks;
+}
+
+/** The line for classification: no terminator, and no UTF-8 BOM — hledger
+ *  accepts a BOM-prefixed journal, so a BOM must not hide a transaction.
+ *  The BOM stays in `raw`; only classification looks through it. */
+function content(line: string): string {
+  return line.replace(/^\uFEFF/, "").replace(/\r?\n$/, "");
+}
+
+function classify(line: string): LineClass {
+  const c = content(line);
+  if (/^\s*$/.test(c)) return "blank";
+  if (/^[ \t]/.test(c)) return "indented";
+  if (/^[;#*]/.test(c)) return "comment";
+  if (/^comment(\s|$)/.test(c)) return "comment-block";
+  if (DATE_START_RE.test(c)) return "date";
+  if (/^P\s/.test(c)) return "price";
+  return "directive";
+}
+
+function priceDate(line: string): string | undefined {
+  const token = line.split(/\s+/)[1];
+  const match = token?.match(DATE_TOKEN_RE);
+  return match ? normalizeDate(match[1], match[3], match[4]) : undefined;
+}

--- a/packages/hledger-journal/src/tidy.ts
+++ b/packages/hledger-journal/src/tidy.ts
@@ -1,0 +1,146 @@
+import { JournalParseError } from "./errors";
+import { DEFAULT_FORMAT, renderPrice, renderTransaction } from "./format";
+import { parsePriceBlock, parseTransactionBlock } from "./parse";
+import { segment } from "./segment";
+import type { Block, FormatConfig } from "./types";
+
+export interface SkippedBlock {
+  startLine: number;
+  reason: string;
+}
+
+export interface TidyResult {
+  text: string;
+  skippedBlocks: SkippedBlock[];
+}
+
+/** A sortable unit: one dated entry plus the comment glued directly above it. */
+interface UnitElement {
+  type: "unit";
+  raw: string;
+  date: string;
+}
+
+/** An immovable run: directives, standalone comments, unparseable entries —
+ *  preserved byte-for-byte, including the blank lines inside the run. */
+interface FixedElement {
+  type: "fixed";
+  raw: string;
+  lastBlockIndex: number;
+}
+
+type Element = UnitElement | FixedElement;
+
+/**
+ * Sort a journal's dated entries chronologically and re-render each one in the
+ * canonical layout. Only entries the strict parser fully understands are
+ * touched; everything else (directives, unparseable entries, standalone
+ * comments) stays byte-identical, acts as a barrier that entries never cross,
+ * and is reported in `skippedBlocks`. Blank lines between sorted units are
+ * normalized to exactly one; blank lines inside preserved runs are kept.
+ */
+export function tidyJournal(text: string, config: FormatConfig = DEFAULT_FORMAT): TidyResult {
+  const blocks = segment(text);
+  const eol = text.includes("\r\n") ? "\r\n" : "\n";
+  const skippedBlocks: SkippedBlock[] = [];
+  const elements: Element[] = [];
+
+  const pushFixed = (raw: string, firstIndex: number, lastIndex: number): void => {
+    const previous = elements[elements.length - 1];
+    if (previous?.type === "fixed") {
+      const gap = blankGap(blocks, previous.lastBlockIndex, firstIndex);
+      if (gap !== undefined) {
+        previous.raw += gap + raw;
+        previous.lastBlockIndex = lastIndex;
+        return;
+      }
+    }
+    elements.push({ type: "fixed", raw, lastBlockIndex: lastIndex });
+  };
+
+  const tryRenderEntry = (block: Block): string | undefined => {
+    try {
+      return block.kind === "transaction"
+        ? renderTransaction(parseTransactionBlock(block), config)
+        : renderPrice(parsePriceBlock(block));
+    } catch (e) {
+      if (e instanceof JournalParseError) {
+        skippedBlocks.push({ startLine: block.startLine, reason: e.reason });
+        return undefined;
+      }
+      throw e;
+    }
+  };
+
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i];
+    if (block.kind === "blank") continue;
+
+    const next = blocks[i + 1];
+    if (block.kind === "comment" && next && isEntryKind(next)) {
+      // The comment is glued to the entry below it; they sort (or stay) together.
+      const rendered = tryRenderEntry(next);
+      if (rendered !== undefined) {
+        elements.push({ type: "unit", raw: block.raw + withEol(rendered, eol), date: next.date as string });
+      } else {
+        pushFixed(block.raw + next.raw, i, i + 1);
+      }
+      i += 1;
+      continue;
+    }
+
+    if (isEntryKind(block)) {
+      const rendered = tryRenderEntry(block);
+      if (rendered !== undefined) {
+        elements.push({ type: "unit", raw: withEol(rendered, eol), date: block.date as string });
+      } else {
+        pushFixed(block.raw, i, i);
+      }
+      continue;
+    }
+
+    pushFixed(block.raw, i, i);
+  }
+
+  sortUnitRuns(elements);
+
+  const parts = elements.map((el) => (el.raw.endsWith("\n") ? el.raw : el.raw + eol));
+  return { text: parts.join(eol), skippedBlocks };
+}
+
+// ── Internals ───────────────────────────────────────────────────────
+
+function isEntryKind(block: Block): boolean {
+  return block.kind === "transaction" || block.kind === "price";
+}
+
+function withEol(rendered: string, eol: string): string {
+  return rendered.replace(/\n/g, eol) + eol;
+}
+
+/** The raw bytes of the blocks strictly between two indices, or undefined if
+ *  any of them is not blank (the runs must then stay separate). */
+function blankGap(blocks: Block[], fromIndex: number, toIndex: number): string | undefined {
+  let gap = "";
+  for (let i = fromIndex + 1; i < toIndex; i++) {
+    if (blocks[i].kind !== "blank") return undefined;
+    gap += blocks[i].raw;
+  }
+  return gap;
+}
+
+/** Stable-sort each maximal run of consecutive units by date; fixed elements
+ *  are barriers that units never cross. */
+function sortUnitRuns(elements: Element[]): void {
+  let runStart = -1;
+  for (let i = 0; i <= elements.length; i++) {
+    const isUnit = i < elements.length && elements[i].type === "unit";
+    if (isUnit && runStart < 0) runStart = i;
+    if (!isUnit && runStart >= 0) {
+      const run = elements.slice(runStart, i) as UnitElement[];
+      run.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+      elements.splice(runStart, i - runStart, ...run);
+      runStart = -1;
+    }
+  }
+}

--- a/packages/hledger-journal/src/types.ts
+++ b/packages/hledger-journal/src/types.ts
@@ -1,0 +1,70 @@
+export type BlockKind = "transaction" | "price" | "directive" | "comment" | "blank" | "other";
+
+export interface Block {
+  kind: BlockKind;
+  /** Exact byte slice of the source, including its line terminators. */
+  raw: string;
+  /** 1-indexed first line of the block in the source. */
+  startLine: number;
+  /** 1-indexed last line of the block in the source. */
+  endLine: number;
+  /** Normalized ISO date for dated entries (transaction/price); undefined when unparseable. */
+  date?: string;
+}
+
+export interface Tag {
+  name: string;
+  value?: string;
+}
+
+export interface Posting {
+  account: string;
+  /** Numeric amount; absent for an elided (balancing) posting. */
+  amount?: number;
+  /** The amount exactly as written (sign and decimals preserved); rendering uses this, never the number. */
+  amountText?: string;
+  currency?: string;
+  assertion?: { amount: number; amountText: string; currency: string };
+  /** Trailing comment, verbatim from the ";" to the end of the line. */
+  comment?: string;
+  /** True for a parenthesized (unbalanced virtual) posting. */
+  virtual?: boolean;
+}
+
+export interface Transaction {
+  /** Normalized ISO date (YYYY-MM-DD). */
+  date: string;
+  /** Status marker; undefined when unmarked. */
+  status?: "*" | "!";
+  code?: string;
+  /** Full description verbatim: the header text after date/status/code, before any comment. */
+  description: string;
+  /** Derived: description before the first "|", trimmed. */
+  payee: string;
+  /** Derived: description after the first "|", trimmed; undefined when there is no "|". */
+  note?: string;
+  /** Header comment, verbatim from the ";" to the end of the line. */
+  headerComment?: string;
+  /** Indented comment lines between the header and the first posting, each verbatim from its ";". */
+  commentLines: string[];
+  /** Tags derived from single-tag comment lines ("; name:" or "; name: value"). */
+  tags: Tag[];
+  postings: Posting[];
+}
+
+export interface PriceDirective {
+  /** Normalized ISO date (YYYY-MM-DD). */
+  date: string;
+  commodity: string;
+  amount: number;
+  /** The amount exactly as written; rendering uses this, never the number. */
+  amountText: string;
+  currency: string;
+}
+
+export interface FormatConfig {
+  /** Leading whitespace of posting/comment lines. */
+  indent: string;
+  /** 0-indexed column where an amount's first digit lands; a minus sign hangs one column left. */
+  alignColumn: number;
+}

--- a/packages/pi-extension/package.json
+++ b/packages/pi-extension/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "description": "Accountant24 customization for pi: ledger tools, commands, system prompt, scaffolding.",
   "dependencies": {
+    "@accountant24/hledger-journal": "*",
     "@earendil-works/pi-coding-agent": "0.79.8",
     "file-type": "22.0.1",
     "typebox": "1.1.38"

--- a/packages/pi-extension/src/ledger/__tests__/transactions.test.ts
+++ b/packages/pi-extension/src/ledger/__tests__/transactions.test.ts
@@ -561,6 +561,105 @@ describe("addTransaction() file routing", () => {
   });
 });
 
+// ── Date-ordered insertion ──────────────────────────────────────────
+
+describe("addTransaction() date-ordered insertion", () => {
+  const laterEntry = "2026-03-20 * Later | Rent\n    Expenses:Rent    900.00 USD\n    Assets:Checking\n";
+
+  function seedMonthly(content: string) {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    writeFileSync(join(LEDGER, "2026", "03.journal"), content);
+  }
+
+  test("should insert an earlier-dated transaction before existing later entries", async () => {
+    seedMonthly(laterEntry);
+    const result = await addTransaction({ ...basicParams, date: "2026-03-05" });
+    const content = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    expect(content).toBe(`${result.transactionText}\n\n${laterEntry}`);
+  });
+
+  test("should place an out-of-order batch date-sorted within the monthly file", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    const result = await addTransactions([tx2, basicParams]); // 03-20 first, 03-15 second
+    const content = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    expect(content).toBe(`${result.transactions[1].transactionText}\n\n${result.transactions[0].transactionText}\n`);
+  });
+
+  test("should insert a same-date transaction after the existing one", async () => {
+    const sameDate = "2026-03-15 * First | Same day\n    Expenses:X    1.00 USD\n    Assets:Checking\n";
+    seedMonthly(`${sameDate}\n${laterEntry}`);
+    const result = await addTransaction(basicParams);
+    const content = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    expect(content).toBe(`${sameDate}\n${result.transactionText}\n\n${laterEntry}`);
+  });
+
+  test("should terminate a file lacking a trailing newline before inserting", async () => {
+    seedMonthly(laterEntry.trimEnd());
+    const result = await addTransaction({ ...basicParams, date: "2026-03-25" });
+    const content = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    expect(content).toBe(`${laterEntry.trimEnd()}\n\n${result.transactionText}\n`);
+  });
+
+  test("should keep a comment attached to its transaction when inserting before it", async () => {
+    seedMonthly(`; rent note\n${laterEntry}`);
+    const result = await addTransaction({ ...basicParams, date: "2026-03-05" });
+    const content = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    expect(content).toBe(`${result.transactionText}\n\n; rent note\n${laterEntry}`);
+  });
+
+  test("should produce a diff with context lines for a mid-file insert", async () => {
+    const earlyEntry = "2026-03-01 * Early | Coffee\n    Expenses:Coffee    5.00 USD\n    Assets:Checking\n";
+    seedMonthly(`${earlyEntry}\n${laterEntry}`);
+    const result = await addTransaction(basicParams);
+    const lines = result.diff.split("\n").filter((l: string) => l.trim());
+    expect(lines.some((l: string) => l.startsWith("+") && l.includes("Whole Foods"))).toBe(true);
+    expect(lines.some((l: string) => !l.startsWith("+") && !l.startsWith("-"))).toBe(true);
+  });
+
+  test("should insert a backdated balance assertion before later transactions", async () => {
+    seedMonthly(laterEntry);
+    await addBalanceAssertions([
+      { date: "2026-03-10", account: "Assets:Checking", balance: { amount: 500, currency: "USD" } },
+    ]);
+    const content = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    expect(content.indexOf("Balance Assertion")).toBeLessThan(content.indexOf("2026-03-20"));
+  });
+
+  test("should insert a backdated price before later transactions", async () => {
+    seedMonthly(laterEntry);
+    await addPrices([{ date: "2026-03-10", commodity: "BTC", price: { amount: 55000, currency: "USD" } }]);
+    const content = readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8");
+    expect(content.indexOf("P 2026-03-10")).toBeLessThan(content.indexOf("2026-03-20"));
+  });
+});
+
+// ── Calendar-date validation ────────────────────────────────────────
+
+describe("calendar-impossible dates", () => {
+  test("should reject a transaction dated on a day that does not exist, before writing anything", async () => {
+    writeFileSync(join(LEDGER, "main.journal"), "");
+    await expect(addTransaction({ ...basicParams, date: "2026-02-31" })).rejects.toThrow(
+      "That calendar day does not exist",
+    );
+    expect(existsSync(join(LEDGER, "2026"))).toBe(false);
+  });
+
+  test("should reject a balance assertion dated on a day that does not exist", async () => {
+    await expect(
+      addBalanceAssertions([
+        { date: "2026-02-30", account: "Assets:Checking", balance: { amount: 1, currency: "USD" } },
+      ]),
+    ).rejects.toThrow("That calendar day does not exist");
+  });
+
+  test("should reject a price dated in a month that does not exist", async () => {
+    await expect(
+      addPrices([{ date: "2026-13-01", commodity: "USD", price: { amount: 0.87, currency: "EUR" } }]),
+    ).rejects.toThrow("That calendar day does not exist");
+  });
+});
+
 // ── main.journal management ─────────────────────────────────────────
 
 describe("addTransaction() main.journal management", () => {

--- a/packages/pi-extension/src/ledger/__tests__/validate.test.ts
+++ b/packages/pi-extension/src/ledger/__tests__/validate.test.ts
@@ -1,13 +1,15 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { spawnText } from "../../spawn";
 
 vi.mock("../../spawn");
 
-import { mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const BASE = mkdtempSync(join(tmpdir(), "accountant24-validate-"));
+const LEDGER = join(BASE, "ledger");
+
 vi.mock("../../config.js", () => ({
   ACCOUNTANT24_HOME: BASE,
   LEDGER_DIR: join(BASE, "ledger"),
@@ -21,13 +23,19 @@ function makeMockProc(exitCode: number, stdout = "", stderr = "") {
 
 const { validateLedger } = await import("../validate.js");
 
-afterEach(() => {});
+afterAll(() => {
+  rmSync(BASE, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  rmSync(LEDGER, { recursive: true, force: true });
+});
 
 describe("validateLedger()", () => {
-  test("should return { ledgerIsValid: true } when hledger check succeeds", async () => {
+  test("should return ledgerIsValid with an empty tidy summary when there are no monthly files", async () => {
     vi.mocked(spawnText).mockResolvedValue(makeMockProc(0));
     const result = await validateLedger();
-    expect(result).toEqual({ ledgerIsValid: true });
+    expect(result).toEqual({ ledgerIsValid: true, tidy: { files: 0, changed: 0, diffs: [], skipped: [] } });
   });
 
   test("should throw Error with stderr when hledger check fails", async () => {
@@ -71,5 +79,168 @@ describe("validateLedger()", () => {
     expect(args).toContain("-f");
     const fIdx = args.indexOf("-f");
     expect(args[fIdx + 1]).toContain("main.journal");
+  });
+});
+
+// ── Tidying before validation ───────────────────────────────────────
+
+// Sloppy 2-space-indent inputs and their canonical renderings (alignment column 69).
+const RENT = "2026-03-20 * Rent\n  Expenses:Rent  900.00 USD\n  Assets:Bank\n";
+const SHOP = "2026-03-05 * Shop\n  Expenses:Food  45.00 USD\n  Assets:Cash\n";
+const CANON_RENT = `2026-03-20 * Rent\n    Expenses:Rent${" ".repeat(52)}900.00 USD\n    Assets:Bank\n`;
+const CANON_SHOP = `2026-03-05 * Shop\n    Expenses:Food${" ".repeat(52)}45.00 USD\n    Assets:Cash\n`;
+
+const MARCH = join(LEDGER, "2026", "03.journal");
+
+describe("validateLedger() tidying", () => {
+  let checkExit = 0;
+  let checkStderr = "";
+  let printExit = 0;
+  let printStderr = "";
+  let printOutputs: string[] | null = null; // null → every print returns "[]"
+
+  beforeEach(() => {
+    mkdirSync(join(LEDGER, "2026"), { recursive: true });
+    writeFileSync(join(LEDGER, "main.journal"), "include 2026/03.journal\n");
+    checkExit = 0;
+    checkStderr = "";
+    printExit = 0;
+    printStderr = "";
+    printOutputs = null;
+    vi.mocked(spawnText).mockImplementation(async (cmd: string[]) => {
+      if (cmd[1] === "print") {
+        return makeMockProc(printExit, printOutputs ? (printOutputs.shift() ?? "[]") : "[]", printStderr);
+      }
+      return makeMockProc(checkExit, "", checkStderr);
+    });
+  });
+
+  test("should sort and format monthly files when the ledger is valid", async () => {
+    writeFileSync(MARCH, `${RENT}\n${SHOP}`);
+    const result = await validateLedger();
+    expect(readFileSync(MARCH, "utf-8")).toBe(`${CANON_SHOP}\n${CANON_RENT}`);
+    expect(result.ledgerIsValid).toBe(true);
+    expect(result.tidy).toMatchObject({ files: 1, changed: 1, skipped: [] });
+    expect(result.tidy.diffs[0].fullFilePath).toBe(MARCH);
+    expect(result.tidy.diffs[0].diff).toContain("Shop");
+  });
+
+  test("should run only hledger check when everything is already tidy", async () => {
+    writeFileSync(MARCH, `${CANON_SHOP}\n${CANON_RENT}`);
+    const result = await validateLedger();
+    expect(result.tidy).toEqual({ files: 1, changed: 0, diffs: [], skipped: [] });
+    expect(vi.mocked(spawnText)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(spawnText).mock.calls[0][0]).toContain("check");
+  });
+
+  test("should not touch ledger files other than the monthly journals", async () => {
+    writeFileSync(MARCH, `${RENT}\n${SHOP}`);
+    const accounts = "account Assets:Bank\naccount   Assets:Cash\n";
+    writeFileSync(join(LEDGER, "accounts.journal"), accounts);
+    const result = await validateLedger();
+    expect(result.tidy.files).toBe(1);
+    expect(readFileSync(join(LEDGER, "accounts.journal"), "utf-8")).toBe(accounts);
+  });
+
+  test("should not tidy at all when the check fails, so errors point at the files as written", async () => {
+    writeFileSync(MARCH, `${RENT}\n${SHOP}`);
+    checkExit = 1;
+    checkStderr = "hledger: Error: unbalanced transaction";
+    await expect(validateLedger()).rejects.toThrow("unbalanced transaction");
+    expect(readFileSync(MARCH, "utf-8")).toBe(`${RENT}\n${SHOP}`);
+    // The check is the only hledger run — no snapshot, no write, no restore.
+    expect(vi.mocked(spawnText)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(spawnText).mock.calls[0][0]).toContain("check");
+  });
+
+  test("should restore tidied files and throw when tidying would change the ledger's meaning", async () => {
+    writeFileSync(MARCH, `${RENT}\n${SHOP}`);
+    printOutputs = ['[{"tdescription":"Rent"}]', '[{"tdescription":"Rent CHANGED"}]'];
+    await expect(validateLedger()).rejects.toThrow("changed the ledger's meaning");
+    expect(readFileSync(MARCH, "utf-8")).toBe(`${RENT}\n${SHOP}`);
+  });
+
+  test("should ignore position-only differences in the semantic comparison", async () => {
+    writeFileSync(MARCH, `${RENT}\n${SHOP}`);
+    printOutputs = [
+      '[{"tdescription":"Rent","tindex":1,"tsourcepos":[{"sourceLine":1}],"ptransaction_":"1","baposition":{"sourceLine":2}}]',
+      '[{"tdescription":"Rent","tindex":9,"tsourcepos":[{"sourceLine":7}],"ptransaction_":"9","baposition":{"sourceLine":8}}]',
+    ];
+    const result = await validateLedger();
+    expect(result.tidy.changed).toBe(1);
+  });
+
+  test("should report the check error for already-tidy files without extra hledger runs", async () => {
+    writeFileSync(MARCH, `${CANON_SHOP}`);
+    checkExit = 1;
+    checkStderr = "hledger: Error: account not declared";
+    await expect(validateLedger()).rejects.toThrow("account not declared");
+    expect(readFileSync(MARCH, "utf-8")).toBe(CANON_SHOP);
+  });
+
+  test("should propagate hledger-not-found without touching files", async () => {
+    writeFileSync(MARCH, `${RENT}\n${SHOP}`);
+    vi.mocked(spawnText).mockResolvedValue(makeMockProc(127));
+    await expect(validateLedger()).rejects.toThrow("hledger not found");
+    expect(readFileSync(MARCH, "utf-8")).toBe(`${RENT}\n${SHOP}`);
+  });
+
+  test("should restore files and rethrow when the semantic snapshot is not valid JSON", async () => {
+    writeFileSync(MARCH, `${RENT}\n${SHOP}`);
+    let printCalls = 0;
+    vi.mocked(spawnText).mockImplementation(async (cmd: string[]) => {
+      if (cmd[1] === "print") {
+        printCalls += 1;
+        return makeMockProc(0, printCalls === 1 ? "[]" : "not json");
+      }
+      return makeMockProc(0);
+    });
+    await expect(validateLedger()).rejects.toThrow(SyntaxError);
+    expect(readFileSync(MARCH, "utf-8")).toBe(`${RENT}\n${SHOP}`);
+  });
+
+  test("should restore files when the formatted result does not parse back", async () => {
+    writeFileSync(MARCH, `${RENT}\n${SHOP}`);
+    let printCalls = 0;
+    vi.mocked(spawnText).mockImplementation(async (cmd: string[]) => {
+      if (cmd[1] === "print") {
+        printCalls += 1;
+        return printCalls === 1 ? makeMockProc(0, "[]") : makeMockProc(1, "", "hledger: Error: parse failure");
+      }
+      return makeMockProc(0);
+    });
+    await expect(validateLedger()).rejects.toThrow("the formatted files did not parse");
+    expect(readFileSync(MARCH, "utf-8")).toBe(`${RENT}\n${SHOP}`);
+  });
+
+  test("should report entries outside the canonical subset and keep them verbatim", async () => {
+    const weird = "2026-03-10 * Weird\n    Assets:X    1 BTC @ 55000 EUR\n";
+    writeFileSync(MARCH, `${RENT}\n${weird}\n${SHOP}`);
+    const result = await validateLedger();
+    expect(result.tidy.skipped).toEqual([
+      { fullFilePath: MARCH, startLine: 5, reason: "cost notation (@) is not supported" },
+    ]);
+    expect(readFileSync(MARCH, "utf-8")).toContain(weird);
+  });
+
+  test("should leave every file untouched when the check fails, including files that needed tidying", async () => {
+    writeFileSync(MARCH, `${RENT}\n${SHOP}`);
+    mkdirSync(join(LEDGER, "2025"), { recursive: true });
+    const clean = CANON_SHOP.replace(/2026-03/g, "2025-12");
+    writeFileSync(join(LEDGER, "2025", "12.journal"), clean);
+    checkExit = 1;
+    checkStderr = "hledger: Error: nope";
+    await expect(validateLedger()).rejects.toThrow("nope");
+    expect(readFileSync(MARCH, "utf-8")).toBe(`${RENT}\n${SHOP}`);
+    expect(readFileSync(join(LEDGER, "2025", "12.journal"), "utf-8")).toBe(clean);
+  });
+
+  test("should still report skipped entries when nothing needed rewriting", async () => {
+    const weird = "2026-03-10 * Weird\n    Assets:X    1 BTC @ 55000 EUR\n";
+    writeFileSync(MARCH, `${CANON_RENT}\n${weird}\n${CANON_SHOP}`);
+    const result = await validateLedger();
+    expect(result.tidy.changed).toBe(0);
+    expect(result.tidy.skipped).toHaveLength(1);
+    expect(vi.mocked(spawnText)).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/pi-extension/src/ledger/tidy.ts
+++ b/packages/pi-extension/src/ledger/tidy.ts
@@ -1,0 +1,87 @@
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tidyJournal } from "@accountant24/hledger-journal";
+import { generateDiffString } from "@earendil-works/pi-coding-agent";
+import { ACCOUNTANT24_HOME, LEDGER_DIR } from "../config";
+import { runHledger } from "./hledger";
+
+export interface TidySummary {
+  files: number;
+  changed: number;
+  diffs: Array<{ fullFilePath: string; diff: string }>;
+  skipped: Array<{ fullFilePath: string; startLine: number; reason: string }>;
+}
+
+export interface TidyPlan extends TidySummary {
+  /** New content per file that needs rewriting, keyed by absolute path. */
+  writes: Map<string, string>;
+  /** Original content of those files, for byte-exact rollback. */
+  snapshots: Map<string, string>;
+}
+
+/** hledger JSON keys that only encode positions or file order; they change
+ *  legitimately when entries move, so the semantic comparison ignores them. */
+const POSITION_KEYS = new Set(["tsourcepos", "tindex", "ptransaction_", "baposition"]);
+
+/** Compute the tidied (date-sorted, canonically formatted) content of every
+ *  monthly journal file, without touching the disk. Blocks the strict parser
+ *  does not fully understand are kept verbatim and reported in `skipped`. */
+export function planTidy(): TidyPlan {
+  const writes = new Map<string, string>();
+  const snapshots = new Map<string, string>();
+  const diffs: TidySummary["diffs"] = [];
+  const skipped: TidySummary["skipped"] = [];
+  const targets = discoverMonthlyFiles();
+
+  for (const fullFilePath of targets) {
+    const oldContent = readFileSync(fullFilePath, "utf-8");
+    const result = tidyJournal(oldContent);
+    for (const block of result.skippedBlocks) {
+      skipped.push({ fullFilePath, startLine: block.startLine, reason: block.reason });
+    }
+    if (result.text === oldContent) continue;
+    snapshots.set(fullFilePath, oldContent);
+    writes.set(fullFilePath, result.text);
+    diffs.push({ fullFilePath, diff: generateDiffString(oldContent, result.text).diff });
+  }
+
+  return { files: targets.length, changed: writes.size, diffs, skipped, writes, snapshots };
+}
+
+export function applyTidy(plan: TidyPlan): void {
+  for (const [fullFilePath, content] of plan.writes) {
+    writeFileSync(fullFilePath, content);
+  }
+}
+
+export function restoreTidy(plan: TidyPlan): void {
+  for (const [fullFilePath, content] of plan.snapshots) {
+    writeFileSync(fullFilePath, content);
+  }
+}
+
+/** The ledger's transactions as hledger sees them, minus position metadata.
+ *  Two equal snapshots prove an edit was layout-only. */
+export async function printSemantics(mainPath: string, signal?: AbortSignal): Promise<string> {
+  const stdout = await runHledger(["print", "-f", mainPath, "-O", "json"], { cwd: ACCOUNTANT24_HOME, signal });
+  return JSON.stringify(JSON.parse(stdout), (key, value) => (POSITION_KEYS.has(key) ? undefined : value));
+}
+
+/** All ledger/YYYY/MM.journal files, in chronological path order. */
+function discoverMonthlyFiles(): string[] {
+  if (!existsSync(LEDGER_DIR)) return [];
+  const result: string[] = [];
+  const years = readdirSync(LEDGER_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && /^\d{4}$/.test(entry.name))
+    .map((entry) => entry.name)
+    .sort();
+  for (const year of years) {
+    const monthly = readdirSync(join(LEDGER_DIR, year))
+      .filter((name) => /^\d{2}\.journal$/.test(name))
+      .sort();
+    for (const name of monthly) {
+      result.push(join(LEDGER_DIR, year, name));
+    }
+  }
+  return result;
+}

--- a/packages/pi-extension/src/ledger/transactions.ts
+++ b/packages/pi-extension/src/ledger/transactions.ts
@@ -1,5 +1,12 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
+import {
+  formatBalanceAssertion,
+  formatPrice,
+  formatTransaction,
+  isValidCalendarDate,
+  JournalDoc,
+} from "@accountant24/hledger-journal";
 import { generateDiffString } from "@earendil-works/pi-coding-agent";
 import { ACCOUNTANT24_HOME, LEDGER_DIR } from "../config";
 import { HledgerCommandError, hledgerCheck } from "./hledger";
@@ -43,6 +50,7 @@ export interface AddTransactionsResult {
 
 interface FormattedEntry {
   text: string;
+  date: string;
   fileKey: string;
   fullFilePath: string;
 }
@@ -120,7 +128,12 @@ function validateEach<T>(paramsList: T[], validate: (params: T) => void, label: 
 /** Every entry lives in the monthly journal of its date. */
 function routeByMonth(date: string, text: string): FormattedEntry {
   const [year, month] = date.split("-");
-  return { text, fileKey: `${year}/${month}`, fullFilePath: resolveSafePath(`${year}/${month}.journal`, LEDGER_DIR) };
+  return {
+    text,
+    date,
+    fileKey: `${year}/${month}`,
+    fullFilePath: resolveSafePath(`${year}/${month}.journal`, LEDGER_DIR),
+  };
 }
 
 function groupByFile(formatted: FormattedEntry[]): Map<string, FormattedEntry[]> {
@@ -141,7 +154,8 @@ interface FileContents {
   newContents: Map<string, string>;
 }
 
-/** Writes transactions to monthly journal files. Returns old and new contents for diff generation. */
+/** Writes entries to monthly journal files, each inserted in date order among
+ *  the existing entries. Returns old and new contents for diff generation. */
 function writeMonthlyFiles(byFile: Map<string, FormattedEntry[]>): FileContents {
   const oldContents = new Map<string, string>();
   const newContents = new Map<string, string>();
@@ -150,18 +164,14 @@ function writeMonthlyFiles(byFile: Map<string, FormattedEntry[]>): FileContents 
     const fullFilePath = entries[0].fullFilePath;
     mkdirSync(dirname(fullFilePath), { recursive: true });
 
-    const isNew = !existsSync(fullFilePath);
-    const oldContent = isNew ? "" : readFileSync(fullFilePath, "utf-8");
+    const oldContent = existsSync(fullFilePath) ? readFileSync(fullFilePath, "utf-8") : "";
     oldContents.set(fileKey, oldContent);
 
-    const joined = entries.map((e) => e.text).join("\n\n");
-    let newContent: string;
-    if (isNew) {
-      newContent = `${joined}\n`;
-    } else {
-      const separator = oldContent.endsWith("\n") ? "\n" : "\n\n";
-      newContent = `${oldContent}${separator}${joined}\n`;
+    const doc = JournalDoc.open(oldContent);
+    for (const entry of entries) {
+      doc.insertEntry(entry.text, entry.date);
     }
+    const newContent = doc.serialize();
     writeFileSync(fullFilePath, newContent);
     newContents.set(fileKey, newContent);
   }
@@ -249,6 +259,9 @@ function validateInputs(params: Pick<AddTransactionParams, "date" | "postings">)
   if (!/^\d{4}-\d{2}-\d{2}$/.test(params.date)) {
     throw new Error(`Invalid date format: ${params.date}. Expected YYYY-MM-DD.`);
   }
+  if (!isValidCalendarDate(params.date)) {
+    throw new Error(`Invalid date: ${params.date}. That calendar day does not exist.`);
+  }
   if (params.postings.length < 2) {
     throw new Error("At least 2 postings are required.");
   }
@@ -266,6 +279,9 @@ function validateAssertionInputs(params: AddBalanceAssertionParams): void {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(params.date)) {
     throw new Error(`Invalid date format: ${params.date}. Expected YYYY-MM-DD.`);
   }
+  if (!isValidCalendarDate(params.date)) {
+    throw new Error(`Invalid date: ${params.date}. That calendar day does not exist.`);
+  }
   if (!params.account) {
     throw new Error("Balance assertion is missing an account.");
   }
@@ -281,6 +297,9 @@ function validatePriceInputs(params: AddPriceParams): void {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(params.date)) {
     throw new Error(`Invalid date format: ${params.date}. Expected YYYY-MM-DD.`);
   }
+  if (!isValidCalendarDate(params.date)) {
+    throw new Error(`Invalid date: ${params.date}. That calendar day does not exist.`);
+  }
   if (!params.commodity) {
     throw new Error("Price is missing a commodity.");
   }
@@ -293,75 +312,4 @@ function validatePriceInputs(params: AddPriceParams): void {
   if (!params.price.currency) {
     throw new Error(`Price for ${params.commodity} is missing the currency.`);
   }
-}
-
-function formatTransaction(params: AddTransactionParams): string {
-  const header = params.description
-    ? `${params.date} * ${params.payee} | ${params.description}`
-    : `${params.date} * ${params.payee}`;
-
-  const lines = [header];
-
-  if (params.tags?.length) {
-    const sortedTags = [...params.tags].sort((a, b) =>
-      a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
-    );
-    for (const tag of sortedTags) {
-      lines.push(tag.value != null ? `    ; ${tag.name}: ${tag.value}` : `    ; ${tag.name}:`);
-    }
-  }
-
-  const sortedPostings = [...params.postings].sort((a, b) => {
-    const groupA = a.amount < 0 ? 0 : 1;
-    const groupB = b.amount < 0 ? 0 : 1;
-    return groupA - groupB;
-  });
-
-  for (const p of sortedPostings) {
-    const sign = p.amount < 0 ? "-" : "";
-    const amountStr = `${sign}${Math.abs(p.amount).toFixed(2)} ${p.currency}`;
-    const prefix = `    ${p.account}`;
-    // Align first digit at column 70 (1-indexed); sign hangs left at 69
-    const targetCol = 69 - sign.length;
-    const pad = Math.max(2, targetCol - prefix.length);
-    lines.push(`${prefix}${" ".repeat(pad)}${amountStr}`);
-  }
-
-  return lines.join("\n");
-}
-
-/** Every checkpoint carries the same canonical payee, so assertions are easy
- *  to spot (and query) in the journal. */
-const BALANCE_ASSERTION_PAYEE = "Balance Assertion";
-
-function formatBalanceAssertion(params: AddBalanceAssertionParams): string {
-  const header = `${params.date} * ${BALANCE_ASSERTION_PAYEE}`;
-  // A zero-amount posting moves no money and balances on its own; hledger's
-  // `= balance` after the amount is the assertion being checked.
-  const amountStr = `0.00 ${params.balance.currency}`;
-  const prefix = `    ${params.account}`;
-  const pad = Math.max(2, 69 - prefix.length);
-  const assertion = ` = ${params.balance.amount.toFixed(2)} ${params.balance.currency}`;
-  return `${header}\n${prefix}${" ".repeat(pad)}${amountStr}${assertion}`;
-}
-
-/** hledger requires double quotes around a commodity symbol containing
- *  anything besides letters or currency signs (digits, spaces, punctuation)
- *  — e.g. a ticker like "SOL2". */
-function quoteCommodity(commodity: string): string {
-  return /^[\p{L}\p{Sc}]+$/u.test(commodity) ? commodity : `"${commodity}"`;
-}
-
-/** Plain decimal rendering preserving the given precision — market rates
- *  carry meaning in their decimals (0.0205), so no fixed rounding; tiny
- *  rates must never fall into exponential notation. */
-function formatPriceAmount(amount: number): string {
-  const plain = String(amount);
-  if (!plain.toLowerCase().includes("e")) return plain;
-  return amount.toFixed(20).replace(/0+$/, "").replace(/\.$/, "");
-}
-
-function formatPrice(params: AddPriceParams): string {
-  const amount = `${formatPriceAmount(params.price.amount)} ${quoteCommodity(params.price.currency)}`;
-  return `P ${params.date} ${quoteCommodity(params.commodity)} ${amount}`;
 }

--- a/packages/pi-extension/src/ledger/validate.ts
+++ b/packages/pi-extension/src/ledger/validate.ts
@@ -1,16 +1,28 @@
 import { LEDGER_DIR } from "../config";
 import { HledgerCommandError, hledgerCheck } from "./hledger";
 import { resolveSafePath } from "./paths";
+import { applyTidy, planTidy, printSemantics, restoreTidy, type TidySummary } from "./tidy";
 
 export interface ValidateLedgerResult {
   ledgerIsValid: boolean;
+  tidy: TidySummary;
 }
 
+/**
+ * Validate the ledger, then tidy the journal files.
+ *
+ * The check runs on the files exactly as they are on disk, so a validation
+ * error always points at lines the user can actually see. Only when the ledger
+ * proves valid are the monthly files rewritten (entries sorted by date,
+ * formatting normalized) — and that rewrite must be layout-only: hledger's own
+ * reading of the ledger is snapshotted before and after, and any difference
+ * (or any failure in between) restores every byte and throws.
+ */
 export async function validateLedger(signal?: AbortSignal): Promise<ValidateLedgerResult> {
-  const resolved = resolveSafePath("main.journal", LEDGER_DIR);
+  const mainPath = resolveSafePath("main.journal", LEDGER_DIR);
 
   try {
-    await hledgerCheck(resolved, { signal });
+    await hledgerCheck(mainPath, { signal });
   } catch (e) {
     if (e instanceof HledgerCommandError) {
       throw new Error(e.stderr);
@@ -18,5 +30,29 @@ export async function validateLedger(signal?: AbortSignal): Promise<ValidateLedg
     throw e;
   }
 
-  return { ledgerIsValid: true };
+  const plan = planTidy();
+  const tidy: TidySummary = { files: plan.files, changed: plan.changed, diffs: plan.diffs, skipped: plan.skipped };
+  if (plan.changed === 0) {
+    return { ledgerIsValid: true, tidy };
+  }
+
+  const before = await printSemantics(mainPath, signal);
+  applyTidy(plan);
+
+  let after: string;
+  try {
+    after = await printSemantics(mainPath, signal);
+  } catch (e) {
+    restoreTidy(plan);
+    if (e instanceof HledgerCommandError) {
+      throw new Error(`Tidying reverted — the formatted files did not parse:\n\n${e.stderr}`);
+    }
+    throw e;
+  }
+  if (after !== before) {
+    restoreTidy(plan);
+    throw new Error("Tidying would have changed the ledger's meaning, so formatting was left untouched.");
+  }
+
+  return { ledgerIsValid: true, tidy };
 }

--- a/packages/pi-extension/src/tools/__tests__/validate.test.ts
+++ b/packages/pi-extension/src/tools/__tests__/validate.test.ts
@@ -3,7 +3,7 @@ import { spawnText } from "../../spawn";
 
 vi.mock("../../spawn");
 
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -71,4 +71,31 @@ test("throws on validation failure", async () => {
 test("re-throws unexpected errors", async () => {
   vi.mocked(spawnText).mockRejectedValue(new TypeError("unexpected"));
   await expect(run({})).rejects.toThrow("unexpected");
+});
+
+test("summarizes the journal files it sorted and formatted", async () => {
+  vi.mocked(spawnText).mockImplementation(async (cmd: string[]) =>
+    cmd[1] === "print" ? makeMockProc(0, "[]") : makeMockProc(0),
+  );
+  mkdirSync(join(LEDGER, "2026"), { recursive: true });
+  writeFileSync(join(LEDGER, "2026", "03.journal"), "2026-03-05 * Shop\n  Expenses:Food  45.00 EUR\n  Assets:Cash\n");
+  const result = await run({});
+  expect(result.content[0].text).toContain("The ledger is valid.");
+  expect(result.content[0].text).toContain("Sorted and formatted 1 journal file(s):");
+  expect(result.content[0].text).toContain(join(LEDGER, "2026", "03.journal"));
+  expect(result.details.tidy.changed).toBe(1);
+});
+
+test("lists entries left outside the canonical format", async () => {
+  vi.mocked(spawnText).mockImplementation(async (cmd: string[]) =>
+    cmd[1] === "print" ? makeMockProc(0, "[]") : makeMockProc(0),
+  );
+  mkdirSync(join(LEDGER, "2026"), { recursive: true });
+  writeFileSync(
+    join(LEDGER, "2026", "03.journal"),
+    "2026-03-20 * Rent\n  Expenses:Rent  900.00 EUR\n  Assets:Bank\n\n2026-03-10 * Weird\n    Assets:X    1 BTC @ 55000 EUR\n",
+  );
+  const result = await run({});
+  expect(result.content[0].text).toContain("Entries left as written");
+  expect(result.content[0].text).toContain("cost notation (@) is not supported");
 });

--- a/packages/pi-extension/src/tools/validate.ts
+++ b/packages/pi-extension/src/tools/validate.ts
@@ -8,15 +8,30 @@ const Params = Type.Object({});
 export const validateTool: ToolDefinition<typeof Params, ValidateLedgerResult> = {
   name: "validate",
   label: TOOL_LABELS.validate,
-  description: "Check the ledger for errors",
-  promptSnippet: "Check the ledger for errors",
+  description:
+    "Check the ledger for errors. When it is valid, also tidies the journal files (sorts entries by date, normalizes formatting); the rewrite is proven meaning-preserving via hledger, and fully reverted otherwise.",
+  promptSnippet: "Check the ledger for errors (also sorts and formats the journal files)",
   parameters: Params,
 
   async execute(_id, _params, signal) {
     const result = await validateLedger(signal);
 
+    const lines = ["The ledger is valid."];
+    if (result.tidy.changed > 0) {
+      lines.push(`Sorted and formatted ${result.tidy.changed} journal file(s):`);
+      for (const diff of result.tidy.diffs) {
+        lines.push(`- ${diff.fullFilePath}`);
+      }
+    }
+    if (result.tidy.skipped.length > 0) {
+      lines.push("", "Entries left as written (outside the canonical format):");
+      for (const skip of result.tidy.skipped) {
+        lines.push(`- ${skip.fullFilePath}:${skip.startLine} — ${skip.reason}`);
+      }
+    }
+
     return {
-      content: [{ type: "text", text: "The ledger is valid." }],
+      content: [{ type: "text", text: lines.join("\n") }],
       details: result,
     };
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "isolatedModules": true,
     "noEmit": true
   },
-  "include": ["packages/pi-extension/src/**/*.ts"]
+  "include": ["packages/pi-extension/src/**/*.ts", "packages/hledger-journal/src/**/*.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -66,10 +66,10 @@ export default defineConfig({
       // Kept just under the current effective baseline so the gate is honest
       // (green today) and each new test suite raises it.
       thresholds: {
-        statements: 97.7,
-        branches: 92.1,
-        functions: 97.7,
-        lines: 98.8,
+        statements: 98,
+        branches: 92.9,
+        functions: 97.9,
+        lines: 98.9,
       },
     },
   },


### PR DESCRIPTION
## What

- New internal package `packages/hledger-journal` for journal parsing, formatting, and conservative editing. Files are split into blocks; only blocks the strict parser fully understands are ever rewritten, everything else is preserved byte for byte.
- `add_transactions`, `add_balance_assertions`, and `add_prices` insert entries into the monthly files in date order instead of appending at the end.
- `validate` now also tidies the journal files after a successful check: entries are sorted by date and re-rendered in the canonical layout. The rewrite must be provably layout-only: `hledger print -O json` snapshots before and after have to match (position fields aside), otherwise every byte is restored. Entries outside the canonical subset (cost notation, symbol-first amounts, posting-attached comments) are left as written and listed in the tool output.
- Dates that do not exist on the calendar (e.g. 2026-02-31) are rejected before anything is written.
- Tag parsing mirrors hledger's own rules (comma-separated tags, no-space values, tags in header comments), verified against hledger's output. BOM-prefixed journals are recognized.

## Why

Every tool hand-rolled its own journal text handling: backdated entries landed at the end of monthly files, formatting drifted, and each new feature needed a new parser. The library gives one safe implementation, with hledger itself as the referee that a rewrite never changed the ledger's meaning.

## Notes

- Mid-file inserts show diffs with context lines instead of a pure append tail.
- Validation errors always point at the files as written on disk; tidying only applies when the ledger is valid.
- 2074 tests green, coverage thresholds ratcheted up.