### PR TITLE
feat: seamless conversation compaction with a live status in the chat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17687,15 +17687,6 @@
         "url": "https://github.com/sponsors/Wombosvideo"
       }
     },
-    "node_modules/tw-shimmer": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/tw-shimmer/-/tw-shimmer-0.4.11.tgz",
-      "integrity": "sha512-pTpGJzp3xaCPO87WeHETngmZHJYvygiSTt4jqzh2oR3DWBoeudi/ANB304zks9+Cm2vQ1ai3w9fetviYdqY8HQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "tailwindcss": ">=4.0.0-0"
-      }
-    },
     "node_modules/type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -18687,8 +18678,7 @@
         "shadcn": "^4.13.0",
         "tailwind-merge": "^3.6.0",
         "tar": "^7.5.19",
-        "tw-animate-css": "^1.4.0",
-        "tw-shimmer": "^0.4.11"
+        "tw-animate-css": "^1.4.0"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.1",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -35,8 +35,7 @@
     "shadcn": "^4.13.0",
     "tailwind-merge": "^3.6.0",
     "tar": "^7.5.19",
-    "tw-animate-css": "^1.4.0",
-    "tw-shimmer": "^0.4.11"
+    "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.1",

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/chain-of-thought.test.ts
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/chain-of-thought.test.ts
@@ -187,8 +187,8 @@ describe("chainLabel()", () => {
     expect(chainLabel(false, 383_000, 3)).toBe("Worked for 6m 23s");
   });
 
-  it("should return 'Worked for <1s' when duration is 0", () => {
-    expect(chainLabel(false, 0, 3)).toBe("Worked for <1s");
+  it("should return 'Worked for 1s' when duration is 0", () => {
+    expect(chainLabel(false, 0, 3)).toBe("Worked for 1s");
   });
 
   it("should fall back to 'Worked through 1 step' (singular) when duration is unknown", () => {

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/disclosure.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/disclosure.test.tsx
@@ -12,18 +12,34 @@ describe("ShimmerLabel", () => {
     expect(screen.getAllByText("Query Ledger")).toHaveLength(1);
   });
 
-  it("should render an aria-hidden shimmer duplicate while active", () => {
+  it("should render its children once while active (the sweep clips to the text itself)", () => {
     render(<ShimmerLabel active>Working</ShimmerLabel>);
-    const copies = screen.getAllByText("Working");
-    expect(copies).toHaveLength(2);
-    const shimmer = copies.find((el) => el.getAttribute("aria-hidden") === "true");
-    expect(shimmer).toBeTruthy();
-    expect(shimmer?.className).toContain("shimmer");
+    expect(screen.getAllByText("Working")).toHaveLength(1);
   });
 
-  it("should not expose the shimmer duplicate to assistive technology", () => {
+  it("should apply the shimmer utility while active", () => {
     render(<ShimmerLabel active>Working</ShimmerLabel>);
-    const visible = screen.getAllByText("Working").filter((el) => el.getAttribute("aria-hidden") !== "true");
-    expect(visible).toHaveLength(1);
+    expect(screen.getByText("Working").className).toContain("shimmer");
+  });
+
+  it("should not apply the shimmer utility when inactive", () => {
+    render(<ShimmerLabel>Worked for 2s</ShimmerLabel>);
+    expect(screen.getByText("Worked for 2s").className).not.toContain("shimmer");
+  });
+
+  it("should disable the sweep under reduced motion while active", () => {
+    render(<ShimmerLabel active>Working</ShimmerLabel>);
+    expect(screen.getByText("Working").className).toContain("motion-reduce:shimmer-none");
+  });
+
+  it("should keep caller classes and pass props through to the label element", () => {
+    render(
+      <ShimmerLabel active data-slot="tool-fallback-trigger-label" className="font-medium">
+        Query Ledger
+      </ShimmerLabel>,
+    );
+    const label = screen.getByText("Query Ledger");
+    expect(label.className).toContain("font-medium");
+    expect(label.getAttribute("data-slot")).toBe("tool-fallback-trigger-label");
   });
 });

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/thread.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/thread.test.tsx
@@ -20,15 +20,23 @@ vi.mock("@/rpc/api", () => ({
 }));
 
 // The chain-of-thought timer reads the raw pi transcript (per-turn timestamps)
-// through usePiThreadState. Stub just that hook so specs can supply a
-// transcript; everything else in react-pi stays real.
-const pi = vi.hoisted(() => ({ transcript: [] as { role: string; timestamp?: number }[] }));
+// and the compaction indicator reads the compaction flag, both through
+// usePiThreadState. Stub just that hook so specs can supply the state;
+// everything else in react-pi stays real.
+const pi = vi.hoisted(() => ({
+  transcript: [] as { role: string; timestamp?: number }[],
+  compaction: { active: false },
+  threadId: "/ws/sessions/t1.jsonl",
+}));
 vi.mock("@assistant-ui/react-pi", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@assistant-ui/react-pi")>()),
-  usePiThreadState: (selector: (st: { messages: unknown[] }) => unknown) => selector({ messages: pi.transcript }),
+  usePiThreadState: (
+    selector: (st: { messages: unknown[]; compaction: { active: boolean }; threadId: string }) => unknown,
+  ) => selector({ messages: pi.transcript, compaction: pi.compaction, threadId: pi.threadId }),
 }));
 
 import { AssistantRuntimeProvider, type ExternalStoreAdapter, useExternalStoreRuntime } from "@assistant-ui/react";
+import { addPendingCompactionMarker, resetPendingCompactionMarkers } from "@/runtime/pendingCompaction";
 import { Thread, type ThreadComponents } from "../thread";
 
 beforeAll(() => {
@@ -39,6 +47,8 @@ beforeAll(() => {
 afterEach(() => {
   cleanup();
   pi.transcript = [];
+  pi.compaction = { active: false };
+  resetPendingCompactionMarkers();
 });
 
 type Msg = {
@@ -202,6 +212,147 @@ describe("Thread working indicator", () => {
     );
     const status = await screen.findByRole("status", { name: "Assistant is working" });
     expect(status).toBeInTheDocument();
+  });
+});
+
+describe("Thread compaction marker", () => {
+  /** A running assistant turn mid-chain (reasoning + tool, nothing answered yet). */
+  const runningChainMsg = (): Msg => ({
+    id: "a1",
+    role: "assistant",
+    status: { type: "running" },
+    content: [
+      { type: "reasoning", text: "Deciding which report to run" },
+      { type: "tool-call", toolCallId: "t1", toolName: "query", args: {}, result: "ok" },
+    ],
+  });
+
+  /** The transcript message pi persists for a finished compaction. */
+  const markerMsg = (): Msg => ({
+    id: "m1",
+    role: "assistant",
+    content: [
+      {
+        type: "data",
+        name: "pi-compaction-summary",
+        data: { summary: "Earlier: reviewed Q1 spending.", tokensBefore: 31000 },
+      },
+    ],
+  });
+
+  describe("while compacting", () => {
+    it("should show the status divider inside the last message when a compaction runs mid-run", async () => {
+      pi.compaction = { active: true };
+      render(
+        <Chrome isRunning messages={[runningChainMsg()]}>
+          <Thread />
+        </Chrome>,
+      );
+      const label = await screen.findByText("Compacting conversation");
+      const divider = label.closest('[data-slot="aui_compaction-indicator"]') as HTMLElement;
+      expect(divider.getAttribute("role")).toBe("status");
+      // In the last message's content flow: the turn anchor stretches the last
+      // message root, so a stream-level sibling would land below the stretch.
+      expect(divider.closest("[data-role=assistant]")).not.toBeNull();
+    });
+
+    it("should show the status divider when the running last message has no timeline yet", async () => {
+      pi.compaction = { active: true };
+      render(
+        <Chrome isRunning messages={[{ id: "a1", role: "assistant", status: { type: "running" }, content: [] }]}>
+          <Thread />
+        </Chrome>,
+      );
+      expect(await screen.findByText("Compacting conversation")).toBeInTheDocument();
+    });
+
+    it("should show the status divider under a finished last message (post-turn threshold compaction)", async () => {
+      pi.compaction = { active: true };
+      render(
+        <Chrome messages={[chainMsg()]}>
+          <Thread />
+        </Chrome>,
+      );
+      expect(await screen.findByText("Worked through 2 steps")).toBeInTheDocument();
+      expect(screen.getByText("Compacting conversation")).toBeInTheDocument();
+    });
+
+    it("should switch to the settled label in place while the marker is still parked", async () => {
+      // Compaction finished (flag off) but the transcript marker is deferred
+      // until the next prompt — the divider must settle in place, not vanish.
+      addPendingCompactionMarker(pi.threadId, { summary: "s", timestamp: 1000 });
+      render(
+        <Chrome messages={[chainMsg()]}>
+          <Thread />
+        </Chrome>,
+      );
+      expect(await screen.findByText("Conversation compacted")).toBeInTheDocument();
+      expect(screen.queryByText("Compacting conversation")).toBeNull();
+    });
+
+    it("should show nothing once the parked marker was consumed", async () => {
+      render(
+        <Chrome messages={[chainMsg()]}>
+          <Thread />
+        </Chrome>,
+      );
+      expect(await screen.findByText("Worked through 2 steps")).toBeInTheDocument();
+      expect(screen.queryByText("Conversation compacted")).toBeNull();
+    });
+
+    it("should not show the status divider when no compaction is running", async () => {
+      render(
+        <Chrome isRunning messages={[runningChainMsg()]}>
+          <Thread />
+        </Chrome>,
+      );
+      expect(await screen.findByText("Working")).toBeInTheDocument();
+      expect(screen.queryByText("Compacting conversation")).toBeNull();
+    });
+
+    it("should not show the status divider on a message that is not the last one", async () => {
+      pi.compaction = { active: true };
+      render(
+        <Chrome messages={[chainMsg(), userMsg("next question")]}>
+          <Thread />
+        </Chrome>,
+      );
+      expect(await screen.findByText("next question")).toBeInTheDocument();
+      expect(screen.queryByText("Compacting conversation")).toBeNull();
+    });
+  });
+
+  describe("once compacted", () => {
+    it("should render the marker from the transcript message, with no summary details", async () => {
+      render(
+        <Chrome messages={[markerMsg()]}>
+          <Thread />
+        </Chrome>,
+      );
+      expect(await screen.findByText("Conversation compacted")).toBeInTheDocument();
+      expect(screen.queryByText("Earlier: reviewed Q1 spending.")).toBeNull();
+    });
+
+    it("should keep the marker between the work before and after it", async () => {
+      render(
+        <Chrome messages={[chainMsg(), markerMsg(), userMsg("next question")]}>
+          <Thread />
+        </Chrome>,
+      );
+      const marker = await screen.findByText("Conversation compacted");
+      const order = [...document.querySelectorAll("[data-role], [data-slot=aui_compaction-summary]")];
+      expect(order.indexOf(marker.closest("[data-slot=aui_compaction-summary]") as Element)).toBeGreaterThan(0);
+      expect(screen.getByText("next question")).toBeInTheDocument();
+    });
+
+    it("should not shimmer once settled", async () => {
+      render(
+        <Chrome messages={[markerMsg()]}>
+          <Thread />
+        </Chrome>,
+      );
+      expect((await screen.findByText("Conversation compacted")).className).not.toContain("shimmer");
+    });
   });
 });
 

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/tool-fallback.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/tool-fallback.test.tsx
@@ -157,7 +157,7 @@ describe("ToolFallback", () => {
     const status: ToolCallMessagePartStatus = { type: "incomplete", reason: "cancelled" };
     render(<ToolFallback {...partProps({ status, result: "partial" })} />);
     const label = screen.getByText("Query Ledger");
-    expect(label.parentElement?.className).toContain("line-through");
+    expect(label.className).toContain("line-through");
     fireEvent.click(label);
     expect(screen.queryByText("Output:")).toBeNull();
     expect(screen.queryByText("partial")).toBeNull();

--- a/packages/desktop/src/renderer/components/accountant24/chain-of-thought.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/chain-of-thought.tsx
@@ -10,6 +10,7 @@ import {
   DisclosureTrigger,
   ShimmerLabel,
 } from "@/components/accountant24/disclosure";
+import { Spinner } from "@/components/shadcn/spinner";
 import { formatDuration } from "@/lib/duration";
 import { cn } from "@/lib/utils";
 
@@ -167,12 +168,14 @@ export function ChainOfThoughtRoot({
       data-slot="aui_chain-of-thought"
       open={userOpen ?? active}
       onOpenChange={setUserOpen}
-      // my-3 mirrors the markdown paragraph rhythm (p is my-3), so the chain
-      // sits with the same gap whether it precedes or follows answer text;
-      // first:mt-0 keeps a chain at the top of a message flush, like p.
-      className="my-3 first:mt-0"
+      // chat-rhythm mirrors the markdown block rhythm, so the chain sits with
+      // the same gap whether it precedes or follows answer text; first:mt-0 /
+      // last:mb-0 keep a chain flush at a message's edges, like p.
+      className="my-chat-rhythm first:mt-0 last:mb-0"
     >
       <DisclosureTrigger data-slot="aui_cot-trigger" className="w-full">
+        {/* Same live-status affordance as the compaction divider. */}
+        {active && <Spinner className="shrink-0" />}
         <ShimmerLabel active={active} className="font-medium">
           {label}
         </ShimmerLabel>
@@ -200,9 +203,9 @@ export const ChainOfThoughtStep: FC<PropsWithChildren<{ variant: "reasoning" | "
   // Rendered outside a chain (standalone tool call): no rail/dot, just the content.
   if (!useContext(InChainContext)) return <>{children}</>;
   return (
-    // pb-3 spaces steps 12px apart (the chat's spacing rhythm); last:pb-0 so
-    // the rail ends flush with the final step instead of trailing past it.
-    <li className="relative min-w-0 pb-3 pl-4 last:pb-0">
+    // chat-rhythm spaces the steps apart; last:pb-0 so the rail ends flush
+    // with the final step instead of trailing past it.
+    <li className="relative min-w-0 pb-chat-rhythm pl-4 last:pb-0">
       <span
         aria-hidden
         className={cn(

--- a/packages/desktop/src/renderer/components/accountant24/compaction-indicator.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/compaction-indicator.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useAuiState } from "@assistant-ui/react";
+import { usePiThreadState } from "@assistant-ui/react-pi";
+import type { FC } from "react";
+import { Marker, MarkerContent, MarkerIcon } from "@/components/shadcn/marker";
+import { Spinner } from "@/components/shadcn/spinner";
+import { cn } from "@/lib/utils";
+import { usePendingCompactionMarkers } from "@/runtime/pendingCompaction";
+
+// Compaction renders as ONE separator divider in the message stream, in both
+// of its states: spinner + shimmering "Compacting conversation" while pi
+// compacts, settling into a plain "Conversation compacted" labeled line that
+// stays in the history (pi persists the record, so reloads show it too).
+//
+// SPACING CONTRACT (see the CHAT SPACING block in index.css): this is a
+// stream-level element. The thread's MessageGroup gap-chat-gap owns ALL
+// spacing between stream elements — the divider must not add vertical margins
+// of its own, in either state, so the active → settled swap happens in place
+// without moving a pixel.
+
+export const COMPACTION_LABEL = "Compacting conversation";
+export const COMPACTED_LABEL = "Conversation compacted";
+
+/** True while pi is compacting the conversation (overflow recovery, or the
+ *  threshold pass before/after a turn). */
+export const useCompactionActive = (): boolean => usePiThreadState((s) => s.compaction.active);
+
+/** The compaction divider in either lifecycle state. */
+export const CompactionDivider: FC<{ active?: boolean; className?: string }> = ({ active = false, className }) => (
+  <Marker
+    variant="separator"
+    data-slot={active ? "aui_compaction-indicator" : "aui_compaction-summary"}
+    {...(active ? { role: "status" } : {})}
+    className={className}
+  >
+    {active && (
+      <MarkerIcon>
+        <Spinner />
+      </MarkerIcon>
+    )}
+    {/* shimmer-color-foreground: the default highlight is a 20%-alpha
+        lightening of the label's own muted color, too faint to read here. */}
+    <MarkerContent className={cn(active && "shimmer shimmer-color-foreground motion-reduce:shimmer-none")}>
+      {active ? COMPACTION_LABEL : COMPACTED_LABEL}
+    </MarkerContent>
+  </Marker>
+);
+
+/** The live divider, mounted INSIDE the last message's content flow (not as a
+ *  stream sibling): assistant-ui's turnAnchor stretches the last message to
+ *  viewport height while a run is pinned, so a stream-level row would land far
+ *  below the text. In-flow, `mt-chat-gap` gives it the same stream-gap
+ *  distance from the text as the transcript marker gets from the MessageGroup
+ *  gap.
+ *
+ *  It covers BOTH lifecycle states: the active sweep while pi compacts, then
+ *  the settled label in place while the transcript marker is still parked
+ *  (see runtime/pendingCompaction.ts — injecting it immediately would break
+ *  the turn anchor and make the thread jump). Once the next user prompt
+ *  delivers the real marker, `isLast` moves on and this component yields to
+ *  CompactionSummary. */
+export const CompactionIndicator: FC = () => {
+  const compacting = useCompactionActive();
+  const threadId = usePiThreadState((s) => s.threadId);
+  const parked = usePendingCompactionMarkers(threadId).length > 0;
+  const isLast = useAuiState((s) => s.message.isLast);
+  if (!isLast || (!compacting && !parked)) return null;
+  return <CompactionDivider active={compacting} className="mt-chat-gap" />;
+};
+
+/** The settled divider, rendered from the transcript's compactionSummary
+ *  message (inside a message root, which already pads with px-2). */
+export const CompactionSummary: FC = () => <CompactionDivider />;

--- a/packages/desktop/src/renderer/components/accountant24/disclosure.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/disclosure.tsx
@@ -91,7 +91,9 @@ export function DisclosureContent({ className, ...props }: React.ComponentProps<
   );
 }
 
-/** Trigger label that shows an animated shimmer overlay while `active`. */
+/** Trigger label that sweeps an animated shimmer across its text while `active`.
+ *  Uses shadcn's `shimmer` utility, which clips the gradient to the text itself
+ *  (`shimmer-none` under reduced motion restores the plain text fill). */
 export function ShimmerLabel({
   active = false,
   className,
@@ -99,13 +101,11 @@ export function ShimmerLabel({
   ...props
 }: React.ComponentProps<"span"> & { active?: boolean }) {
   return (
-    <span className={cn("relative inline-block leading-none", className)} {...props}>
-      <span>{children}</span>
-      {active && (
-        <span aria-hidden className="shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none">
-          {children}
-        </span>
-      )}
+    <span
+      className={cn("inline-block leading-none", active && "shimmer motion-reduce:shimmer-none", className)}
+      {...props}
+    >
+      {children}
     </span>
   );
 }

--- a/packages/desktop/src/renderer/components/accountant24/markdown-text.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/markdown-text.tsx
@@ -40,7 +40,7 @@ const CodeHeader: FC<CodeHeaderProps> = ({ language, code }) => {
   };
 
   return (
-    <div className="aui-code-header-root bg-input/50 mt-3 flex items-center justify-between rounded-t-xl px-3.5 py-1.5 text-xs">
+    <div className="aui-code-header-root bg-input/50 mt-chat-rhythm flex items-center justify-between rounded-t-xl px-3.5 py-1.5 text-xs">
       <span className="aui-code-header-language text-muted-foreground font-medium lowercase">{language}</span>
       <TooltipIconButton tooltip="Copy" onClick={onCopy}>
         {!isCopied && <CopyIcon className="animate-in zoom-in-75 fade-in duration-150" />}
@@ -82,7 +82,7 @@ const defaultComponents = memoizeMarkdownComponents({
     <h6 className={cn("aui-md-h6 mt-3 mb-1 text-sm font-medium first:mt-0 last:mb-0", className)} {...props} />
   ),
   p: ({ className, ...props }) => (
-    <p className={cn("aui-md-p my-3 leading-relaxed first:mt-0 last:mb-0", className)} {...props} />
+    <p className={cn("aui-md-p my-chat-rhythm leading-relaxed first:mt-0 last:mb-0", className)} {...props} />
   ),
   a: ({ className, ...props }) => (
     <a
@@ -93,7 +93,7 @@ const defaultComponents = memoizeMarkdownComponents({
   blockquote: ({ className, ...props }) => (
     <blockquote
       className={cn(
-        "aui-md-blockquote border-muted-foreground/30 text-muted-foreground my-3 border-s-2 ps-4",
+        "aui-md-blockquote border-muted-foreground/30 text-muted-foreground my-chat-rhythm border-s-2 ps-4",
         className,
       )}
       {...props}
@@ -101,18 +101,18 @@ const defaultComponents = memoizeMarkdownComponents({
   ),
   ul: ({ className, ...props }) => (
     <ul
-      className={cn("aui-md-ul marker:text-muted-foreground my-3 ms-5 list-disc [&>li]:mt-1", className)}
+      className={cn("aui-md-ul marker:text-muted-foreground my-chat-rhythm ms-5 list-disc [&>li]:mt-1", className)}
       {...props}
     />
   ),
   ol: ({ className, ...props }) => (
     <ol
-      className={cn("aui-md-ol marker:text-muted-foreground my-3 ms-5 list-decimal [&>li]:mt-1", className)}
+      className={cn("aui-md-ol marker:text-muted-foreground my-chat-rhythm ms-5 list-decimal [&>li]:mt-1", className)}
       {...props}
     />
   ),
   hr: ({ className, ...props }) => (
-    <hr className={cn("aui-md-hr border-muted-foreground/20 my-3", className)} {...props} />
+    <hr className={cn("aui-md-hr border-muted-foreground/20 my-chat-rhythm", className)} {...props} />
   ),
   table: MarkdownTable,
   th: ({ className, ...props }) => (

--- a/packages/desktop/src/renderer/components/accountant24/message-error.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/message-error.tsx
@@ -9,7 +9,7 @@ export const MessageError: FC = () => {
   return (
     <MessagePrimitive.Error>
       <ErrorPrimitive.Root asChild>
-        <Bubble variant="destructive" className="mt-3">
+        <Bubble variant="destructive" className="mt-chat-rhythm">
           <BubbleContent className="flex items-center gap-2">
             <AlertCircleIcon className="size-4 shrink-0" />
             <ErrorPrimitive.Message className="line-clamp-2" />

--- a/packages/desktop/src/renderer/components/accountant24/thread.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/thread.tsx
@@ -17,6 +17,7 @@ import {
   ChainOfThoughtStep,
   splitReasoningSections,
 } from "@/components/accountant24/chain-of-thought";
+import { CompactionIndicator, CompactionSummary } from "@/components/accountant24/compaction-indicator";
 import { Composer, EditComposer, isNewChatView } from "@/components/accountant24/composer";
 import { MarkdownText } from "@/components/accountant24/markdown-text";
 import { MessageError } from "@/components/accountant24/message-error";
@@ -76,12 +77,13 @@ const ThreadRoot: FC<{ isEmpty: boolean }> = ({ isEmpty }) => {
       <ThreadPrimitive.Viewport
         turnAnchor="top"
         data-slot="aui_thread-viewport"
-        // scroll-fade-t-6: fade older messages at the top edge (24px). The
-        // sticky composer lives inside this container, so no bottom fade. The
-        // size is paired with pt-6 on the user-message root: turnAnchor="top"
-        // pins that element's box to the edge, so its padding keeps the just
-        // sent bubble below the fade zone.
-        className="scroll-fade-t scroll-fade-t-6 relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth"
+        // Fade older messages at the top edge. The sticky composer lives
+        // inside this container, so no bottom fade. The fade height and the
+        // user-message root's pt-chat-turn share the chat-turn token (see the
+        // CHAT SPACING block in index.css): turnAnchor="top" pins that
+        // element's box to the edge, and its padding keeps the just sent
+        // bubble below the fade zone.
+        className="scroll-fade-t scroll-fade-t-(length:--spacing-chat-turn) relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth"
       >
         <div
           className={cn(
@@ -93,7 +95,13 @@ const ThreadRoot: FC<{ isEmpty: boolean }> = ({ isEmpty }) => {
             <Welcome />
           </AuiIf>
 
-          <MessageGroup className="mb-14 gap-6 empty:hidden">
+          {/* SPACING CONTRACT (see the CHAT SPACING block in index.css):
+              gap-chat-gap owns ALL vertical spacing between stream elements
+              (messages, markers, status rows). Stream-level children must not
+              add vertical margins of their own; the user message's
+              pt-chat-turn (scroll-fade anchor) is the one deliberate
+              exception. */}
+          <MessageGroup className="mb-14 gap-chat-gap empty:hidden">
             <ThreadPrimitive.Messages>{() => <ThreadMessage />}</ThreadPrimitive.Messages>
           </MessageGroup>
 
@@ -204,6 +212,7 @@ const AssistantMessage: FC = () => {
                   </ChainOfThoughtStep>
                 );
               case "data":
+                if (part.name === "pi-compaction-summary") return <CompactionSummary />;
                 return part.dataRendererUI;
               case "indicator":
                 return (
@@ -225,6 +234,9 @@ const AssistantMessage: FC = () => {
             }
           }}
         </MessagePrimitive.GroupedParts>
+        {/* In the content flow, not the stream: the turn anchor stretches the
+            last message, so a stream sibling would land below the stretch. */}
+        <CompactionIndicator />
         <MessageError />
       </div>
     </MessagePrimitive.Root>
@@ -235,10 +247,11 @@ const UserMessage: FC = () => {
   return (
     <MessagePrimitive.Root
       data-slot="aui_user-message-root"
-      // pt-6 matches the viewport's scroll-fade-t-6: the top anchor pins this
-      // element's box to the viewport edge, so the padding keeps the bubble
-      // out of the fade zone right after sending.
-      className="fade-in slide-in-from-bottom-1 animate-in px-2 pt-6 duration-150 [contain-intrinsic-size:auto_60px] [content-visibility:auto]"
+      // pt-chat-turn matches the viewport's fade-zone height (same token, see
+      // CHAT SPACING in index.css): the top anchor pins this element's box to
+      // the viewport edge, so the padding keeps the bubble out of the fade
+      // zone right after sending.
+      className="fade-in slide-in-from-bottom-1 animate-in px-2 pt-chat-turn duration-150 [contain-intrinsic-size:auto_60px] [content-visibility:auto]"
       data-role="user"
     >
       <Message align="end">

--- a/packages/desktop/src/renderer/components/shadcn/marker.tsx
+++ b/packages/desktop/src/renderer/components/shadcn/marker.tsx
@@ -1,0 +1,68 @@
+import { mergeProps } from "@base-ui/react/merge-props";
+import { useRender } from "@base-ui/react/use-render";
+import { cva, type VariantProps } from "class-variance-authority";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const markerVariants = cva(
+  "group/marker relative flex min-h-4 w-full items-center gap-2 text-left text-sm text-muted-foreground [&_svg:not([class*='size-'])]:size-4 [a]:underline [a]:underline-offset-3 [a]:hover:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: "",
+        separator:
+          "before:mr-1 before:h-px before:min-w-0 before:flex-1 before:bg-border after:ml-1 after:h-px after:min-w-0 after:flex-1 after:bg-border",
+        border: "border-b border-border pb-2",
+      },
+    },
+  },
+);
+
+function Marker({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"div"> & VariantProps<typeof markerVariants>) {
+  return useRender({
+    defaultTagName: "div",
+    props: mergeProps<"div">(
+      {
+        className: cn(markerVariants({ variant, className })),
+      },
+      props,
+    ),
+    render,
+    state: {
+      slot: "marker",
+      variant,
+    },
+  });
+}
+
+function MarkerIcon({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="marker-icon"
+      aria-hidden="true"
+      className={cn("size-4 shrink-0 [&_svg:not([class*='size-'])]:size-4", className)}
+      {...props}
+    />
+  );
+}
+
+function MarkerContent({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="marker-content"
+      className={cn(
+        "min-w-0 wrap-break-word group-data-[variant=separator]/marker:flex-none group-data-[variant=separator]/marker:text-center *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Marker, MarkerContent, MarkerIcon, markerVariants };

--- a/packages/desktop/src/renderer/index.css
+++ b/packages/desktop/src/renderer/index.css
@@ -1,5 +1,4 @@
 @import "tailwindcss";
-@import "tw-shimmer";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/inter";
@@ -131,6 +130,30 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+}
+
+/* ==========================================================================
+   CHAT SPACING — the single source of truth for every vertical gap in the
+   conversation. Retune the chat by editing these three values; components
+   must reference the tokens (gap-chat-gap, pt-chat-turn, my-chat-rhythm,
+   mt-chat-rhythm, pb-chat-rhythm, ...) and never hardcode chat spacing.
+
+   - chat-gap    Space between stream elements (user/assistant messages,
+                 compaction markers, status rows). Owned exclusively by the
+                 thread's MessageGroup gap — stream elements must not add
+                 vertical margins of their own.
+   - chat-turn   EXTRA space above each user message. Exists so a just-sent
+                 turn, pinned to the viewport top by turnAnchor, clears the
+                 top scroll-fade zone (whose height uses this same token),
+                 and doubles as the visual turn break: chat-gap + chat-turn
+                 before every user turn.
+   - chat-rhythm Vertical rhythm INSIDE one message: markdown flow blocks,
+                 the chain-of-thought box and its rail steps, error bubbles.
+   ========================================================================== */
+@theme {
+  --spacing-chat-gap: 1.5rem;
+  --spacing-chat-turn: 1.5rem;
+  --spacing-chat-rhythm: 0.75rem;
 }
 
 @layer base {

--- a/packages/desktop/src/renderer/lib/__tests__/duration.test.ts
+++ b/packages/desktop/src/renderer/lib/__tests__/duration.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from "vitest";
 import { formatDuration } from "../duration";
 
 describe("formatDuration()", () => {
-  it("should return '<1s' when ms is 0", () => {
-    expect(formatDuration(0)).toBe("<1s");
+  it("should return '1s' when ms is 0 (sub-second rounds up, never '0s' or '<1s')", () => {
+    expect(formatDuration(0)).toBe("1s");
   });
 
-  it("should return '<1s' when ms is 999", () => {
-    expect(formatDuration(999)).toBe("<1s");
+  it("should return '1s' when ms is 999", () => {
+    expect(formatDuration(999)).toBe("1s");
   });
 
   it("should return '1s' when ms is 1000", () => {

--- a/packages/desktop/src/renderer/lib/duration.ts
+++ b/packages/desktop/src/renderer/lib/duration.ts
@@ -1,7 +1,8 @@
-/** Format a millisecond duration for compact UI display: "<1s", "6s", "45s", "6m 23s". */
+/** Format a millisecond duration for compact UI display: "1s", "6s", "45s",
+ *  "6m 23s". Sub-second durations round up to "1s" — a plain floor would show
+ *  a puzzling "0s". */
 export const formatDuration = (ms: number) => {
-  if (ms < 1000) return "<1s";
-  const seconds = Math.floor(ms / 1000);
+  const seconds = Math.max(1, Math.floor(ms / 1000));
   if (seconds < 60) return `${seconds}s`;
   return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
 };

--- a/packages/desktop/src/renderer/rpc/types.ts
+++ b/packages/desktop/src/renderer/rpc/types.ts
@@ -121,6 +121,15 @@ export type AuthEvent =
 export interface AgentMessage {
   role: string;
   content?: unknown;
+  /** Set on assistant messages: how the turn ended ("stop" | "error" | "aborted" | "length" | ...). */
+  stopReason?: string;
+  /** Provider error text when stopReason is "error". */
+  errorMessage?: string;
+  /** Set on compactionSummary messages: the text pi kept in place of the old history. */
+  summary?: string;
+  /** Set on compactionSummary messages: context size before the compaction. */
+  tokensBefore?: number;
+  timestamp?: number;
 }
 
 export interface ToolResult {
@@ -134,9 +143,22 @@ export interface AssistantDelta {
 
 export type AgentEvent =
   | { type: "agent_start" }
-  | { type: "agent_end" }
+  | { type: "agent_end"; willRetry?: boolean }
+  | { type: "agent_settled" }
   | { type: "turn_start" }
   | { type: "turn_end" }
+  | { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
+  | {
+      type: "compaction_end";
+      reason: "manual" | "threshold" | "overflow";
+      result?: { summary?: string; tokensBefore?: number };
+      aborted?: boolean;
+      willRetry?: boolean;
+      errorMessage?: string;
+    }
+  | { type: "auto_retry_start"; attempt: number; delayMs: number; errorMessage?: string }
+  | { type: "auto_retry_end"; success: boolean }
+  | { type: "queue_update"; steering: string[]; followUp: string[] }
   | { type: "message_start"; message: AgentMessage }
   | { type: "message_update"; message: AgentMessage; assistantMessageEvent: AssistantDelta }
   | { type: "message_end"; message: AgentMessage }

--- a/packages/desktop/src/renderer/runtime/__tests__/agentBridge.test.ts
+++ b/packages/desktop/src/renderer/runtime/__tests__/agentBridge.test.ts
@@ -420,6 +420,70 @@ describe("agentBridge", () => {
     });
   });
 
+  describe("overflow recovery interception", () => {
+    const overflowEnd = {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [],
+        stopReason: "error",
+        errorMessage: "prompt is too long: 213462 tokens > 200000 maximum",
+      },
+      sessionPath: A,
+    };
+
+    it("should hide the overflow error from subscribers when auto-compaction recovers", async () => {
+      const bridge = await loadBridge();
+      const seen: { type: string }[] = [];
+      bridge.addEventListener((e) => seen.push(e as { type: string }));
+      await flush();
+
+      emit(overflowEnd);
+      emit({ type: "agent_end", willRetry: false, sessionPath: A });
+      emit({ type: "compaction_start", reason: "overflow", sessionPath: A });
+      emit({ type: "compaction_end", reason: "overflow", aborted: false, willRetry: true, sessionPath: A });
+      emit({ type: "agent_start", sessionPath: A }); // the retry run
+      expect(seen.map((e) => e.type)).toEqual(["compaction_start", "compaction_end", "agent_start"]);
+    });
+
+    it("should replay the held overflow error to subscribers when the hold times out", async () => {
+      vi.useFakeTimers();
+      const bridge = await loadBridge();
+      const seen: { type: string }[] = [];
+      bridge.addEventListener((e) => seen.push(e as { type: string }));
+      await vi.advanceTimersByTimeAsync(0);
+
+      emit(overflowEnd);
+      emit({ type: "agent_end", willRetry: false, sessionPath: A });
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(seen.map((e) => e.type)).toEqual(["message_start", "message_end", "agent_end"]);
+    });
+
+    it("should replay held events to subscribers before error listeners when the child crashes", async () => {
+      const bridge = await loadBridge();
+      const log: string[] = [];
+      bridge.addEventListener((e) => log.push(`event:${(e as { type: string }).type}`));
+      bridge.addErrorListener(() => log.push("error"));
+      await flush();
+
+      emit(overflowEnd);
+      emitTerminated({ sessionPath: A, code: 1, signal: null, stderr: "" });
+      expect(log).toEqual(["event:message_start", "event:message_end", "error"]);
+    });
+
+    it("should expose the session's compaction state via compactionState()", async () => {
+      const bridge = await loadBridge();
+      bridge.addEventListener(() => {});
+      await flush();
+
+      expect(bridge.compactionState(A)).toBeUndefined();
+      emit({ type: "compaction_start", reason: "overflow", sessionPath: A });
+      expect(bridge.compactionState(A)).toEqual({ active: true, reason: "overflow", everCompacted: true });
+      emit({ type: "compaction_end", reason: "overflow", aborted: false, willRetry: true, sessionPath: A });
+      expect(bridge.compactionState(A)).toMatchObject({ active: false, everCompacted: true });
+    });
+  });
+
   describe("process errors (addErrorListener)", () => {
     it("should report a restart hint and stderr tail when a child is signal-terminated", async () => {
       const bridge = await loadBridge();

--- a/packages/desktop/src/renderer/runtime/__tests__/electronPiClient.test.ts
+++ b/packages/desktop/src/renderer/runtime/__tests__/electronPiClient.test.ts
@@ -3,6 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { encodeAttachmentRef } from "../../lib/attachmentMarker";
 import { createElectronPiClient } from "../electronPiClient";
 import { newChatModel } from "../newChatModel";
+import {
+  addPendingCompactionMarker,
+  getPendingCompactionMarkers,
+  resetPendingCompactionMarkers,
+} from "../pendingCompaction";
 
 // electronPiClient bridges the per-session pi RPC streams to the runtime
 // (routing every command and event by threadId = sessionPath) and reports the
@@ -35,6 +40,8 @@ const h = vi.hoisted(() => ({
   deleted: [] as string[],
   /** request types that should reject, to exercise error/edge paths. */
   errorTypes: new Set<string>(),
+  /** compactionState response — per-test override for the heal-on-subscribe. */
+  compaction: undefined as { active: boolean; reason?: string; everCompacted: boolean } | undefined,
   /** skills_list response — feeds the skill_used native/custom lookup. */
   skills: [] as { name: string; description: string; enabled: boolean; native?: boolean }[],
   track: vi.fn(),
@@ -67,6 +74,7 @@ vi.mock("../agentBridge", () => ({
       if (command.type === "get_messages") return { messages: h.messages };
       return {};
     },
+    compactionState: () => h.compaction,
   },
 }));
 vi.mock("../../rpc/api", () => ({
@@ -136,6 +144,8 @@ beforeEach(() => {
   h.settingsThrows = false;
   h.deleted.length = 0;
   h.errorTypes = new Set();
+  h.compaction = undefined;
+  resetPendingCompactionMarkers();
   h.state = { model: { provider: "anthropic", id: "claude-x" }, sessionFile: "/ws/sessions/s1.jsonl" };
   h.skills = [{ name: "subscription-audit", description: "Audit.", enabled: true, native: true }];
   newChatModel.set(undefined);
@@ -539,10 +549,57 @@ describe("createElectronPiClient() event mapping", () => {
     expect(events[0]).toMatchObject({ type: "tool_execution_end", isError: true });
   });
 
-  it("should pass an unrecognized event type through as a bare typed body", () => {
+  it("should forward willRetry on agent_end so the reducer keeps the run alive across recoveries", () => {
     const { events } = captureLive(createElectronPiClient());
-    emitL({ type: "queue_update", queue: [] });
-    expect(events[0]).toMatchObject({ type: "queue_update", threadId: LIVE, seq: 1 });
+    emitL({ type: "agent_end", willRetry: true });
+    expect(events[0]).toMatchObject({ type: "agent_end", willRetry: true });
+  });
+
+  it("should forward the reason on compaction_start", () => {
+    const { events } = captureLive(createElectronPiClient());
+    emitL({ type: "compaction_start", reason: "overflow" });
+    expect(events[0]).toMatchObject({ type: "compaction_start", reason: "overflow" });
+  });
+
+  it("should forward aborted, willRetry, errorMessage and result on compaction_end", () => {
+    const { events } = captureLive(createElectronPiClient());
+    const result = { summary: "kept", tokensBefore: 31000 };
+    emitL({ type: "compaction_end", reason: "overflow", aborted: false, willRetry: true, errorMessage: "e", result });
+    expect(events[0]).toMatchObject({
+      type: "compaction_end",
+      aborted: false,
+      willRetry: true,
+      errorMessage: "e",
+      result,
+    });
+  });
+
+  it("should forward auto retry payloads (attempt, delayMs, success)", () => {
+    const { events } = captureLive(createElectronPiClient());
+    emitL({ type: "auto_retry_start", attempt: 2, delayMs: 500 });
+    emitL({ type: "auto_retry_end", success: true });
+    expect(events[0]).toMatchObject({ type: "auto_retry_start", attempt: 2, delayMs: 500 });
+    expect(events[1]).toMatchObject({ type: "auto_retry_end", success: true });
+  });
+
+  it("should forward queue_update with its steering and follow-up arrays", () => {
+    const { events } = captureLive(createElectronPiClient());
+    emitL({ type: "queue_update", steering: ["s1"], followUp: ["f1"] });
+    expect(events[0]).toMatchObject({ type: "queue_update", steering: ["s1"], followUp: ["f1"] });
+  });
+
+  it("should keep stopReason and errorMessage on a message_end assistant message", () => {
+    const { events } = captureLive(createElectronPiClient());
+    const msg = { role: "assistant", content: [], stopReason: "error", errorMessage: "boom" };
+    emitL({ type: "message_end", message: msg });
+    expect(body(events[0]).message).toEqual(msg);
+  });
+
+  it("should pass an unrecognized event type through with its payload but without the sessionPath tag", () => {
+    const { events } = captureLive(createElectronPiClient());
+    emitL({ type: "session_info_changed", name: "My chat" });
+    expect(events[0]).toMatchObject({ type: "session_info_changed", name: "My chat", threadId: LIVE, seq: 1 });
+    expect(body(events[0]).sessionPath).toBeUndefined();
   });
 
   it("should stamp a strictly increasing seq per emitted event", () => {
@@ -565,6 +622,68 @@ describe("createElectronPiClient() event mapping", () => {
     emitL({ type: "agent_start" });
     emitError(LIVE, "boom");
     expect(events).toHaveLength(0);
+  });
+
+  describe("pending marker cleanup on snapshot", () => {
+    // Regression: a compaction parked its marker, then the user switched away
+    // and back BEFORE the next prompt. ThreadController.load() fetches the
+    // snapshot via getThread() directly (not via subscribe), and the snapshot
+    // already contains pi's persisted compactionSummary — without the cleanup
+    // the parked copy was injected later as a duplicate bottom marker.
+    it("should drop parked markers when getThread fetches a snapshot", async () => {
+      addPendingCompactionMarker(LIVE, { summary: "s", timestamp: 1000 });
+      await createElectronPiClient().getThread(LIVE);
+      expect(getPendingCompactionMarkers(LIVE)).toEqual([]);
+    });
+
+    it("should keep other sessions' parked markers when one thread loads", async () => {
+      addPendingCompactionMarker("/ws/sessions/other.jsonl", { summary: "s", timestamp: 1000 });
+      await createElectronPiClient().getThread(LIVE);
+      expect(getPendingCompactionMarkers("/ws/sessions/other.jsonl")).toHaveLength(1);
+    });
+
+    it("should drop parked markers on the subscribe snapshot path too", async () => {
+      addPendingCompactionMarker(LIVE, { summary: "s", timestamp: 1000 });
+      const client = createElectronPiClient();
+      client.subscribe(LIVE, () => {});
+      await flushLookup();
+      expect(getPendingCompactionMarkers(LIVE)).toEqual([]);
+    });
+  });
+
+  describe("compaction heal on subscribe", () => {
+    // react-pi's cached thread controllers unsubscribe ~30s after unmount and
+    // snapshots don't carry compaction, so each new subscription re-syncs from
+    // the bridge's compaction mirror.
+    it("should emit a synthetic compaction_start when subscribing while a compaction is running", () => {
+      h.compaction = { active: true, reason: "overflow", everCompacted: true };
+      const { events } = captureLive(createElectronPiClient());
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({ type: "compaction_start", reason: "overflow", threadId: LIVE });
+    });
+
+    it("should emit a synthetic compaction_end when subscribing after a compaction finished", () => {
+      h.compaction = { active: false, reason: "threshold", everCompacted: true };
+      const { events } = captureLive(createElectronPiClient());
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({ type: "compaction_end", aborted: false, willRetry: false });
+    });
+
+    it("should emit nothing when the session has never compacted", () => {
+      h.compaction = undefined;
+      resetPendingCompactionMarkers();
+      const { events } = captureLive(createElectronPiClient());
+      expect(events).toHaveLength(0);
+    });
+
+    it("should emit the heal after the snapshot when subscribing with a snapshot", async () => {
+      h.compaction = { active: true, reason: "overflow", everCompacted: true };
+      const client = createElectronPiClient();
+      const events: PiClientEvent[] = [];
+      client.subscribe(LIVE, (e) => events.push(e));
+      await flushLookup();
+      expect(events.map((e) => e.type)).toEqual(["snapshot", "compaction_start"]);
+    });
   });
 });
 

--- a/packages/desktop/src/renderer/runtime/__tests__/overflowPatterns.test.ts
+++ b/packages/desktop/src/renderer/runtime/__tests__/overflowPatterns.test.ts
@@ -1,0 +1,58 @@
+import { getOverflowPatterns, isContextOverflow } from "@earendil-works/pi-ai/base";
+import { describe, expect, it } from "vitest";
+import { isOverflowErrorMessage, OVERFLOW_PATTERNS } from "../overflowPatterns";
+
+// overflowPatterns.ts is a verbatim copy of pi-ai's overflow detection (the
+// import would drag pi-ai's generated model catalog into the renderer bundle).
+// These drift guards compare the copy against the INSTALLED pi-ai on every
+// test run: when a pi upgrade changes the patterns, they fail and the copy
+// gets re-synced.
+
+describe("overflowPatterns drift guard", () => {
+  it("should carry exactly the installed pi-ai overflow patterns", () => {
+    expect(OVERFLOW_PATTERNS.map(String)).toEqual(getOverflowPatterns().map(String));
+  });
+
+  it("should agree with pi-ai's isContextOverflow on representative error messages", () => {
+    const samples = [
+      // Overflow errors from the pattern list's documented examples.
+      "prompt is too long: 213462 tokens > 200000 maximum",
+      '413 {"error":{"type":"request_too_large","message":"Request exceeds the maximum size"}}',
+      "Your input exceeds the context window of this model",
+      "The input token count (1196265) exceeds the maximum number of tokens allowed (1048575)",
+      "This model's maximum prompt length is 131072 but the request contains 537812 tokens",
+      "Please reduce the length of the messages or completion",
+      "the request exceeds the available context size, try increasing it",
+      "context_length_exceeded",
+      "too many tokens",
+      "400 status code (no body)",
+      // Non-overflow exclusions and plain errors.
+      "ThrottlingException: Too many tokens, please wait before trying again.",
+      "Throttling error: Too many tokens, please wait before trying again.",
+      "rate limit exceeded, too many tokens",
+      "Too many requests, slow down",
+      "Internal server error",
+      "Invalid API key",
+    ];
+    for (const errorMessage of samples) {
+      const message = { role: "assistant", content: [], stopReason: "error", errorMessage };
+      expect
+        .soft(isOverflowErrorMessage(errorMessage), errorMessage)
+        .toBe(isContextOverflow(message as unknown as Parameters<typeof isContextOverflow>[0]));
+    }
+  });
+});
+
+describe("isOverflowErrorMessage()", () => {
+  it("should return true for a provider overflow error", () => {
+    expect(isOverflowErrorMessage("prompt is too long: 213462 tokens > 200000 maximum")).toBe(true);
+  });
+
+  it("should return false for a throttling error that also mentions tokens", () => {
+    expect(isOverflowErrorMessage("ThrottlingException: rate limit, too many tokens, please wait.")).toBe(false);
+  });
+
+  it("should return false for an unrelated error", () => {
+    expect(isOverflowErrorMessage("Internal server error")).toBe(false);
+  });
+});

--- a/packages/desktop/src/renderer/runtime/__tests__/overflowRecovery.test.ts
+++ b/packages/desktop/src/renderer/runtime/__tests__/overflowRecovery.test.ts
@@ -1,0 +1,395 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionAgentEvent } from "../../rpc/types";
+import { OverflowRecoveryInterceptor } from "../overflowRecovery";
+import { getPendingCompactionMarkers, resetPendingCompactionMarkers } from "../pendingCompaction";
+
+// The interceptor is a pure state machine over the sidecar event stream: it
+// holds pi's transient context-overflow error until the stream shows whether
+// auto-compaction recovered (drop) or not (replay). Tests drive it with the
+// exact event sequences the pi SDK emits (verified against agent-session.js).
+
+const A = "/ws/sessions/a.jsonl";
+const B = "/ws/sessions/b.jsonl";
+
+/** Anthropic's real overflow error text — matches pi's overflow patterns. */
+const OVERFLOW_TEXT = "prompt is too long: 213462 tokens > 200000 maximum";
+
+const overflowMessage = {
+  role: "assistant",
+  content: [],
+  stopReason: "error",
+  errorMessage: OVERFLOW_TEXT,
+};
+
+const ev = (type: string, extra: Record<string, unknown> = {}, sessionPath = A) =>
+  ({ type, ...extra, sessionPath }) as SessionAgentEvent;
+
+const overflowEnd = (sessionPath = A) => ev("message_end", { message: overflowMessage }, sessionPath);
+const agentEnd = (sessionPath = A) => ev("agent_end", { willRetry: false }, sessionPath);
+const compactionStart = (reason = "overflow") => ev("compaction_start", { reason });
+const compactionEnd = (over: Record<string, unknown> = {}) =>
+  ev("compaction_end", { reason: "overflow", aborted: false, willRetry: true, ...over });
+
+let emitted: SessionAgentEvent[];
+let interceptor: OverflowRecoveryInterceptor;
+
+const types = () => emitted.map((e) => e.type);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  resetPendingCompactionMarkers();
+  emitted = [];
+  interceptor = new OverflowRecoveryInterceptor((e) => emitted.push(e));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("OverflowRecoveryInterceptor", () => {
+  describe("passthrough (no hold)", () => {
+    it("should pass a non-overflow error message_end through untouched", () => {
+      const e = ev("message_end", {
+        message: { role: "assistant", content: [], stopReason: "error", errorMessage: "Internal server error" },
+      });
+      interceptor.process(e);
+      expect(emitted).toEqual([e]);
+    });
+
+    it("should pass a rate-limit error through untouched (non-overflow pattern exclusion)", () => {
+      const e = ev("message_end", {
+        message: { role: "assistant", content: [], stopReason: "error", errorMessage: "rate limit exceeded" },
+      });
+      interceptor.process(e);
+      expect(emitted).toEqual([e]);
+    });
+
+    it("should pass a successful assistant message_end through untouched", () => {
+      const e = ev("message_end", { message: { role: "assistant", content: [], stopReason: "stop" } });
+      interceptor.process(e);
+      expect(emitted).toEqual([e]);
+    });
+
+    it("should pass ordinary run events through untouched", () => {
+      for (const e of [ev("agent_start"), ev("turn_start"), ev("turn_end"), agentEnd()]) interceptor.process(e);
+      expect(types()).toEqual(["agent_start", "turn_start", "turn_end", "agent_end"]);
+    });
+  });
+
+  describe("holding an overflow error", () => {
+    it("should suppress the overflow message_end and the following agent_end", () => {
+      interceptor.process(overflowEnd());
+      interceptor.process(agentEnd());
+      expect(emitted).toHaveLength(0);
+    });
+
+    it("should pass turn_end through while holding", () => {
+      interceptor.process(overflowEnd());
+      interceptor.process(ev("turn_end"));
+      interceptor.process(agentEnd());
+      expect(types()).toEqual(["turn_end"]);
+    });
+
+    it("should pass compaction_start through while keeping the hold", () => {
+      interceptor.process(overflowEnd());
+      interceptor.process(agentEnd());
+      interceptor.process(compactionStart());
+      expect(types()).toEqual(["compaction_start"]);
+    });
+  });
+
+  describe("successful recovery", () => {
+    const runRecovery = () => {
+      interceptor.process(overflowEnd());
+      interceptor.process(ev("turn_end"));
+      interceptor.process(agentEnd());
+      interceptor.process(compactionStart());
+      interceptor.process(compactionEnd());
+    };
+
+    it("should drop the held error for good when the retry run starts", () => {
+      runRecovery();
+      interceptor.process(ev("agent_start"));
+      interceptor.process(ev("turn_start"));
+      expect(types()).toEqual(["turn_end", "compaction_start", "compaction_end", "agent_start", "turn_start"]);
+    });
+
+    it("should not replay after the retry consumed the hold even when the timer elapses", () => {
+      runRecovery();
+      interceptor.process(ev("agent_start"));
+      vi.advanceTimersByTime(60_000);
+      expect(types()).toEqual(["turn_end", "compaction_start", "compaction_end", "agent_start"]);
+    });
+
+    it("should not let the recovery-pending timer fire during a slow compaction", () => {
+      interceptor.process(overflowEnd());
+      interceptor.process(agentEnd());
+      interceptor.process(compactionStart());
+      vi.advanceTimersByTime(60_000); // summarization can take arbitrarily long
+      expect(types()).toEqual(["compaction_start"]);
+    });
+
+    it("should replay when compaction succeeded but no continuation ever arrived", () => {
+      runRecovery();
+      vi.advanceTimersByTime(10_000);
+      expect(types()).toEqual([
+        "turn_end",
+        "compaction_start",
+        "compaction_end",
+        "message_start",
+        "message_end",
+        "agent_end",
+      ]);
+    });
+
+    it("should give up and replay when the run ends again instead of continuing", () => {
+      runRecovery();
+      interceptor.process(agentEnd()); // continuation never started; the run just ended
+      expect(types()).toEqual([
+        "turn_end",
+        "compaction_start",
+        "compaction_end",
+        "message_start",
+        "message_end",
+        "agent_end", // the held one
+        "agent_end", // the new one, forwarded after the flush
+      ]);
+    });
+
+    it("should treat a completed message after compaction as the continuation and drop the hold", () => {
+      interceptor.process(overflowEnd());
+      interceptor.process(compactionEnd());
+      interceptor.process(ev("message_end", { message: { role: "assistant", content: [], stopReason: "stop" } }));
+      vi.advanceTimersByTime(60_000);
+      expect(types()).toEqual(["compaction_end", "message_end"]);
+    });
+
+    it("should replay when the run settles without a continuation (agent_settled)", () => {
+      runRecovery();
+      interceptor.process(ev("agent_settled"));
+      expect(types()).toEqual([
+        "turn_end",
+        "compaction_start",
+        "compaction_end",
+        "message_start",
+        "message_end",
+        "agent_end",
+        "agent_settled",
+      ]);
+    });
+  });
+
+  describe("failed recovery", () => {
+    it("should replay with pi's friendlier error text when compaction_end carries one", () => {
+      const friendly = "Context overflow recovery failed after one compact-and-retry attempt.";
+      interceptor.process(overflowEnd());
+      interceptor.process(agentEnd());
+      // The one-attempt guard emits compaction_end WITHOUT a compaction_start.
+      interceptor.process(compactionEnd({ willRetry: false, errorMessage: friendly }));
+
+      expect(types()).toEqual(["compaction_end", "message_start", "message_end", "agent_end"]);
+      const replayed = emitted[2] as { message?: { errorMessage?: string } };
+      expect(replayed.message?.errorMessage).toBe(friendly);
+    });
+
+    it("should replay with the original provider error when compaction was aborted", () => {
+      interceptor.process(overflowEnd());
+      interceptor.process(agentEnd());
+      interceptor.process(compactionStart());
+      interceptor.process(compactionEnd({ aborted: true, willRetry: false }));
+
+      expect(types()).toEqual(["compaction_start", "compaction_end", "message_start", "message_end", "agent_end"]);
+      const replayed = emitted[3] as { message?: { errorMessage?: string } };
+      expect(replayed.message?.errorMessage).toBe(OVERFLOW_TEXT);
+    });
+
+    it("should replay the synthetic message_start with the same message as the message_end", () => {
+      interceptor.process(overflowEnd());
+      interceptor.process(compactionEnd({ willRetry: false, errorMessage: "failed" }));
+      const start = emitted[1] as { message?: unknown };
+      const end = emitted[2] as { message?: unknown };
+      expect(start.message).toEqual(end.message);
+    });
+  });
+
+  describe("no compaction coming", () => {
+    it("should replay in order after the hold timeout when nothing follows", () => {
+      interceptor.process(overflowEnd());
+      interceptor.process(agentEnd());
+      vi.advanceTimersByTime(10_000);
+      expect(types()).toEqual(["message_start", "message_end", "agent_end"]);
+    });
+
+    it("should stay silent just before the timeout and replay at it", () => {
+      interceptor.process(overflowEnd());
+      vi.advanceTimersByTime(9_999);
+      expect(emitted).toHaveLength(0);
+      vi.advanceTimersByTime(1);
+      expect(types()).toEqual(["message_start", "message_end"]);
+    });
+
+    it("should flush the held error before forwarding an unexpected new run", () => {
+      interceptor.process(overflowEnd());
+      interceptor.process(agentEnd());
+      interceptor.process(ev("agent_start")); // user re-prompted; no compaction happened
+      expect(types()).toEqual(["message_start", "message_end", "agent_end", "agent_start"]);
+    });
+
+    it("should flush the held error when the run settles without compaction (agent_settled)", () => {
+      interceptor.process(overflowEnd());
+      interceptor.process(agentEnd());
+      interceptor.process(ev("agent_settled"));
+      expect(types()).toEqual(["message_start", "message_end", "agent_end", "agent_settled"]);
+    });
+
+    it("should flush the held error before forwarding an unexpected completed message", () => {
+      interceptor.process(overflowEnd());
+      interceptor.process(ev("message_end", { message: { role: "assistant", content: [], stopReason: "stop" } }));
+      expect(types()).toEqual(["message_start", "message_end", "message_end"]);
+    });
+
+    it("should flush the first overflow before holding a second one", () => {
+      interceptor.process(overflowEnd());
+      interceptor.process(ev("message_end", { message: { ...overflowMessage, errorMessage: OVERFLOW_TEXT } }));
+      // First hold replayed; the second overflow is now held instead.
+      expect(types()).toEqual(["message_start", "message_end"]);
+      vi.advanceTimersByTime(10_000);
+      expect(types()).toEqual(["message_start", "message_end", "message_start", "message_end"]);
+    });
+  });
+
+  describe("flush()", () => {
+    it("should replay held events when flushed (child crash path)", () => {
+      interceptor.process(overflowEnd());
+      interceptor.process(agentEnd());
+      interceptor.flush(A);
+      expect(types()).toEqual(["message_start", "message_end", "agent_end"]);
+    });
+
+    it("should do nothing when flushing a session with no hold", () => {
+      interceptor.flush(A);
+      expect(emitted).toHaveLength(0);
+    });
+
+    it("should not replay again when the timer elapses after a flush", () => {
+      interceptor.process(overflowEnd());
+      interceptor.flush(A);
+      vi.advanceTimersByTime(60_000);
+      expect(types()).toEqual(["message_start", "message_end"]);
+    });
+  });
+
+  describe("per-session isolation", () => {
+    it("should keep holding session A while passing session B's events through", () => {
+      interceptor.process(overflowEnd(A));
+      interceptor.process(ev("agent_start", {}, B));
+      interceptor.process(overflowEnd(B));
+      interceptor.process(compactionEnd({ willRetry: false, errorMessage: "failed" })); // session A
+      // B's agent_start passed; B's overflow is held separately; A replayed.
+      expect(emitted.map((e) => [e.type, e.sessionPath])).toEqual([
+        ["agent_start", B],
+        ["compaction_end", A],
+        ["message_start", A],
+        ["message_end", A],
+      ]);
+    });
+  });
+
+  describe("persistent compaction record (deferred marker)", () => {
+    const result = { summary: "Earlier: reviewed Q1 spending.", tokensBefore: 31000 };
+    const userStart = () => ev("message_start", { message: { role: "user", content: [] } });
+
+    it("should park the marker on a successful compaction instead of injecting it", () => {
+      interceptor.process(ev("compaction_start", { reason: "threshold" }));
+      interceptor.process(compactionEnd({ reason: "threshold", willRetry: false, result }));
+      // No transcript message yet — injecting here would break the turn anchor.
+      expect(types()).toEqual(["compaction_start", "compaction_end"]);
+      expect(getPendingCompactionMarkers(A)).toEqual([
+        { summary: result.summary, tokensBefore: 31000, timestamp: expect.any(Number) },
+      ]);
+    });
+
+    it("should inject the parked marker right before the next user prompt", () => {
+      interceptor.process(ev("compaction_start", { reason: "threshold" }));
+      interceptor.process(compactionEnd({ reason: "threshold", willRetry: false, result }));
+      interceptor.process(userStart());
+      expect(types()).toEqual(["compaction_start", "compaction_end", "message_start", "message_start"]);
+      const marker = emitted[2] as { message?: { role?: string; summary?: string } };
+      const user = emitted[3] as { message?: { role?: string } };
+      expect(marker.message?.role).toBe("compactionSummary");
+      expect(marker.message?.summary).toBe(result.summary);
+      expect(user.message?.role).toBe("user");
+      expect(getPendingCompactionMarkers(A)).toEqual([]);
+    });
+
+    it("should inject the marker only once", () => {
+      interceptor.process(compactionEnd({ reason: "threshold", willRetry: false, result }));
+      interceptor.process(userStart());
+      interceptor.process(userStart());
+      expect(types().filter((t) => t === "message_start")).toHaveLength(3); // marker + two user prompts
+    });
+
+    it("should park the marker for a successful overflow recovery too", () => {
+      interceptor.process(overflowEnd());
+      interceptor.process(agentEnd());
+      interceptor.process(compactionStart());
+      interceptor.process(compactionEnd({ result }));
+      expect(types()).toEqual(["compaction_start", "compaction_end"]);
+      expect(getPendingCompactionMarkers(A)).toHaveLength(1);
+    });
+
+    it("should park both markers when two compactions happen before the next prompt", () => {
+      interceptor.process(compactionEnd({ reason: "overflow", result }));
+      interceptor.process(ev("agent_start"));
+      interceptor.process(compactionEnd({ reason: "threshold", willRetry: false, result: { summary: "second" } }));
+      expect(getPendingCompactionMarkers(A)).toHaveLength(2);
+      interceptor.process(userStart());
+      const roles = emitted.map((e) => (e as { message?: { role?: string } }).message?.role).filter(Boolean);
+      expect(roles).toEqual(["compactionSummary", "compactionSummary", "user"]);
+    });
+
+    it("should park nothing when the compaction failed", () => {
+      interceptor.process(ev("compaction_start", { reason: "threshold" }));
+      interceptor.process(
+        compactionEnd({ reason: "threshold", willRetry: false, errorMessage: "Auto-compaction failed" }),
+      );
+      expect(getPendingCompactionMarkers(A)).toEqual([]);
+    });
+
+    it("should park nothing when compaction_end carries no result", () => {
+      interceptor.process(ev("compaction_start", { reason: "manual" }));
+      interceptor.process(compactionEnd({ reason: "manual", willRetry: false }));
+      expect(getPendingCompactionMarkers(A)).toEqual([]);
+    });
+
+    it("should keep sessions separate", () => {
+      interceptor.process(compactionEnd({ reason: "threshold", willRetry: false, result }));
+      interceptor.process(ev("message_start", { message: { role: "user", content: [] } }, B));
+      // B's prompt must not consume A's parked marker.
+      expect(getPendingCompactionMarkers(A)).toHaveLength(1);
+    });
+  });
+
+  describe("compactionState()", () => {
+    it("should be undefined for a session that never compacted", () => {
+      interceptor.process(ev("agent_start"));
+      expect(interceptor.compactionState(A)).toBeUndefined();
+    });
+
+    it("should mirror an active compaction with its reason", () => {
+      interceptor.process(ev("compaction_start", { reason: "threshold" }));
+      expect(interceptor.compactionState(A)).toEqual({ active: true, reason: "threshold", everCompacted: true });
+    });
+
+    it("should mirror a finished compaction as inactive but everCompacted", () => {
+      interceptor.process(ev("compaction_start", { reason: "manual" }));
+      interceptor.process(ev("compaction_end", { reason: "manual", aborted: false, willRetry: false }));
+      expect(interceptor.compactionState(A)).toEqual({ active: false, reason: "manual", everCompacted: true });
+    });
+
+    it("should track compaction per session", () => {
+      interceptor.process(ev("compaction_start", { reason: "threshold" }, A));
+      expect(interceptor.compactionState(B)).toBeUndefined();
+    });
+  });
+});

--- a/packages/desktop/src/renderer/runtime/agentBridge.ts
+++ b/packages/desktop/src/renderer/runtime/agentBridge.ts
@@ -16,6 +16,7 @@
 
 import { type AgentExit, agentApi } from "../rpc/api";
 import type { SessionAgentEvent } from "../rpc/types";
+import { type CompactionMirror, OverflowRecoveryInterceptor } from "./overflowRecovery";
 
 type EventListener = (e: SessionAgentEvent) => void;
 type ErrorListener = (sessionPath: string, message: string) => void;
@@ -47,6 +48,10 @@ class AgentBridge {
   private readonly errorListeners = new Set<ErrorListener>();
   /** In-flight request() promises keyed by their correlation id. */
   private readonly pending = new Map<string, PendingRequest>();
+  /** Holds pi's transient context-overflow error until the stream shows
+   *  whether auto-compaction recovered (then it is dropped) or not (then it is
+   *  replayed) — every listener sees the corrected stream. */
+  private readonly interceptor = new OverflowRecoveryInterceptor((e) => this.fanOut(e));
 
   /** Attach the event/terminate/error subscriptions exactly once — they listen
    *  on the IPC channel, not a specific child, so they survive respawns. */
@@ -65,6 +70,10 @@ class AgentBridge {
    *  Other sessions' children are untouched; the next send to this session
    *  respawns its child. */
   private onStopped(sessionPath: string, message: string): void {
+    // Replay any held overflow error first, so it lands on its message before
+    // listeners mark the thread failed (a later timer replay would overwrite
+    // the failed state with idle).
+    this.interceptor.flush(sessionPath);
     const error = new Error(message);
     for (const p of [...this.pending.values()]) if (p.sessionPath === sessionPath) p.fail(error);
     for (const fn of [...this.errorListeners]) fn(sessionPath, message);
@@ -89,7 +98,17 @@ class AgentBridge {
       agentApi.send(e.sessionPath, response).catch(() => undefined);
       return;
     }
+    this.interceptor.process(e);
+  }
+
+  private fanOut(e: SessionAgentEvent): void {
     for (const fn of [...this.listeners]) fn(e);
+  }
+
+  /** The session's last known compaction state (undefined until one starts).
+   *  `electronPiClient.subscribe()` re-syncs new subscriptions from this. */
+  compactionState(sessionPath: string): CompactionMirror | undefined {
+    return this.interceptor.compactionState(sessionPath);
   }
 
   /** Subscribe to the live event stream (all sessions — filter by

--- a/packages/desktop/src/renderer/runtime/electronPiClient.ts
+++ b/packages/desktop/src/renderer/runtime/electronPiClient.ts
@@ -42,6 +42,7 @@ import { agentApi, authApi, sessionsApi, settingsApi, skillsApi } from "../rpc/a
 import type { AgentEvent, ModelInfo, SessionSummary } from "../rpc/types";
 import { agentBridge } from "./agentBridge";
 import { newChatModel } from "./newChatModel";
+import { takePendingCompactionMarkers } from "./pendingCompaction";
 
 /** Subset of the `get_state` response we read. */
 type PiState = {
@@ -183,8 +184,6 @@ export function createElectronPiClient(): PiClient {
     switch (e.type) {
       case "agent_start":
         return { type: "agent_start" };
-      case "agent_end":
-        return { type: "agent_end" };
       case "turn_start": {
         const t = (turns.get(threadId) ?? -1) + 1;
         turns.set(threadId, t);
@@ -213,8 +212,14 @@ export function createElectronPiClient(): PiClient {
         };
       case "tool_execution_end":
         return { type: "tool_execution_end", toolCallId: e.toolCallId, result: e.result, isError: Boolean(e.isError) };
-      default:
-        return { type: (e as { type: string }).type } as unknown as PiClientEventBody;
+      default: {
+        // Forward everything else with its full payload, as node/mapping.ts
+        // does — the reducer needs e.g. `agent_end.willRetry` (keeps runStatus
+        // running across recoveries), `compaction_start.reason`, and
+        // `queue_update`'s arrays; unknown types are ignored downstream.
+        const { sessionPath: _sessionPath, ...body } = e as { type: string; sessionPath?: string };
+        return body as unknown as PiClientEventBody;
+      }
     }
   };
 
@@ -271,6 +276,12 @@ export function createElectronPiClient(): PiClient {
         agentBridge.request<{ messages: unknown }>(threadId, { type: "get_messages" }, "get_messages"),
         agentBridge.request<PiState>(threadId, { type: "get_state" }, "get_state"),
       ]);
+      // Every snapshot flows through here (ThreadController.load() calls this
+      // directly; subscribe()'s snapshot branch does too). The fetched
+      // transcript already carries pi's persisted compactionSummary entries,
+      // so any marker still parked for a later injection would now duplicate
+      // the one in the snapshot.
+      takePendingCompactionMarkers(threadId);
       return buildSnapshot(threadId, state, msgs.messages);
     },
 
@@ -364,6 +375,20 @@ export function createElectronPiClient(): PiClient {
         if (!active) return;
         listener({ ...body, threadId, seq: nextSeq(threadId) } as PiClientEvent);
       };
+      // Re-sync this subscription with the session's live compaction state:
+      // react-pi keeps thread state in a cached controller that unsubscribes
+      // ~30s after unmount, and snapshots don't carry compaction — so without
+      // this a compaction that started (or ended) while unsubscribed would be
+      // missed (or stick forever). Runs after attachLive() so nothing races.
+      const emitCompactionHeal = () => {
+        const c = agentBridge.compactionState(threadId);
+        if (!c?.everCompacted) return;
+        emit(
+          c.active
+            ? { type: "compaction_start", reason: c.reason ?? "threshold" }
+            : { type: "compaction_end", aborted: false, willRetry: false },
+        );
+      };
       const attachLive = () => {
         if (!active) return;
         offs.push(
@@ -389,6 +414,7 @@ export function createElectronPiClient(): PiClient {
           .then((snapshot) => {
             emit({ type: "snapshot", snapshot });
             attachLive();
+            emitCompactionHeal();
           })
           .catch((err) => {
             emit({ type: "error", error: err instanceof Error ? err.message : String(err) });
@@ -396,6 +422,7 @@ export function createElectronPiClient(): PiClient {
           });
       } else {
         attachLive();
+        emitCompactionHeal();
       }
 
       return () => {

--- a/packages/desktop/src/renderer/runtime/overflowPatterns.ts
+++ b/packages/desktop/src/renderer/runtime/overflowPatterns.ts
@@ -1,0 +1,53 @@
+// Local copy of pi's context-overflow error detection, for the renderer bundle.
+//
+// The canonical source is @earendil-works/pi-ai `utils/overflow.ts`
+// (`isContextOverflow`), which the pi SDK itself uses to decide whether an
+// errored assistant message triggers compact-and-retry. Importing it here would
+// drag pi-ai's ~580KB generated model catalog into the renderer bundle (the
+// `./base` entry re-exports it and rollup cannot shake it off), so the two
+// regex lists are copied verbatim instead. A drift-guard test compares them
+// against the installed pi-ai on every run — if pi adds a provider pattern,
+// that test fails and this file gets re-synced.
+//
+// Only the error-message case is replicated: the silent (z.ai) and length-stop
+// (MiMo) overflow cases need the model's context window and end in stopReason
+// "stop"/"length", which the overflow-recovery interceptor never suppresses.
+
+export const OVERFLOW_PATTERNS: readonly RegExp[] = [
+  /prompt is too long/i, // Anthropic token overflow
+  /request_too_large/i, // Anthropic request byte-size overflow (HTTP 413)
+  /input is too long for requested model/i, // Amazon Bedrock
+  /exceeds the context window/i, // OpenAI (Completions & Responses API)
+  /exceeds (?:the )?(?:model'?s )?maximum context length(?: of [\d,]+ tokens?|\s*\([\d,]+\))/i, // OpenAI-compatible proxies (LiteLLM)
+  /input token count.*exceeds the maximum/i, // Google (Gemini)
+  /maximum prompt length is \d+/i, // xAI (Grok)
+  /reduce the length of the messages/i, // Groq
+  /maximum context length is \d+ tokens/i, // OpenRouter (most backends)
+  /exceeds (?:the )?maximum allowed input length of [\d,]+ tokens?/i, // OpenRouter/Poolside
+  /input \(\d+ tokens\) is longer than the model'?s context length \(\d+ tokens\)/i, // Together AI
+  /exceeds the limit of \d+/i, // GitHub Copilot
+  /exceeds the available context size/i, // llama.cpp server
+  /greater than the context length/i, // LM Studio
+  /context window exceeds limit/i, // MiniMax
+  /exceeded model token limit/i, // Kimi For Coding
+  /too large for model with \d+ maximum context length/i, // Mistral
+  /model_context_window_exceeded/i, // z.ai non-standard finish_reason surfaced as error text
+  /prompt too long; exceeded (?:max )?context length/i, // Ollama explicit overflow error
+  /context[_ ]length[_ ]exceeded/i, // Generic fallback
+  /too many tokens/i, // Generic fallback
+  /token limit exceeded/i, // Generic fallback
+  /^4(?:00|13)\s*(?:status code)?\s*\(no body\)/i, // Cerebras: 400/413 with no body
+];
+
+/** Errors that must NOT count as overflow even when an overflow pattern also
+ *  matches (e.g. Bedrock throttling: "Too many tokens, please wait…"). */
+export const NON_OVERFLOW_PATTERNS: readonly RegExp[] = [
+  /^(Throttling error|Service unavailable):/i, // AWS Bedrock non-overflow errors (human-readable prefixes from formatBedrockError)
+  /rate limit/i, // Generic rate limiting
+  /too many requests/i, // Generic HTTP 429 style
+];
+
+/** True when the error text of a `stopReason: "error"` assistant message
+ *  indicates a context overflow — mirrors pi-ai's `isContextOverflow` case 1. */
+export const isOverflowErrorMessage = (errorMessage: string): boolean =>
+  !NON_OVERFLOW_PATTERNS.some((p) => p.test(errorMessage)) && OVERFLOW_PATTERNS.some((p) => p.test(errorMessage));

--- a/packages/desktop/src/renderer/runtime/overflowRecovery.ts
+++ b/packages/desktop/src/renderer/runtime/overflowRecovery.ts
@@ -1,0 +1,234 @@
+// Suppresses the transient error pi emits on context overflow (A-42).
+//
+// On overflow the SDK sends an assistant message with `stopReason: "error"`,
+// then `agent_end { willRetry: false }` — and only AFTER that recovers on its
+// own: `compaction_start { reason: "overflow" }` → summarize → `compaction_end
+// { willRetry: true }` → continue the run on the compacted context. The SDK
+// even strips the errored message from its own state before retrying; only the
+// UI would show it. So we hold exactly that message (and its `agent_end`, which
+// keeps the thread visibly running through the 30s+ compaction) until the
+// stream tells us which way it went:
+//
+// - compaction succeeded and the run continued → drop the held events; the
+//   user never sees an error, just the "Compacting conversation" step.
+// - compaction failed / never started / the child died → replay the held
+//   events so the normal error bubble shows (with pi's friendlier recovery
+//   message when it sent one).
+//
+// Real (non-overflow) errors never match the pattern check and are never
+// delayed. `agent_settled` (pi ≥ 0.80.4, "run fully settled incl. compaction
+// and retry") is handled as a flush trigger already; on the pinned 0.79.8 it
+// never fires, so ~10s timers are the fallback decision points.
+
+import type { SessionAgentEvent } from "../rpc/types";
+import { isOverflowErrorMessage } from "./overflowPatterns";
+import { addPendingCompactionMarker, takePendingCompactionMarkers } from "./pendingCompaction";
+
+type MessageEndEvent = Extract<SessionAgentEvent, { type: "message_end" }>;
+
+/** Renderer-side mirror of a session's compaction state, kept because react-pi
+ *  drops its live subscription ~30s after a thread unmounts and snapshots do
+ *  not carry compaction — `electronPiClient.subscribe()` re-syncs from this. */
+export interface CompactionMirror {
+  active: boolean;
+  reason?: "manual" | "threshold" | "overflow";
+  everCompacted: boolean;
+}
+
+interface Hold {
+  /** recovery-pending: waiting to learn whether compaction handles the error.
+   *  continuation-pending: compaction succeeded, waiting for the retry run. */
+  phase: "recovery-pending" | "continuation-pending";
+  messageEnd: MessageEndEvent;
+  agentEnd?: SessionAgentEvent;
+  timer?: ReturnType<typeof setTimeout>;
+}
+
+/** Events that prove the run is (still) executing — in continuation-pending
+ *  they confirm the post-compaction retry took over. `message_end` and
+ *  `agent_end` are handled separately. */
+const RUN_ACTIVITY = new Set([
+  "agent_start",
+  "turn_start",
+  "message_start",
+  "message_update",
+  "tool_execution_start",
+  "tool_execution_update",
+  "tool_execution_end",
+]);
+
+const isOverflowErrorEnd = (e: SessionAgentEvent): boolean => {
+  if (e.type !== "message_end") return false;
+  const m = e.message;
+  if (m?.role !== "assistant" || m.stopReason !== "error" || typeof m.errorMessage !== "string") return false;
+  return isOverflowErrorMessage(m.errorMessage);
+};
+
+export class OverflowRecoveryInterceptor {
+  private readonly holds = new Map<string, Hold>();
+  private readonly compactions = new Map<string, CompactionMirror>();
+
+  constructor(
+    private readonly emit: (e: SessionAgentEvent) => void,
+    private readonly holdTimeoutMs = 10_000,
+  ) {}
+
+  /** Route every fan-out-bound stream event through here. */
+  process(e: SessionAgentEvent): void {
+    this.trackCompaction(e);
+    // A new user prompt starts a new turn: assistant-ui re-anchors the
+    // viewport anyway, so this is the one moment the parked compaction
+    // markers can enter the transcript without making the thread jump.
+    if (e.type === "message_start" && e.message?.role === "user") {
+      this.injectPendingMarkers(e.sessionPath);
+    }
+    const hold = this.holds.get(e.sessionPath);
+    if (e.type === "compaction_end") {
+      this.handleCompactionEnd(e, hold);
+      return;
+    }
+    if (!hold) {
+      if (e.type === "message_end" && isOverflowErrorEnd(e)) {
+        this.beginHold(e);
+        return;
+      }
+      this.emit(e);
+      return;
+    }
+    switch (e.type) {
+      case "agent_end":
+        if (hold.phase === "recovery-pending") {
+          hold.agentEnd = e;
+          return;
+        }
+        // continuation-pending: the run ended without any activity — give up.
+        this.replayHeld(e.sessionPath);
+        this.emit(e);
+        return;
+      case "compaction_start":
+        // The decision point moves to compaction_end, which pi always emits.
+        if (hold.phase === "recovery-pending") this.clearTimer(hold);
+        this.emit(e);
+        return;
+      case "agent_settled":
+        // Run fully settled without the continuation consuming the hold.
+        this.replayHeld(e.sessionPath);
+        this.emit(e);
+        return;
+      case "message_end":
+        if (isOverflowErrorEnd(e)) {
+          this.replayHeld(e.sessionPath);
+          this.beginHold(e);
+          return;
+        }
+        this.settleOnActivity(hold, e.sessionPath);
+        this.emit(e);
+        return;
+      default:
+        if (RUN_ACTIVITY.has(e.type)) this.settleOnActivity(hold, e.sessionPath);
+        this.emit(e);
+        return;
+    }
+  }
+
+  /** Replay anything held for the session (used on child crash, before the
+   *  bridge notifies error listeners, so the error lands on the message). */
+  flush(sessionPath: string): void {
+    this.replayHeld(sessionPath);
+  }
+
+  private handleCompactionEnd(e: Extract<SessionAgentEvent, { type: "compaction_end" }>, hold: Hold | undefined): void {
+    this.emit(e);
+    if (hold?.phase === "recovery-pending") {
+      if (e.willRetry === true && !e.aborted && e.errorMessage === undefined) {
+        hold.phase = "continuation-pending";
+        this.armTimer(hold, e.sessionPath);
+      } else {
+        // Failed / aborted / won't retry — surface the error, preferring
+        // pi's actionable recovery message over the raw provider text.
+        this.replayHeld(e.sessionPath, e.errorMessage);
+      }
+    }
+    // Park the permanent trace instead of injecting it now: a transcript
+    // message appended here would break assistant-ui's [user, assistant]
+    // turn-anchor tail and collapse the reserved space under the divider
+    // (the thread would visibly jump). The in-message divider shows the
+    // settled state in place; injectPendingMarkers() delivers the transcript
+    // marker with the next user prompt. pi writes the same entry to the
+    // session file, so reloads show it regardless.
+    if (e.aborted || e.errorMessage !== undefined || typeof e.result?.summary !== "string") return;
+    const { summary, tokensBefore } = e.result;
+    addPendingCompactionMarker(e.sessionPath, { summary, tokensBefore, timestamp: Date.now() });
+  }
+
+  private injectPendingMarkers(sessionPath: string): void {
+    for (const marker of takePendingCompactionMarkers(sessionPath)) {
+      this.emit({
+        type: "message_start",
+        message: { role: "compactionSummary", ...marker },
+        sessionPath,
+      });
+    }
+  }
+
+  compactionState(sessionPath: string): CompactionMirror | undefined {
+    return this.compactions.get(sessionPath);
+  }
+
+  private trackCompaction(e: SessionAgentEvent): void {
+    if (e.type === "compaction_start") {
+      this.compactions.set(e.sessionPath, { active: true, reason: e.reason, everCompacted: true });
+    } else if (e.type === "compaction_end") {
+      this.compactions.set(e.sessionPath, { active: false, reason: e.reason, everCompacted: true });
+    }
+  }
+
+  /** Run activity while holding: expected in continuation-pending (the retry
+   *  arrived — drop the held error), unexpected in recovery-pending (no
+   *  compaction is coming — surface it). */
+  private settleOnActivity(hold: Hold, sessionPath: string): void {
+    if (hold.phase === "continuation-pending") this.discardHeld(sessionPath);
+    else this.replayHeld(sessionPath);
+  }
+
+  private beginHold(e: MessageEndEvent): void {
+    const hold: Hold = { phase: "recovery-pending", messageEnd: e };
+    this.holds.set(e.sessionPath, hold);
+    this.armTimer(hold, e.sessionPath);
+  }
+
+  private armTimer(hold: Hold, sessionPath: string): void {
+    this.clearTimer(hold);
+    hold.timer = setTimeout(() => this.replayHeld(sessionPath), this.holdTimeoutMs);
+  }
+
+  private clearTimer(hold: Hold): void {
+    if (hold.timer !== undefined) clearTimeout(hold.timer);
+    hold.timer = undefined;
+  }
+
+  private discardHeld(sessionPath: string): void {
+    const hold = this.holds.get(sessionPath);
+    if (!hold) return;
+    this.clearTimer(hold);
+    this.holds.delete(sessionPath);
+  }
+
+  private replayHeld(sessionPath: string, overrideError?: string): void {
+    const hold = this.holds.get(sessionPath);
+    if (!hold) return;
+    this.clearTimer(hold);
+    this.holds.delete(sessionPath);
+    const message = overrideError
+      ? { ...hold.messageEnd.message, errorMessage: overrideError }
+      : hold.messageEnd.message;
+    // The synthetic message_start makes the replay land even if a snapshot
+    // arrived mid-hold and cleared the reducer's streaming slot (a message_end
+    // without an open slot is silently dropped). If no snapshot intervened it
+    // adds an empty assistant entry that group-merge renders invisibly and the
+    // next snapshot removes.
+    this.emit({ type: "message_start", message, sessionPath });
+    this.emit({ ...hold.messageEnd, message });
+    if (hold.agentEnd) this.emit(hold.agentEnd);
+  }
+}

--- a/packages/desktop/src/renderer/runtime/pendingCompaction.ts
+++ b/packages/desktop/src/renderer/runtime/pendingCompaction.ts
@@ -1,0 +1,66 @@
+// Markers for compactions that finished but are NOT yet in the transcript.
+//
+// Injecting the compactionSummary transcript message the moment a compaction
+// ends breaks assistant-ui's turn anchor (the [user, assistant] tail pattern),
+// which tears down the viewport's reserved space and makes the whole thread
+// jump. So a successful compaction parks its marker here; the in-message
+// divider shows the settled state in place, and the overflow-recovery
+// interceptor injects the real transcript marker right before the NEXT user
+// message — the moment assistant-ui re-anchors the new turn anyway, so nothing
+// visibly moves.
+//
+// A thread snapshot reload drops the pending copy: pi persists the same
+// compactionSummary in the session file, so the fetched transcript already
+// carries it.
+
+import { useSyncExternalStore } from "react";
+
+export interface PendingCompactionMarker {
+  summary: string;
+  tokensBefore?: number;
+  /** When the compaction finished — keeps injected markers chronological. */
+  timestamp: number;
+}
+
+const pending = new Map<string, readonly PendingCompactionMarker[]>();
+const listeners = new Set<() => void>();
+const EMPTY: readonly PendingCompactionMarker[] = [];
+
+const notify = () => {
+  for (const fn of [...listeners]) fn();
+};
+
+export function addPendingCompactionMarker(sessionPath: string, marker: PendingCompactionMarker): void {
+  pending.set(sessionPath, [...(pending.get(sessionPath) ?? []), marker]);
+  notify();
+}
+
+export function getPendingCompactionMarkers(sessionPath: string): readonly PendingCompactionMarker[] {
+  return pending.get(sessionPath) ?? EMPTY;
+}
+
+/** Remove and return the session's pending markers (injection consumed them,
+ *  or a snapshot made them redundant). */
+export function takePendingCompactionMarkers(sessionPath: string): readonly PendingCompactionMarker[] {
+  const markers = pending.get(sessionPath);
+  if (!markers || markers.length === 0) return EMPTY;
+  pending.delete(sessionPath);
+  notify();
+  return markers;
+}
+
+function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+/** Reactive view of one session's pending markers. */
+export function usePendingCompactionMarkers(sessionPath: string): readonly PendingCompactionMarker[] {
+  return useSyncExternalStore(subscribe, () => getPendingCompactionMarkers(sessionPath));
+}
+
+/** Test helper. */
+export function resetPendingCompactionMarkers(): void {
+  pending.clear();
+  notify();
+}


### PR DESCRIPTION
## Problem

When a conversation outgrew the model's context window, the chat showed a destructive error bubble even though the agent recovered on its own (pi auto-compacts the history and retries). There was also no indication that a compaction was happening, and the persisted error stayed in the chat history.

## Changes

**Seamless overflow recovery** (`fix`)
- A renderer-side interceptor holds pi's transient overflow error until the event stream shows whether auto-compaction recovered: on success the error is dropped for good, on failure it is shown with pi's actionable message. Real errors are never delayed.
- The run stays visually "running" through the whole recovery (no composer/indicator flicker), and event payloads (`willRetry`, compaction, auto-retry, queue) now reach the runtime intact.
- Overflow detection reuses pi's own provider patterns via a local copy with a drift-guard test that compares it against the installed pi on every run.

**Compaction status in the chat** (`feat`)
- While pi compacts: a separator line with a spinner and a shimmering "Compacting conversation" label, at the exact spot where the permanent marker will settle.
- Once done: a plain "Conversation compacted" divider that stays in the history (and reloads render the same marker from the session file).
- The marker enters the transcript together with the next user message, so the viewport never jumps when a compaction finishes.
- Bonus polish: the "Working" label got the same spinner, and sub-second durations show as "1s" instead of "<1s".

**Central chat spacing** (`refactor`)
- All vertical gaps in the conversation are now defined by three design tokens in `index.css` (stream gap, turn break, in-message rhythm); every chat component references the tokens instead of hardcoded values.

## Testing

- ~60 new unit/component tests: the interceptor state machine, marker parking/injection, snapshot dedup, divider states, spacing contract; coverage gate holds at 98.8%.
- Live-verified in the dev app with real compactions: pixel-stable divider swap, uniform 24/48px gaps, no scroll jumps, no duplicate markers after thread switches.