### PR TITLE
feat: connect Accountant24 to other apps over the Agent Client Protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ The Electron desktop app:
 - `src/preload/` — the `window.api` bridge; every IPC channel must be allowlisted here.
 - `src/renderer/` — the React app, sandboxed; reaches main only through `window.api` (typed wrappers in `rpc/api.ts`).
 - `src/shared/` — IPC payload types used by both main and renderer (and the agent host). Types only, imported with `import type` from both sides; never add runtime code here.
+- `src/acp/` — the Agent Client Protocol server: a second, headless front door that lets external ACP clients (Buzz, Zed, …) drive the same agent over stdio. Built as `out/main/acp.js` and launched by `resources/accountant24-acp`, outside Electron — so nothing here, or in anything it imports, may use Electron APIs.
 
 The agent itself is `packages/pi-extension`, bundled and loaded into the agent-host utilityProcess that main forks lazily (one process for all chats).
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -19,7 +19,7 @@
       },
       {
         "group": "Guides",
-        "pages": ["docs/go-fully-local"]
+        "pages": ["docs/go-fully-local", "docs/connect-other-apps"]
       },
       {
         "group": "Resources",
@@ -32,6 +32,7 @@
     { "source": "/quickstart", "destination": "/docs/quickstart" },
     { "source": "/skills", "destination": "/docs/skills" },
     { "source": "/go-fully-local", "destination": "/docs/go-fully-local" },
+    { "source": "/connect-other-apps", "destination": "/docs/connect-other-apps" },
     { "source": "/comparison", "destination": "/docs/comparison" },
     { "source": "/faq", "destination": "/docs/faq" }
   ],

--- a/docs/docs/connect-other-apps.mdx
+++ b/docs/docs/connect-other-apps.mdx
@@ -1,0 +1,59 @@
+---
+title: "Connect other apps"
+sidebarTitle: "Connect other apps"
+description: "Chat with your ledger from Buzz, Zed, or any other app that speaks the Agent Client Protocol."
+---
+
+Accountant24 speaks the [Agent Client Protocol](https://agentclientprotocol.com) (ACP), the open standard agent apps use to talk to coding agents. Register one command and you can chat with your ledger from Buzz, Zed, Neovim, or anything else that supports ACP.
+
+## Find your command
+
+Open Settings → Connect and copy the command. It looks like this:
+
+```
+/Applications/Accountant24.app/Contents/Resources/accountant24-acp
+```
+
+That path is all any ACP client needs. There are no arguments and no environment variables to set, and Accountant24 itself does not have to be running.
+
+## Buzz
+
+1. Open Add runtimes and choose **Custom harness**.
+2. Set **Name** to `Accountant24`. The ID fills in automatically.
+3. Paste the command into **Command**.
+4. Leave Arguments and Env vars empty.
+5. Save, then pick Accountant24 as the runtime for an agent.
+
+## Zed
+
+Add this to your `settings.json`:
+
+```json
+{
+  "agent_servers": {
+    "Accountant24": {
+      "type": "custom",
+      "command": "/Applications/Accountant24.app/Contents/Resources/accountant24-acp",
+      "args": []
+    }
+  }
+}
+```
+
+## What to expect
+
+Everything points at the same `~/Accountant24` workspace, so a chat you start in another app shows up in your Accountant24 chat list, and the ledger stays the single source of truth.
+
+The model picker in the other app lists the models you enabled in Settings → Models, and starts on your default model. Switching models there affects that chat only.
+
+A few things worth knowing:
+
+- **Accountant24 ignores the working directory the client sends.** It is a ledger agent, not a coding agent, so it always works on your ledger rather than on whatever folder the other app is pointed at.
+- **MCP servers configured in the other app are ignored.** The agent uses its own ledger tools.
+- **Connect a provider first.** If no model provider is set up, the other app reports that authentication is required. Open Settings → Providers in Accountant24 to connect one.
+
+## Troubleshooting
+
+**The client reports that the command was not found.** Check the exact path in Settings → Connect. If you moved Accountant24 out of your Applications folder, the path changed with it.
+
+**Nothing happens after connecting.** Most clients keep a log of what the agent wrote to its error stream. Accountant24 reports startup problems there, prefixed with `[accountant24-acp]`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.3.0.tgz",
+      "integrity": "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.91.1",
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
@@ -18655,6 +18664,7 @@
       "name": "@accountant24/desktop",
       "version": "0.0.0-dev",
       "dependencies": {
+        "@agentclientprotocol/sdk": "^1.3.0",
         "@aptabase/electron": "^0.3.1",
         "@assistant-ui/react": "^0.14.24",
         "@assistant-ui/react-lexical": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "tsx scripts/bundle-extension.ts && cd packages/desktop && npm run dev",
     "start:agent": "tsx scripts/bundle-extension.ts && node node_modules/@earendil-works/pi-coding-agent/dist/cli.js --offline --no-extensions --no-skills --no-prompt-templates --system-prompt packages/desktop/resources/system.md --skill packages/desktop/resources/skills -e packages/desktop/resources/accountant24-extension.js",
     "build": "tsx scripts/bundle-extension.ts && cd packages/desktop && npm run build",
+    "acp": "npm run build && packages/desktop/resources/accountant24-acp",
     "dist": "npm run build && cd packages/desktop && electron-builder --mac -c.extraMetadata.version=$npm_package_version",
     "dist:dir": "npm run build && cd packages/desktop && electron-builder --mac --dir -c.extraMetadata.version=$npm_package_version",
     "test": "vitest run",

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -50,6 +50,11 @@ extraResources:
   # Static system prompt passed to the agent via `pi --system-prompt`.
   - from: resources/system.md
     to: system.md
+  # The ACP launcher: the command an external ACP client (Buzz, Zed, …) is
+  # pointed at. Lands next to the app tree so it can find both Contents/MacOS
+  # (the Electron binary it runs as Node) and app/out/main/acp.js.
+  - from: resources/accountant24-acp
+    to: accountant24-acp
   # Native (built-in) skills, loaded via `pi --skill <dir>` — embedded so users
   # can't remove or disable them (the workspace skills folder is third-party only).
   - from: resources/skills

--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
           // The agent-host utilityProcess entry, emitted as out/main/agent-host.js
           // next to the main bundle (see env.ts agentHostEntryPath).
           "agent-host": path.resolve(import.meta.dirname, "src/main/agent/host/index.ts"),
+          // The ACP agent, emitted as out/main/acp.js. Not an Electron process at
+          // all: resources/accountant24-acp runs it under ELECTRON_RUN_AS_NODE so
+          // external ACP clients can drive the agent over stdio.
+          acp: path.resolve(import.meta.dirname, "src/acp/index.ts"),
         },
       },
     },

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -12,6 +12,7 @@
     "verify": "npm run typecheck && npm run build"
   },
   "dependencies": {
+    "@agentclientprotocol/sdk": "^1.3.0",
     "@aptabase/electron": "^0.3.1",
     "@assistant-ui/react": "^0.14.24",
     "@assistant-ui/react-lexical": "^0.2.4",

--- a/packages/desktop/resources/accountant24-acp
+++ b/packages/desktop/resources/accountant24-acp
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Accountant24 as an ACP agent, speaking JSON-RPC over stdio.
+#
+# Register this file's absolute path as the command in any ACP client (Buzz's
+# Custom harness, Zed's agent_servers, ...). No arguments, no env vars needed.
+# The desktop app does not have to be running.
+#
+# Packaged, this sits at Contents/Resources/ with the app tree under app/. In a
+# dev checkout it sits at packages/desktop/resources/.
+#
+# Both layouts run Electron as Node (ELECTRON_RUN_AS_NODE) rather than a `node`
+# from PATH. That is deliberate: ACP clients are GUI apps and spawn us with a
+# minimal PATH, so a system `node` is often not resolvable — and depending on
+# one would also mean the dev and packaged paths run different runtimes.
+set -eu
+
+RES=$(cd -- "$(dirname -- "$0")" && pwd)
+export ACCOUNTANT24_RESOURCES="$RES"
+
+# Packaged layout.
+if [ -f "$RES/app/out/main/acp.js" ]; then
+  CONTENTS=$(cd -- "$RES/.." && pwd)
+  # Resolve the app binary by listing Contents/MacOS rather than hardcoding the
+  # product name, so renaming the app cannot break this launcher.
+  ELECTRON=$(find "$CONTENTS/MacOS" -maxdepth 1 -type f -perm -u+x 2>/dev/null | head -n 1)
+  if [ -n "$ELECTRON" ]; then
+    ELECTRON_RUN_AS_NODE=1 exec "$ELECTRON" "$RES/app/out/main/acp.js" "$@"
+  fi
+  echo "accountant24-acp: no runnable binary in $CONTENTS/MacOS" >&2
+  exit 1
+fi
+
+# Dev layout: packages/desktop/resources/../out/main/acp.js, after `npm run build`.
+if [ -f "$RES/../out/main/acp.js" ]; then
+  ROOT=$(cd -- "$RES/../../.." && pwd)
+  for candidate in \
+    "$ROOT/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron" \
+    "$ROOT/packages/desktop/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron" \
+    "$ROOT/node_modules/electron/dist/electron"; do
+    if [ -x "$candidate" ]; then
+      ELECTRON_RUN_AS_NODE=1 exec "$candidate" "$RES/../out/main/acp.js" "$@"
+    fi
+  done
+  # Last resort for a checkout with no installed Electron.
+  if command -v node >/dev/null 2>&1; then
+    exec node "$RES/../out/main/acp.js" "$@"
+  fi
+  echo "accountant24-acp: no Electron in node_modules and no node on PATH; run 'npm install'" >&2
+  exit 1
+fi
+
+echo "accountant24-acp: build output not found; run 'npm run build' first" >&2
+exit 1

--- a/packages/desktop/src/acp/__tests__/config.test.ts
+++ b/packages/desktop/src/acp/__tests__/config.test.ts
@@ -1,0 +1,180 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// config.ts resolves the resource dir without Electron and applies the agent env
+// to this process. The filesystem and homedir are the faked I/O boundaries.
+
+const h = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  homedir: vi.fn(() => "/home/user"),
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: h.existsSync,
+  readFileSync: h.readFileSync,
+  mkdirSync: h.mkdirSync,
+  writeFileSync: vi.fn(),
+}));
+vi.mock("node:os", () => ({ homedir: h.homedir }));
+
+import { loadAcpConfig, resolveResourceDir } from "../config";
+
+// The built entry lives at <root>/out/main/acp.js in both layouts; only where
+// that root sits differs.
+const MODULE_URL = "file:///repo/packages/desktop/out/main/acp.js";
+const DEV_RESOURCES = "/repo/packages/desktop/resources";
+const PACKAGED_URL = "file:///Apps/Accountant24.app/Contents/Resources/app/out/main/acp.js";
+const PACKAGED_RESOURCES = "/Apps/Accountant24.app/Contents/Resources";
+
+const ENV_KEYS = ["ACCOUNTANT24_RESOURCES", "ACCOUNTANT24_HOME", "PI_CODING_AGENT_DIR", "PATH", "TESSDATA_PREFIX"];
+let saved: Record<string, string | undefined>;
+let chdir: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  delete process.env.ACCOUNTANT24_RESOURCES;
+  process.env.ACCOUNTANT24_HOME = "/ws";
+  h.existsSync.mockReset();
+  h.existsSync.mockReturnValue(false);
+  h.readFileSync.mockReset();
+  h.readFileSync.mockReturnValue("{}");
+  h.homedir.mockReturnValue("/home/user");
+  h.mkdirSync.mockReset();
+  chdir = vi.spyOn(process, "chdir").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  chdir.mockRestore();
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+/** Mark a dir as a real resource dir (holding both bundled agent assets). */
+function resourcesAt(dir: string) {
+  h.existsSync.mockImplementation((p: string) => p === `${dir}/system.md` || p === `${dir}/accountant24-extension.js`);
+}
+
+describe("resolveResourceDir()", () => {
+  it("should use ACCOUNTANT24_RESOURCES when the launcher set it", () => {
+    process.env.ACCOUNTANT24_RESOURCES = "/explicit/res";
+    expect(resolveResourceDir(MODULE_URL)).toBe("/explicit/res");
+  });
+
+  it("should ignore an empty ACCOUNTANT24_RESOURCES and probe instead", () => {
+    process.env.ACCOUNTANT24_RESOURCES = "";
+    resourcesAt(DEV_RESOURCES);
+    expect(resolveResourceDir(MODULE_URL)).toBe(DEV_RESOURCES);
+  });
+
+  it("should find the dev layout at ../../resources", () => {
+    resourcesAt(DEV_RESOURCES);
+    expect(resolveResourceDir(MODULE_URL)).toBe(DEV_RESOURCES);
+  });
+
+  it("should find the packaged layout three levels above the entry", () => {
+    resourcesAt(PACKAGED_RESOURCES);
+    expect(resolveResourceDir(PACKAGED_URL)).toBe(PACKAGED_RESOURCES);
+  });
+
+  it("should prefer the dev layout when both probes would match", () => {
+    h.existsSync.mockReturnValue(true);
+    expect(resolveResourceDir(MODULE_URL)).toBe(DEV_RESOURCES);
+  });
+
+  it("should require both bundled assets, not just one", () => {
+    h.existsSync.mockImplementation((p: string) => p === `${DEV_RESOURCES}/system.md`);
+    // Neither candidate is complete, so it falls back to the first.
+    expect(resolveResourceDir(MODULE_URL)).toBe(DEV_RESOURCES);
+  });
+
+  it("should fall back to the dev candidate when nothing is found", () => {
+    h.existsSync.mockReturnValue(false);
+    expect(resolveResourceDir(MODULE_URL)).toBe(DEV_RESOURCES);
+  });
+});
+
+describe("loadAcpConfig()", () => {
+  it("should assemble the agent host config from the workspace and resources", () => {
+    process.env.ACCOUNTANT24_RESOURCES = "/res";
+    expect(loadAcpConfig(MODULE_URL).host).toEqual({
+      workspaceDir: "/ws",
+      sessionsDir: "/ws/sessions",
+      skillsDir: "/ws/skills",
+      nativeSkillsDir: "/res/skills",
+      extensionPath: "/res/accountant24-extension.js",
+      systemPromptPath: "/res/system.md",
+    });
+  });
+
+  // Load bearing: the extension spawns bare hledger/pdftotext/tesseract, so this
+  // process must carry the vendored bin dir before the runtime loads it.
+  it("should apply the agent env to this process", () => {
+    process.env.ACCOUNTANT24_RESOURCES = "/res";
+    process.env.PATH = "/usr/bin";
+    h.existsSync.mockImplementation((p: string) => p === `/res${path.sep}bin` || p === `/res${path.sep}tessdata`);
+    loadAcpConfig(MODULE_URL);
+    expect(process.env.PATH).toBe(`/res/bin${path.delimiter}/usr/bin`);
+    expect(process.env.TESSDATA_PREFIX).toBe("/res/tessdata");
+    expect(process.env.PI_CODING_AGENT_DIR).toBe("/ws");
+  });
+
+  // pi stamps process.cwd() into every new session header, and the app lists
+  // sessions filtered by that header. Without this the chats an ACP client
+  // creates would be invisible in the app.
+  it("should adopt the workspace as the working directory", () => {
+    process.env.ACCOUNTANT24_RESOURCES = "/res";
+    loadAcpConfig(MODULE_URL);
+    expect(chdir).toHaveBeenCalledWith("/ws");
+  });
+
+  it("should create the sessions dir before adopting it", () => {
+    process.env.ACCOUNTANT24_RESOURCES = "/res";
+    loadAcpConfig(MODULE_URL);
+    expect(h.mkdirSync).toHaveBeenCalledWith("/ws/sessions", { recursive: true });
+  });
+
+  it("should read defaultModel and enabledModels from app settings", () => {
+    process.env.ACCOUNTANT24_RESOURCES = "/res";
+    h.existsSync.mockImplementation((p: string) => p === "/ws/app-settings.json");
+    h.readFileSync.mockReturnValue(
+      JSON.stringify({ defaultModel: "anthropic/claude-sonnet-5", enabledModels: ["anthropic/claude-sonnet-5"] }),
+    );
+    const cfg = loadAcpConfig(MODULE_URL);
+    expect(cfg.defaultModel).toBe("anthropic/claude-sonnet-5");
+    expect(cfg.enabledModels).toEqual(["anthropic/claude-sonnet-5"]);
+  });
+
+  it("should leave defaultModel undefined when no settings file exists", () => {
+    process.env.ACCOUNTANT24_RESOURCES = "/res";
+    h.existsSync.mockReturnValue(false);
+    expect(loadAcpConfig(MODULE_URL).defaultModel).toBeUndefined();
+  });
+
+  it("should report the version from the package.json above the built entry", () => {
+    process.env.ACCOUNTANT24_RESOURCES = "/res";
+    h.existsSync.mockReturnValue(false);
+    h.readFileSync.mockImplementation((p: string) =>
+      p === "/repo/packages/desktop/package.json" ? JSON.stringify({ version: "1.2.3" }) : "{}",
+    );
+    expect(loadAcpConfig(MODULE_URL).version).toBe("1.2.3");
+  });
+
+  it("should fall back to 0.0.0 when the package.json cannot be read", () => {
+    process.env.ACCOUNTANT24_RESOURCES = "/res";
+    h.readFileSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    expect(loadAcpConfig(MODULE_URL).version).toBe("0.0.0");
+  });
+
+  it("should fall back to 0.0.0 when the package.json has no version", () => {
+    process.env.ACCOUNTANT24_RESOURCES = "/res";
+    h.existsSync.mockReturnValue(false);
+    h.readFileSync.mockReturnValue(JSON.stringify({ name: "x" }));
+    expect(loadAcpConfig(MODULE_URL).version).toBe("0.0.0");
+  });
+});

--- a/packages/desktop/src/acp/__tests__/events.test.ts
+++ b/packages/desktop/src/acp/__tests__/events.test.ts
@@ -1,0 +1,159 @@
+import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { toSessionUpdate } from "../events";
+
+/** pi's event union is wide and mostly irrelevant here; cast the fixtures. */
+const ev = (e: unknown): AgentSessionEvent => e as AgentSessionEvent;
+
+const messageUpdate = (assistantMessageEvent: unknown) =>
+  ev({ type: "message_update", message: {}, assistantMessageEvent });
+
+describe("toSessionUpdate()", () => {
+  describe("assistant text", () => {
+    it("should map a text_delta to an agent_message_chunk carrying the delta", () => {
+      expect(toSessionUpdate(messageUpdate({ type: "text_delta", delta: "Hello", contentIndex: 0 }))).toEqual({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "Hello" },
+      });
+    });
+
+    it("should map a thinking_delta to an agent_thought_chunk", () => {
+      expect(toSessionUpdate(messageUpdate({ type: "thinking_delta", delta: "hmm", contentIndex: 0 }))).toEqual({
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: "hmm" },
+      });
+    });
+
+    // text_end repeats the whole block; emitting it would duplicate everything
+    // already streamed as deltas.
+    it("should drop text_end so streamed text is not duplicated", () => {
+      expect(toSessionUpdate(messageUpdate({ type: "text_end", content: "Hello", contentIndex: 0 }))).toBeNull();
+    });
+
+    it("should drop thinking_end", () => {
+      expect(toSessionUpdate(messageUpdate({ type: "thinking_end", content: "hmm", contentIndex: 0 }))).toBeNull();
+    });
+
+    it("should drop an empty delta rather than emit an empty chunk", () => {
+      expect(toSessionUpdate(messageUpdate({ type: "text_delta", delta: "", contentIndex: 0 }))).toBeNull();
+    });
+
+    it("should drop stream lifecycle events", () => {
+      expect(toSessionUpdate(messageUpdate({ type: "start" }))).toBeNull();
+      expect(toSessionUpdate(messageUpdate({ type: "text_start", contentIndex: 0 }))).toBeNull();
+      expect(toSessionUpdate(messageUpdate({ type: "toolcall_delta", delta: "{", contentIndex: 0 }))).toBeNull();
+      expect(toSessionUpdate(messageUpdate({ type: "done", reason: "stop" }))).toBeNull();
+    });
+  });
+
+  describe("tool calls", () => {
+    it("should open a tool call as in_progress with its label, kind and raw input", () => {
+      const event = ev({
+        type: "tool_execution_start",
+        toolCallId: "call_1",
+        toolName: "query",
+        args: { query: "balance" },
+      });
+      expect(toSessionUpdate(event)).toEqual({
+        sessionUpdate: "tool_call",
+        toolCallId: "call_1",
+        title: "Query Ledger",
+        kind: "search",
+        status: "in_progress",
+        rawInput: { query: "balance" },
+      });
+    });
+
+    it("should complete a successful tool call with its text content", () => {
+      const result = { content: [{ type: "text", text: "1,234.00 EUR" }], details: {} };
+      const event = ev({ type: "tool_execution_end", toolCallId: "call_1", toolName: "query", result, isError: false });
+      expect(toSessionUpdate(event)).toEqual({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "call_1",
+        status: "completed",
+        content: [{ type: "content", content: { type: "text", text: "1,234.00 EUR" } }],
+        rawOutput: result,
+      });
+    });
+
+    it("should mark a failed tool call as failed", () => {
+      const event = ev({
+        type: "tool_execution_end",
+        toolCallId: "call_2",
+        toolName: "validate",
+        result: { content: [{ type: "text", text: "unbalanced" }] },
+        isError: true,
+      });
+      expect(toSessionUpdate(event)).toMatchObject({ status: "failed" });
+    });
+
+    it("should carry image content through", () => {
+      const event = ev({
+        type: "tool_execution_end",
+        toolCallId: "c",
+        toolName: "extract_text",
+        result: { content: [{ type: "image", data: "aGk=", mimeType: "image/png" }] },
+        isError: false,
+      });
+      expect(toSessionUpdate(event)).toMatchObject({
+        content: [{ type: "content", content: { type: "image", data: "aGk=", mimeType: "image/png" } }],
+      });
+    });
+
+    it("should skip malformed content parts instead of failing the update", () => {
+      const event = ev({
+        type: "tool_execution_end",
+        toolCallId: "c",
+        toolName: "query",
+        result: { content: [null, { type: "text" }, { type: "text", text: "" }, "nope", { type: "text", text: "ok" }] },
+        isError: false,
+      });
+      expect(toSessionUpdate(event)).toMatchObject({
+        content: [{ type: "content", content: { type: "text", text: "ok" } }],
+      });
+    });
+
+    it.each([
+      ["a missing result", undefined],
+      ["a null result", null],
+      ["a non-object result", "oops"],
+      ["a result with no content array", { details: {} }],
+    ])("should produce empty content for %s", (_label, result) => {
+      const event = ev({ type: "tool_execution_end", toolCallId: "c", toolName: "query", result, isError: false });
+      expect(toSessionUpdate(event)).toMatchObject({ content: [] });
+    });
+  });
+
+  describe("session info", () => {
+    it("should map a renamed session to a session_info_update", () => {
+      expect(toSessionUpdate(ev({ type: "session_info_changed", name: "Groceries" }))).toEqual({
+        sessionUpdate: "session_info_update",
+        title: "Groceries",
+      });
+    });
+
+    it("should drop a cleared session name", () => {
+      expect(toSessionUpdate(ev({ type: "session_info_changed", name: undefined }))).toBeNull();
+    });
+  });
+
+  describe("events with no ACP equivalent", () => {
+    it.each([
+      "agent_start",
+      "agent_end",
+      "turn_start",
+      "turn_end",
+      "message_start",
+      "message_end",
+      "tool_execution_update",
+      "queue_update",
+      "compaction_start",
+      "compaction_end",
+      "thinking_level_changed",
+      "auto_retry_start",
+      "auto_retry_end",
+    ])("should drop %s", (type) => {
+      expect(toSessionUpdate(ev({ type }))).toBeNull();
+    });
+  });
+});

--- a/packages/desktop/src/acp/__tests__/models.test.ts
+++ b/packages/desktop/src/acp/__tests__/models.test.ts
@@ -1,0 +1,99 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import { describe, expect, it } from "vitest";
+import { findModel, MODEL_CONFIG_ID, modelConfigOption, type PiModel, selectableModels } from "../models";
+
+const anthropic: PiModel = { provider: "anthropic", id: "claude-sonnet-5", name: "Claude Sonnet 5" };
+const openai: PiModel = { provider: "openai", id: "gpt-5.5", name: "GPT-5.5" };
+// A model id containing a slash — the provider is only the part before the first one.
+const ollama: PiModel = { provider: "ollama", id: "library/qwen3", name: "Qwen 3" };
+const all = [anthropic, openai, ollama];
+
+/** Narrow the config-option union to the select variant's choices. */
+const selectOptions = (option: SessionConfigOption | undefined) =>
+  option && option.type === "select" ? option.options : undefined;
+
+describe("selectableModels()", () => {
+  it("should return every model when no selection is stored", () => {
+    expect(selectableModels(all, undefined)).toEqual(all);
+  });
+
+  it("should return every model when the selection is empty (the 'all' sentinel)", () => {
+    expect(selectableModels(all, [])).toEqual(all);
+  });
+
+  it("should keep only the enabled models, in registry order", () => {
+    expect(selectableModels(all, ["openai/gpt-5.5", "anthropic/claude-sonnet-5"])).toEqual([anthropic, openai]);
+  });
+
+  it("should match a model id that itself contains a slash", () => {
+    expect(selectableModels(all, ["ollama/library/qwen3"])).toEqual([ollama]);
+  });
+
+  it("should fall back to all models when the selection matches nothing available", () => {
+    expect(selectableModels(all, ["removed/model"])).toEqual(all);
+  });
+
+  it("should return nothing when no models are available at all", () => {
+    expect(selectableModels([], ["anthropic/claude-sonnet-5"])).toEqual([]);
+  });
+});
+
+describe("modelConfigOption()", () => {
+  it("should build a select option in the model category", () => {
+    expect(modelConfigOption(all, undefined, openai)).toEqual({
+      id: MODEL_CONFIG_ID,
+      name: "Model",
+      category: "model",
+      type: "select",
+      currentValue: "openai/gpt-5.5",
+      options: [
+        { value: "anthropic/claude-sonnet-5", name: "Claude Sonnet 5" },
+        { value: "openai/gpt-5.5", name: "GPT-5.5" },
+        { value: "ollama/library/qwen3", name: "Qwen 3" },
+      ],
+    });
+  });
+
+  it("should return undefined when no model is available, so no picker is advertised", () => {
+    expect(modelConfigOption([], undefined, undefined)).toBeUndefined();
+  });
+
+  it("should default currentValue to the first selectable model when none is active", () => {
+    expect(modelConfigOption(all, undefined, undefined)?.currentValue).toBe("anthropic/claude-sonnet-5");
+  });
+
+  it("should list only enabled models", () => {
+    expect(selectOptions(modelConfigOption(all, ["openai/gpt-5.5"], openai))).toEqual([
+      { value: "openai/gpt-5.5", name: "GPT-5.5" },
+    ]);
+  });
+
+  it("should fall back to the model id when the model has no display name", () => {
+    expect(selectOptions(modelConfigOption([{ provider: "custom", id: "my-model" }], undefined, undefined))).toEqual([
+      { value: "custom/my-model", name: "my-model" },
+    ]);
+  });
+});
+
+describe("findModel()", () => {
+  it("should resolve a provider/modelId id", () => {
+    expect(findModel(all, "openai/gpt-5.5")).toBe(openai);
+  });
+
+  it("should resolve an id whose model part contains a slash", () => {
+    expect(findModel(all, "ollama/library/qwen3")).toBe(ollama);
+  });
+
+  it("should return undefined for an unknown model", () => {
+    expect(findModel(all, "openai/nope")).toBeUndefined();
+  });
+
+  it.each([
+    ["no slash", "gpt-5.5"],
+    ["empty provider", "/gpt-5.5"],
+    ["empty model", "openai/"],
+    ["empty string", ""],
+  ])("should return undefined for a malformed id (%s)", (_label, id) => {
+    expect(findModel(all, id)).toBeUndefined();
+  });
+});

--- a/packages/desktop/src/acp/__tests__/no-electron.test.ts
+++ b/packages/desktop/src/acp/__tests__/no-electron.test.ts
@@ -1,0 +1,64 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// The ACP entry runs under ELECTRON_RUN_AS_NODE (packaged) or plain node (dev).
+// In neither case does `require("electron")` give a usable `app`, so a single
+// stray import anywhere in this module graph breaks the launcher at runtime
+// with an error that would not show up in any other test.
+
+const ACP_DIR = resolve(fileURLToPath(new URL("..", import.meta.url)));
+
+const IMPORT_RE = /(?:^|\n)\s*(?:import|export)[\s\S]*?from\s+["']([^"']+)["']/g;
+
+function importsOf(file: string): string[] {
+  const source = readFileSync(file, "utf8");
+  return [...source.matchAll(IMPORT_RE)].map((m) => m[1]);
+}
+
+/** Resolve a relative specifier to a .ts file on disk. */
+function resolveLocal(fromFile: string, specifier: string): string | undefined {
+  const base = resolve(dirname(fromFile), specifier);
+  for (const candidate of [`${base}.ts`, join(base, "index.ts")]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/** Every source file reachable from the ACP entry, following relative imports. */
+function moduleGraph(): Map<string, string[]> {
+  const graph = new Map<string, string[]>();
+  const queue = readdirSync(ACP_DIR)
+    .filter((f) => f.endsWith(".ts"))
+    .map((f) => join(ACP_DIR, f));
+
+  while (queue.length > 0) {
+    const file = queue.pop() as string;
+    if (graph.has(file)) continue;
+    const specifiers = importsOf(file);
+    graph.set(file, specifiers);
+    for (const specifier of specifiers) {
+      if (!specifier.startsWith(".")) continue;
+      const target = resolveLocal(file, specifier);
+      if (target && !graph.has(target)) queue.push(target);
+    }
+  }
+  return graph;
+}
+
+describe("the ACP module graph", () => {
+  it("should reach more than just the entry files", () => {
+    // Guards the guard: a broken resolver would make the assertion below vacuous.
+    const graph = moduleGraph();
+    expect(graph.size).toBeGreaterThan(5);
+    expect([...graph.keys()].some((f) => f.includes(`${"main"}/agent/host/`))).toBe(true);
+  });
+
+  it("should not import electron anywhere", () => {
+    const offenders = [...moduleGraph()]
+      .filter(([, specifiers]) => specifiers.some((s) => s === "electron" || s.startsWith("electron/")))
+      .map(([file]) => file);
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/desktop/src/acp/__tests__/prompt.test.ts
+++ b/packages/desktop/src/acp/__tests__/prompt.test.ts
@@ -1,0 +1,87 @@
+import type { ContentBlock } from "@agentclientprotocol/sdk";
+import { describe, expect, it } from "vitest";
+import { toPiPrompt } from "../prompt";
+
+describe("toPiPrompt()", () => {
+  it("should return an empty prompt for no blocks", () => {
+    expect(toPiPrompt([])).toEqual({ message: "", images: [] });
+  });
+
+  it("should pass a single text block through unchanged", () => {
+    expect(toPiPrompt([{ type: "text", text: "How much did I spend?" }])).toEqual({
+      message: "How much did I spend?",
+      images: [],
+    });
+  });
+
+  it("should join multiple text blocks with a blank line", () => {
+    const blocks: ContentBlock[] = [
+      { type: "text", text: "first" },
+      { type: "text", text: "second" },
+    ];
+    expect(toPiPrompt(blocks).message).toBe("first\n\nsecond");
+  });
+
+  it("should skip an empty text block rather than emit a blank paragraph", () => {
+    const blocks: ContentBlock[] = [
+      { type: "text", text: "only" },
+      { type: "text", text: "" },
+    ];
+    expect(toPiPrompt(blocks).message).toBe("only");
+  });
+
+  it("should collect image blocks separately from the message", () => {
+    const blocks: ContentBlock[] = [
+      { type: "text", text: "what is this?" },
+      { type: "image", data: "aGk=", mimeType: "image/png" },
+    ];
+    expect(toPiPrompt(blocks)).toEqual({
+      message: "what is this?",
+      images: [{ type: "image", mimeType: "image/png", data: "aGk=" }],
+    });
+  });
+
+  it("should keep multiple images in order", () => {
+    const blocks: ContentBlock[] = [
+      { type: "image", data: "one", mimeType: "image/png" },
+      { type: "image", data: "two", mimeType: "image/jpeg" },
+    ];
+    expect(toPiPrompt(blocks).images.map((i) => i.data)).toEqual(["one", "two"]);
+  });
+
+  it("should render a resource_link as its URI", () => {
+    const blocks: ContentBlock[] = [{ type: "resource_link", uri: "file:///ws/ledger/main.journal", name: "main" }];
+    expect(toPiPrompt(blocks).message).toBe("[Context] file:///ws/ledger/main.journal");
+  });
+
+  it("should inline a text resource as a fenced block tagged with its URI", () => {
+    const blocks: ContentBlock[] = [
+      { type: "resource", resource: { uri: "file:///ws/notes.md", text: "hello", mimeType: "text/markdown" } },
+    ];
+    expect(toPiPrompt(blocks).message).toBe("[Context] file:///ws/notes.md\n```\nhello\n```");
+  });
+
+  it("should announce a binary resource by URI only, since pi cannot read the blob", () => {
+    const blocks: ContentBlock[] = [
+      { type: "resource", resource: { uri: "file:///ws/scan.pdf", blob: "JVBER", mimeType: "application/pdf" } },
+    ];
+    expect(toPiPrompt(blocks).message).toBe("[Context] file:///ws/scan.pdf");
+  });
+
+  it("should ignore an unknown block type instead of failing the turn", () => {
+    const blocks = [
+      { type: "audio", data: "x", mimeType: "audio/wav" },
+      { type: "text", text: "still here" },
+    ] as ContentBlock[];
+    expect(toPiPrompt(blocks)).toEqual({ message: "still here", images: [] });
+  });
+
+  it("should preserve the order of mixed text and context blocks", () => {
+    const blocks: ContentBlock[] = [
+      { type: "text", text: "look at" },
+      { type: "resource_link", uri: "file:///a", name: "a" },
+      { type: "text", text: "and tell me" },
+    ];
+    expect(toPiPrompt(blocks).message).toBe("look at\n\n[Context] file:///a\n\nand tell me");
+  });
+});

--- a/packages/desktop/src/acp/__tests__/server.integration.test.ts
+++ b/packages/desktop/src/acp/__tests__/server.integration.test.ts
@@ -1,0 +1,427 @@
+import {
+  client as acpClient,
+  type ClientContext,
+  methods,
+  PROTOCOL_VERSION,
+  type SessionNotification,
+  type SessionUpdate,
+} from "@agentclientprotocol/sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { AcpConfig } from "../config";
+import { type AcpDeps, createAcpAgent } from "../server";
+
+// Drives the real ACP agent over the SDK's in-process transport, with a fake pi
+// runtime standing in for the agent. Asserts the wire contract a client (Buzz,
+// Zed) actually depends on.
+
+const MODELS = [
+  { provider: "anthropic", id: "claude-sonnet-5", name: "Claude Sonnet 5" },
+  { provider: "openai", id: "gpt-5.5", name: "GPT-5.5" },
+];
+
+const config = (overrides: Partial<AcpConfig> = {}): AcpConfig =>
+  ({
+    workspace: { workspaceDir: "/ws", sessionsDir: "/ws/sessions" },
+    resources: {},
+    host: { workspaceDir: "/ws" },
+    defaultModel: undefined,
+    enabledModels: undefined,
+    version: "1.2.3",
+    ...overrides,
+  }) as AcpConfig;
+
+/** A fake pi runtime whose prompt() emits a scripted event stream. */
+function fakeRuntime(script: object[] = []) {
+  const listeners: ((event: object) => void)[] = [];
+  const session = {
+    model: MODELS[0] as unknown,
+    subscribe: (listener: (event: object) => void) => {
+      listeners.push(listener);
+      return () => {
+        listeners.splice(listeners.indexOf(listener), 1);
+      };
+    },
+    prompt: vi.fn(async () => {
+      for (const event of script) for (const l of [...listeners]) l(event);
+    }),
+    abort: vi.fn(async () => {}),
+    setModel: vi.fn(async (model: unknown) => {
+      session.model = model;
+    }),
+  };
+  return { session, dispose: vi.fn(async () => {}) };
+}
+
+interface Harness {
+  updates: SessionUpdate[];
+  runtimes: ReturnType<typeof fakeRuntime>[];
+}
+
+/** Run `op` against a live agent connection, collecting session/update notifications. */
+async function withAgent<T>(
+  op: (cx: ClientContext, h: Harness) => Promise<T>,
+  opts: { deps?: Partial<AcpDeps>; script?: object[] } = {},
+): Promise<T> {
+  const harness: Harness = { updates: [], runtimes: [] };
+  let n = 0;
+  const agentApp = createAcpAgent({
+    config: config(),
+    modelRegistry: { getAvailable: () => MODELS },
+    newSessionPath: () => `/ws/sessions/session-${++n}.jsonl`,
+    createRuntime: async () => {
+      const runtime = fakeRuntime(opts.script ?? []);
+      harness.runtimes.push(runtime);
+      return runtime as never;
+    },
+    ...opts.deps,
+  });
+
+  const clientApp = acpClient().onNotification(methods.client.session.update, (ctx) => {
+    harness.updates.push((ctx.params as SessionNotification).update);
+  });
+
+  return clientApp.connectWith(agentApp, (cx) => op(cx, harness));
+}
+
+const initialize = (cx: ClientContext) =>
+  cx.request(methods.agent.initialize, { protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} });
+
+const newSession = (cx: ClientContext, cwd = "/some/other/dir") =>
+  cx.request(methods.agent.session.new, { cwd, mcpServers: [] });
+
+const textPrompt = (text: string) => [{ type: "text" as const, text }];
+
+describe("initialize", () => {
+  it("should answer with protocol version 1 and the agent's identity", async () => {
+    const res = await withAgent((cx) => initialize(cx));
+    expect(res.protocolVersion).toBe(1);
+    expect(res.agentInfo).toEqual({ name: "accountant24", title: "Accountant24", version: "1.2.3" });
+  });
+
+  // Buzz asks for 2 as a deliberate pre-standard pin; the spec says answer with
+  // the latest version we actually support.
+  it("should still answer 1 when the client requests a newer protocol version", async () => {
+    const res = await withAgent((cx) =>
+      cx.request(methods.agent.initialize, { protocolVersion: 2, clientCapabilities: {} }),
+    );
+    expect(res.protocolVersion).toBe(1);
+  });
+
+  it("should advertise image and embedded-context prompt support but not loadSession", async () => {
+    const res = await withAgent((cx) => initialize(cx));
+    expect(res.agentCapabilities).toMatchObject({
+      loadSession: false,
+      promptCapabilities: { image: true, audio: false, embeddedContext: true },
+    });
+  });
+
+  it("should advertise no auth methods when a provider is configured", async () => {
+    const res = await withAgent((cx) => initialize(cx));
+    expect(res.authMethods).toEqual([]);
+  });
+
+  it("should point at the app when no provider is configured", async () => {
+    const res = await withAgent((cx) => initialize(cx), {
+      deps: { modelRegistry: { getAvailable: () => [] } },
+    });
+    expect(res.authMethods).toHaveLength(1);
+    expect(res.authMethods?.[0]).toMatchObject({ id: "accountant24-app" });
+  });
+
+  it("should degrade to no-provider rather than fail when the model registry throws", async () => {
+    const res = await withAgent((cx) => initialize(cx), {
+      deps: {
+        modelRegistry: {
+          getAvailable: () => {
+            throw new Error("models.json is corrupt");
+          },
+        },
+      },
+    });
+    expect(res.authMethods).toHaveLength(1);
+  });
+});
+
+describe("session/new", () => {
+  it("should return a session id and the model picker", async () => {
+    const res = await withAgent(async (cx) => newSession(cx));
+    expect(res.sessionId).toBe("/ws/sessions/session-1.jsonl");
+    expect(res.configOptions).toEqual([
+      {
+        id: "model",
+        name: "Model",
+        category: "model",
+        type: "select",
+        currentValue: "anthropic/claude-sonnet-5",
+        options: [
+          { value: "anthropic/claude-sonnet-5", name: "Claude Sonnet 5" },
+          { value: "openai/gpt-5.5", name: "GPT-5.5" },
+        ],
+      },
+    ]);
+  });
+
+  it("should apply the app's default model to the fresh session", async () => {
+    const { runtimes } = await withAgent(
+      async (cx, h) => {
+        await newSession(cx);
+        return h;
+      },
+      { deps: { config: config({ defaultModel: "openai/gpt-5.5" }) } },
+    );
+    expect(runtimes[0].session.setModel).toHaveBeenCalledWith(MODELS[1]);
+  });
+
+  it("should leave pi's own default alone when the configured model is unavailable", async () => {
+    const { runtimes } = await withAgent(
+      async (cx, h) => {
+        await newSession(cx);
+        return h;
+      },
+      { deps: { config: config({ defaultModel: "removed/model" }) } },
+    );
+    expect(runtimes[0].session.setModel).not.toHaveBeenCalled();
+  });
+
+  it("should offer no picker when no model is available", async () => {
+    const res = await withAgent(async (cx) => newSession(cx), {
+      deps: { modelRegistry: { getAvailable: () => [] } },
+    });
+    expect(res.configOptions).toEqual([]);
+  });
+
+  it("should give concurrent sessions distinct ids", async () => {
+    const [a, b] = await withAgent(async (cx) => Promise.all([newSession(cx), newSession(cx)]));
+    expect(a.sessionId).not.toBe(b.sessionId);
+  });
+
+  // Deliberate deviations, both documented in the Connect docs page. They are
+  // reported on stderr so the reason is visible in the client's agent log.
+  describe("deliberate deviations", () => {
+    it("should ignore the client's cwd and say so, since it always works on the ledger", async () => {
+      const log = vi.fn();
+      await withAgent(async (cx) => newSession(cx, "/some/other/dir"), { deps: { log } });
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("ignoring client cwd /some/other/dir"));
+    });
+
+    it("should not log when the client's cwd already is the workspace", async () => {
+      const log = vi.fn();
+      await withAgent(async (cx) => newSession(cx, "/ws"), { deps: { log } });
+      expect(log).not.toHaveBeenCalledWith(expect.stringContaining("ignoring client cwd"));
+    });
+
+    it("should ignore MCP servers and say so, since the pi SDK has no MCP client", async () => {
+      const log = vi.fn();
+      const res = await withAgent(
+        async (cx) =>
+          cx.request(methods.agent.session.new, {
+            cwd: "/ws",
+            mcpServers: [{ name: "files", command: "mcp-files", args: [], env: [] }],
+          }),
+        { deps: { log } },
+      );
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("ignoring 1 MCP server"));
+      // Ignored, not rejected: the session still opens.
+      expect(res.sessionId).toBeTruthy();
+    });
+  });
+});
+
+describe("session/prompt", () => {
+  it("should stream assistant text and end the turn", async () => {
+    const script = [
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "You spent " } },
+      { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "42 EUR." } },
+    ];
+    const { res, updates } = await withAgent(
+      async (cx, h) => {
+        const { sessionId } = await newSession(cx);
+        const res = await cx.request(methods.agent.session.prompt, {
+          sessionId,
+          prompt: textPrompt("how much did I spend?"),
+        });
+        return { res, updates: h.updates };
+      },
+      { script },
+    );
+
+    expect(res).toEqual({ stopReason: "end_turn" });
+    expect(updates).toEqual([
+      { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "You spent " } },
+      { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "42 EUR." } },
+    ]);
+  });
+
+  it("should report tool calls as they start and finish", async () => {
+    const script = [
+      { type: "tool_execution_start", toolCallId: "c1", toolName: "query", args: { q: "balance" } },
+      {
+        type: "tool_execution_end",
+        toolCallId: "c1",
+        toolName: "query",
+        result: { content: [{ type: "text", text: "42 EUR" }] },
+        isError: false,
+      },
+    ];
+    const updates = await withAgent(
+      async (cx, h) => {
+        const { sessionId } = await newSession(cx);
+        await cx.request(methods.agent.session.prompt, { sessionId, prompt: textPrompt("balance?") });
+        return h.updates;
+      },
+      { script },
+    );
+
+    expect(updates[0]).toMatchObject({
+      sessionUpdate: "tool_call",
+      toolCallId: "c1",
+      title: "Query Ledger",
+      kind: "search",
+      status: "in_progress",
+    });
+    expect(updates[1]).toMatchObject({ sessionUpdate: "tool_call_update", toolCallId: "c1", status: "completed" });
+  });
+
+  it("should pass the prompt text through to pi", async () => {
+    const { runtimes } = await withAgent(async (cx, h) => {
+      const { sessionId } = await newSession(cx);
+      await cx.request(methods.agent.session.prompt, { sessionId, prompt: textPrompt("hello") });
+      return h;
+    });
+    expect(runtimes[0].session.prompt).toHaveBeenCalledWith("hello", expect.objectContaining({ images: [] }));
+  });
+
+  it("should reject an unknown session with invalid params", async () => {
+    await expect(
+      withAgent((cx) => cx.request(methods.agent.session.prompt, { sessionId: "nope", prompt: textPrompt("hi") })),
+    ).rejects.toMatchObject({ code: -32602 });
+  });
+
+  // The SDK maps its authRequired helper to -32000 (it uses -32002 for
+  // resource-not-found), so assert the helper's real code.
+  it("should fail with auth_required when no provider is configured", async () => {
+    await expect(
+      withAgent(
+        async (cx) => {
+          const { sessionId } = await newSession(cx);
+          return cx.request(methods.agent.session.prompt, { sessionId, prompt: textPrompt("hi") });
+        },
+        { deps: { modelRegistry: { getAvailable: () => [] } } },
+      ),
+    ).rejects.toMatchObject({ code: -32000 });
+  });
+});
+
+describe("session/cancel", () => {
+  it("should abort the run and resolve the turn as cancelled", async () => {
+    const { res, runtimes } = await withAgent(async (cx, h) => {
+      const { sessionId } = await newSession(cx);
+      // Cancel lands while the prompt is in flight.
+      h.runtimes[0].session.prompt.mockImplementation(async () => {
+        await cx.notify(methods.agent.session.cancel, { sessionId });
+      });
+      const res = await cx.request(methods.agent.session.prompt, { sessionId, prompt: textPrompt("long one") });
+      return { res, runtimes: h.runtimes };
+    });
+
+    expect(res).toEqual({ stopReason: "cancelled" });
+    expect(runtimes[0].session.abort).toHaveBeenCalled();
+  });
+
+  it("should treat a thrown abort as cancelled rather than an error", async () => {
+    const res = await withAgent(async (cx, h) => {
+      const { sessionId } = await newSession(cx);
+      h.runtimes[0].session.prompt.mockImplementation(async () => {
+        await cx.notify(methods.agent.session.cancel, { sessionId });
+        throw new Error("The operation was aborted");
+      });
+      return cx.request(methods.agent.session.prompt, { sessionId, prompt: textPrompt("long one") });
+    });
+    expect(res).toEqual({ stopReason: "cancelled" });
+  });
+
+  it("should surface a genuine failure instead of swallowing it", async () => {
+    await expect(
+      withAgent(async (cx, h) => {
+        const { sessionId } = await newSession(cx);
+        h.runtimes[0].session.prompt.mockImplementation(async () => {
+          throw new Error("provider exploded");
+        });
+        return cx.request(methods.agent.session.prompt, { sessionId, prompt: textPrompt("hi") });
+      }),
+    ).rejects.toThrow(/provider exploded/);
+  });
+
+  it("should ignore a cancel for an unknown session", async () => {
+    await expect(
+      withAgent(async (cx) => cx.notify(methods.agent.session.cancel, { sessionId: "nope" })),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("session/set_config_option", () => {
+  it("should switch the model and return the complete option list", async () => {
+    const { res, runtimes } = await withAgent(async (cx, h) => {
+      const { sessionId } = await newSession(cx);
+      const res = await cx.request(methods.agent.session.setConfigOption, {
+        sessionId,
+        configId: "model",
+        value: "openai/gpt-5.5",
+      });
+      return { res, runtimes: h.runtimes };
+    });
+
+    expect(runtimes[0].session.setModel).toHaveBeenCalledWith(MODELS[1]);
+    expect(res.configOptions).toHaveLength(1);
+    expect(res.configOptions[0]).toMatchObject({ id: "model", currentValue: "openai/gpt-5.5" });
+  });
+
+  it("should also broadcast the change as a config_option_update", async () => {
+    const updates = await withAgent(async (cx, h) => {
+      const { sessionId } = await newSession(cx);
+      await cx.request(methods.agent.session.setConfigOption, {
+        sessionId,
+        configId: "model",
+        value: "openai/gpt-5.5",
+      });
+      return h.updates;
+    });
+    expect(updates).toContainEqual(expect.objectContaining({ sessionUpdate: "config_option_update" }));
+  });
+
+  it("should reject an unknown config id", async () => {
+    await expect(
+      withAgent(async (cx) => {
+        const { sessionId } = await newSession(cx);
+        return cx.request(methods.agent.session.setConfigOption, { sessionId, configId: "theme", value: "dark" });
+      }),
+    ).rejects.toMatchObject({ code: -32602 });
+  });
+
+  it("should reject an unknown model value", async () => {
+    await expect(
+      withAgent(async (cx) => {
+        const { sessionId } = await newSession(cx);
+        return cx.request(methods.agent.session.setConfigOption, {
+          sessionId,
+          configId: "model",
+          value: "nope/nope",
+        });
+      }),
+    ).rejects.toMatchObject({ code: -32602 });
+  });
+});
+
+describe("unsupported methods", () => {
+  // Buzz probes extension methods and treats a `{}` success as "delivered"; the
+  // only safe answer for something we do not implement is method-not-found.
+  it("should answer method not found rather than a bare success", async () => {
+    await expect(withAgent((cx) => cx.request("_some/extension/method", {}))).rejects.toMatchObject({ code: -32601 });
+  });
+
+  it("should answer method not found for session/load, which we do not advertise", async () => {
+    await expect(
+      withAgent((cx) => cx.request(methods.agent.session.load, { sessionId: "x", cwd: "/ws", mcpServers: [] })),
+    ).rejects.toMatchObject({ code: -32601 });
+  });
+});

--- a/packages/desktop/src/acp/__tests__/sessions.test.ts
+++ b/packages/desktop/src/acp/__tests__/sessions.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest";
+import type { UiBridge } from "../../main/agent/host/host";
+import { autoAnsweringUi, SessionStore } from "../sessions";
+
+/** A fake pi runtime; only the slice the store touches. */
+function fakeRuntime() {
+  const listeners: ((event: object) => void)[] = [];
+  return {
+    listeners,
+    session: {
+      subscribe: vi.fn((listener: (event: object) => void) => {
+        listeners.push(listener);
+        return () => {
+          listeners.splice(listeners.indexOf(listener), 1);
+        };
+      }),
+      abort: vi.fn(async () => {}),
+    },
+    dispose: vi.fn(async () => {}),
+  };
+}
+
+/** Register a waiter the way pi's extension UI context does, then emit. */
+function askDialog(ui: UiBridge, id: string, method: string): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    ui.pending.set(id, { resolve, reject });
+    ui.emit({ type: "extension_ui_request", id, method });
+  });
+}
+
+describe("autoAnsweringUi()", () => {
+  // A blocking dialog with nobody to answer it would hang the turn forever,
+  // and ACP has no way to surface one.
+  it("should confirm a blocking confirm dialog", async () => {
+    const ui = autoAnsweringUi();
+    await expect(askDialog(ui, "ui1", "confirm")).resolves.toEqual({ confirmed: true });
+  });
+
+  it("should answer an input dialog with an empty value", async () => {
+    const ui = autoAnsweringUi();
+    await expect(askDialog(ui, "ui1", "input")).resolves.toEqual({ confirmed: true, value: "" });
+  });
+
+  it("should answer select and editor dialogs too", async () => {
+    const ui = autoAnsweringUi();
+    await expect(askDialog(ui, "ui1", "select")).resolves.toEqual({ confirmed: true });
+    await expect(askDialog(ui, "ui2", "editor")).resolves.toEqual({ confirmed: true });
+  });
+
+  it("should not leak the waiter once answered", async () => {
+    const ui = autoAnsweringUi();
+    await askDialog(ui, "ui1", "confirm");
+    expect(ui.pending.size).toBe(0);
+  });
+
+  it("should ignore display-only events, which register no waiter", () => {
+    const ui = autoAnsweringUi();
+    expect(() => ui.emit({ type: "extension_ui_request", id: "ui9", method: "notify", message: "hi" })).not.toThrow();
+    expect(ui.pending.size).toBe(0);
+  });
+
+  it("should ignore an event with no id", () => {
+    const ui = autoAnsweringUi();
+    expect(() => ui.emit({ type: "extension_ui_request", method: "notify" })).not.toThrow();
+  });
+});
+
+describe("SessionStore", () => {
+  const open = (store: SessionStore, id: string, runtime = fakeRuntime(), onEvent = vi.fn()) =>
+    store.open(id, async () => runtime as never, onEvent).then((session) => ({ session, runtime, onEvent }));
+
+  it("should expose an opened session by id", async () => {
+    const store = new SessionStore();
+    const { session } = await open(store, "s1");
+    expect(store.get("s1")).toBe(session);
+    expect(session.cancelled).toBe(false);
+  });
+
+  it("should return undefined for an unknown id", () => {
+    expect(new SessionStore().get("nope")).toBeUndefined();
+  });
+
+  it("should forward runtime events to the listener", async () => {
+    const store = new SessionStore();
+    const { runtime, onEvent } = await open(store, "s1");
+    runtime.listeners[0]({ type: "agent_start" });
+    expect(onEvent).toHaveBeenCalledWith({ type: "agent_start" });
+  });
+
+  it("should abort, dispose and forget the session on dispose", async () => {
+    const store = new SessionStore();
+    const { session, runtime } = await open(store, "s1");
+    await session.dispose();
+
+    expect(runtime.session.abort).toHaveBeenCalled();
+    expect(runtime.dispose).toHaveBeenCalled();
+    expect(store.get("s1")).toBeUndefined();
+  });
+
+  it("should stop forwarding events after dispose", async () => {
+    const store = new SessionStore();
+    const { session, runtime, onEvent } = await open(store, "s1");
+    await session.dispose();
+    expect(runtime.listeners).toHaveLength(0);
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+
+  it("should still forget the session when teardown throws", async () => {
+    const store = new SessionStore();
+    const runtime = fakeRuntime();
+    runtime.session.abort.mockRejectedValue(new Error("already gone"));
+    const { session } = await open(store, "s1", runtime);
+
+    await expect(session.dispose()).resolves.toBeUndefined();
+    expect(store.get("s1")).toBeUndefined();
+  });
+
+  it("should dispose every open session", async () => {
+    const store = new SessionStore();
+    const a = await open(store, "s1");
+    const b = await open(store, "s2");
+
+    await store.disposeAll();
+
+    expect(a.runtime.dispose).toHaveBeenCalled();
+    expect(b.runtime.dispose).toHaveBeenCalled();
+    expect(store.get("s1")).toBeUndefined();
+    expect(store.get("s2")).toBeUndefined();
+  });
+});

--- a/packages/desktop/src/acp/__tests__/tools.test.ts
+++ b/packages/desktop/src/acp/__tests__/tools.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { TOOL_LABELS as EXTENSION_LABELS } from "../../../../pi-extension/src/tool-labels";
+import { TOOL_LABELS as RENDERER_LABELS } from "../../renderer/lib/tool-labels";
+import { EXTENSION_TOOLS, toolKind, toolTitle } from "../tools";
+
+describe("tool label maps", () => {
+  // The three copies exist so neither the renderer nor this node-side module
+  // imports the agent package. This is the guard that keeps them honest: a tool
+  // renamed in one place fails here instead of silently showing a raw name.
+  it("should agree across the extension, renderer and ACP copies", () => {
+    const acpLabels = Object.fromEntries(Object.entries(EXTENSION_TOOLS).map(([name, t]) => [name, t.label]));
+    expect(acpLabels).toEqual(EXTENSION_LABELS);
+    expect(RENDERER_LABELS).toEqual(EXTENSION_LABELS);
+  });
+});
+
+describe("toolTitle()", () => {
+  it("should return 'Query Ledger' for query", () => {
+    expect(toolTitle("query")).toBe("Query Ledger");
+  });
+
+  it("should return 'Commit & Push' for commit_and_push", () => {
+    expect(toolTitle("commit_and_push")).toBe("Commit & Push");
+  });
+
+  it("should label pi's built-in tools too", () => {
+    expect(toolTitle("bash")).toBe("Bash");
+    expect(toolTitle("read")).toBe("Read");
+  });
+
+  it("should prettify an unknown snake_case name", () => {
+    expect(toolTitle("some_new_tool")).toBe("Some new tool");
+  });
+
+  it("should prettify an unknown kebab-case name", () => {
+    expect(toolTitle("some-new-tool")).toBe("Some new tool");
+  });
+
+  it("should return the capitalized name for an unknown single word", () => {
+    expect(toolTitle("frobnicate")).toBe("Frobnicate");
+  });
+
+  it("should return an empty string for an empty name", () => {
+    expect(toolTitle("")).toBe("");
+  });
+});
+
+describe("toolKind()", () => {
+  it("should classify query as search", () => {
+    expect(toolKind("query")).toBe("search");
+  });
+
+  it("should classify every ledger-writing tool as edit", () => {
+    for (const name of ["add_transactions", "add_balance_assertions", "add_prices", "update_memory"]) {
+      expect(toolKind(name)).toBe("edit");
+    }
+  });
+
+  it("should classify extract_text as read", () => {
+    expect(toolKind("extract_text")).toBe("read");
+  });
+
+  it("should classify validate as think", () => {
+    expect(toolKind("validate")).toBe("think");
+  });
+
+  it("should classify commit_and_push and bash as execute", () => {
+    expect(toolKind("commit_and_push")).toBe("execute");
+    expect(toolKind("bash")).toBe("execute");
+  });
+
+  it("should fall back to other for an unknown tool", () => {
+    expect(toolKind("some_new_tool")).toBe("other");
+  });
+});

--- a/packages/desktop/src/acp/config.ts
+++ b/packages/desktop/src/acp/config.ts
@@ -1,0 +1,108 @@
+// Config for the ACP process, resolved without Electron.
+//
+// main/env.ts gets the resource dir from Electron's `app`; here it comes from
+// the launcher via ACCOUNTANT24_RESOURCES, falling back to a probe relative to
+// this module so `node out/main/acp.js` works in dev too.
+
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  agentEnv,
+  agentHostConfig,
+  type ResourcePaths,
+  resourcePaths,
+  type WorkspacePaths,
+  workspacePaths,
+} from "../main/agent/host/workspace";
+import { readAppSettings } from "../main/app-settings";
+import type { AgentHostConfig } from "../shared/agentHost";
+
+export interface AcpConfig {
+  workspace: WorkspacePaths;
+  resources: ResourcePaths;
+  host: AgentHostConfig;
+  /** `provider/modelId` the user picked in the app, when set. */
+  defaultModel: string | undefined;
+  /** Model ids the user enabled in the app; empty/undefined means all. */
+  enabledModels: string[] | undefined;
+  /** Reported to the client in `agentInfo`. */
+  version: string;
+}
+
+/** A resource dir is the real one if it holds the assets the agent needs. */
+function looksLikeResourceDir(dir: string): boolean {
+  return existsSync(`${dir}/system.md`) && existsSync(`${dir}/accountant24-extension.js`);
+}
+
+/**
+ * Where the vendored tools, extension bundle and system prompt live.
+ *
+ * The launcher exports ACCOUNTANT24_RESOURCES, so the probe below only matters
+ * when running the built entry directly. Two layouts:
+ *
+ *   dev       packages/desktop/out/main/acp.js         → ../../resources
+ *   packaged  …/Contents/Resources/app/out/main/acp.js → ../../..
+ *
+ * (asar is disabled, so the packaged app tree really is on disk under app/.)
+ */
+export function resolveResourceDir(moduleUrl: string = import.meta.url): string {
+  const fromEnv = process.env.ACCOUNTANT24_RESOURCES;
+  if (fromEnv && fromEnv.length > 0) return fromEnv;
+  const candidates = ["../../resources", "../../.."].map((rel) =>
+    fileURLToPath(new URL(rel, moduleUrl)).replace(/(.)\/$/, "$1"),
+  );
+  return candidates.find(looksLikeResourceDir) ?? candidates[0];
+}
+
+/** The app version, read from the package.json two levels above the built entry. */
+function readVersion(moduleUrl: string): string {
+  try {
+    const pkg = fileURLToPath(new URL("../../package.json", moduleUrl));
+    const parsed = JSON.parse(readFileSync(pkg, "utf8")) as { version?: unknown };
+    return typeof parsed.version === "string" ? parsed.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+/**
+ * Resolve everything the ACP server needs AND make this process look like the
+ * agent host: same env, same working directory.
+ *
+ * Both are load bearing, not cosmetic.
+ *
+ * The env: the extension spawns bare `hledger`, `pdftotext` and `tesseract`, so
+ * without the vendored bin/ on PATH and TESSDATA_PREFIX set they silently
+ * resolve to a system install or throw.
+ *
+ * The cwd: an ACP client spawns us from wherever it likes (Buzz uses ~/.buzz),
+ * but pi stamps `process.cwd()` into the header of every new session file, and
+ * `SessionManager.list(cwd, sessionDir)` filters on that header. Leave it alone
+ * and chats started over ACP never show up in the app's chat list. The desktop
+ * app gets this for free by forking the agent host with cwd set to the
+ * workspace; here we have to adopt it ourselves.
+ *
+ * All of it must happen before the pi runtime loads the extension.
+ */
+export function loadAcpConfig(moduleUrl: string = import.meta.url): AcpConfig {
+  const resources = resourcePaths(resolveResourceDir(moduleUrl));
+  const workspace = workspacePaths();
+
+  const env = agentEnv(workspace, resources);
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value === "string") process.env[key] = value;
+  }
+
+  mkdirSync(workspace.sessionsDir, { recursive: true });
+  process.chdir(workspace.workspaceDir);
+
+  const settings = readAppSettings(workspace);
+  return {
+    workspace,
+    resources,
+    host: agentHostConfig(workspace, resources),
+    defaultModel: settings.defaultModel,
+    enabledModels: settings.enabledModels,
+    version: readVersion(moduleUrl),
+  };
+}

--- a/packages/desktop/src/acp/events.ts
+++ b/packages/desktop/src/acp/events.ts
@@ -1,0 +1,78 @@
+// pi session events → ACP session/update notifications.
+//
+// Pure and total: every pi event maps to at most one ACP update, and anything
+// without an ACP equivalent (turn bookkeeping, compaction, queue changes) maps
+// to null and is dropped. Keeping this a plain function is what makes the whole
+// translation testable without a running agent.
+
+import type { ContentBlock, SessionUpdate, ToolCallContent } from "@agentclientprotocol/sdk";
+import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
+import { toolKind, toolTitle } from "./tools";
+
+/** pi's AgentToolResult, narrowed to what we can render. `result` is typed
+ *  `any` on the event, so treat every field as untrusted. */
+function toolResultContent(result: unknown): ToolCallContent[] {
+  if (!result || typeof result !== "object") return [];
+  const content = (result as { content?: unknown }).content;
+  if (!Array.isArray(content)) return [];
+  const blocks: ToolCallContent[] = [];
+  for (const part of content) {
+    if (!part || typeof part !== "object") continue;
+    const { type, text, data, mimeType } = part as {
+      type?: unknown;
+      text?: unknown;
+      data?: unknown;
+      mimeType?: unknown;
+    };
+    if (type === "text" && typeof text === "string" && text.length > 0) {
+      blocks.push({ type: "content", content: { type: "text", text } });
+    } else if (type === "image" && typeof data === "string" && typeof mimeType === "string") {
+      blocks.push({ type: "content", content: { type: "image", data, mimeType } });
+    }
+  }
+  return blocks;
+}
+
+const textChunk = (text: string, kind: "agent_message_chunk" | "agent_thought_chunk"): SessionUpdate =>
+  ({ sessionUpdate: kind, content: { type: "text", text } satisfies ContentBlock }) as SessionUpdate;
+
+/** Translate one pi event, or null when it has no ACP equivalent. */
+export function toSessionUpdate(event: AgentSessionEvent): SessionUpdate | null {
+  switch (event.type) {
+    case "message_update": {
+      const delta = event.assistantMessageEvent;
+      // Only the deltas carry incremental text; the *_end variants repeat the
+      // whole block and would duplicate everything already streamed.
+      if (delta.type === "text_delta" && delta.delta) return textChunk(delta.delta, "agent_message_chunk");
+      if (delta.type === "thinking_delta" && delta.delta) return textChunk(delta.delta, "agent_thought_chunk");
+      return null;
+    }
+
+    case "tool_execution_start":
+      return {
+        sessionUpdate: "tool_call",
+        toolCallId: event.toolCallId,
+        title: toolTitle(event.toolName),
+        kind: toolKind(event.toolName),
+        // pi only emits this once the call is actually running, so there is no
+        // "pending" phase to represent.
+        status: "in_progress",
+        rawInput: event.args,
+      };
+
+    case "tool_execution_end":
+      return {
+        sessionUpdate: "tool_call_update",
+        toolCallId: event.toolCallId,
+        status: event.isError ? "failed" : "completed",
+        content: toolResultContent(event.result),
+        rawOutput: event.result,
+      };
+
+    case "session_info_changed":
+      return event.name ? { sessionUpdate: "session_info_update", title: event.name } : null;
+
+    default:
+      return null;
+  }
+}

--- a/packages/desktop/src/acp/index.ts
+++ b/packages/desktop/src/acp/index.ts
@@ -1,0 +1,65 @@
+// Entry for the ACP agent: stdio wiring only, all logic lives in server.ts and
+// the translation modules (this file is excluded from coverage as entry glue).
+//
+// Launched by an ACP client via resources/accountant24-acp. Nothing here may
+// import Electron: this process runs under ELECTRON_RUN_AS_NODE (packaged) or
+// plain node (dev).
+
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+import { Readable, Writable } from "node:stream";
+import { ndJsonStream } from "@agentclientprotocol/sdk";
+import { createPiRuntimeFactory, createRegistries } from "../main/agent/host/runtime";
+import { loadAcpConfig } from "./config";
+import { createAcpAgent } from "./server";
+
+// stdout IS the protocol stream: one stray line corrupts it and the client
+// drops the connection. Capture the real writer for the transport, then send
+// everything else (pi's own console output included) to stderr, which ACP
+// reserves for logging.
+const writeStdout = process.stdout.write.bind(process.stdout);
+process.stdout.write = process.stderr.write.bind(process.stderr) as typeof process.stdout.write;
+const log = (message: string): void => {
+  process.stderr.write(`[accountant24-acp] ${message}\n`);
+};
+
+// Adopts the workspace: agent env (PATH with the vendored hledger, …) and cwd.
+// Must happen before the runtime loads the extension.
+const config = loadAcpConfig();
+
+const registries = createRegistries(config.host.workspaceDir);
+
+// Writes through the captured stdout, not the patched process.stdout.
+const protocolOut = new Writable({
+  write(chunk, _encoding, callback) {
+    writeStdout(chunk);
+    callback();
+  },
+});
+
+const stream = ndJsonStream(
+  Writable.toWeb(protocolOut) as WritableStream<Uint8Array>,
+  Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>,
+);
+
+const app = createAcpAgent({
+  config,
+  createRuntime: createPiRuntimeFactory(config.host, registries),
+  modelRegistry: registries.modelRegistry,
+  // Same scheme as the desktop app's router, so ACP chats sit alongside the
+  // app's own in ~/Accountant24/sessions.
+  newSessionPath: () =>
+    resolve(config.workspace.sessionsDir, `${new Date().toISOString().replace(/[:.]/g, "-")}_${randomUUID()}.jsonl`),
+  log,
+});
+
+const connection = app.connect(stream);
+log(`ready (protocol v1, workspace ${config.workspace.workspaceDir})`);
+
+connection.closed.then(
+  () => process.exit(0),
+  (error: unknown) => {
+    log(`connection closed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  },
+);

--- a/packages/desktop/src/acp/models.ts
+++ b/packages/desktop/src/acp/models.ts
@@ -1,0 +1,59 @@
+// The model picker an ACP client renders, expressed as an ACP session config
+// option with category "model" (the stable replacement for the removed
+// session/set_model). Buzz reads exactly this out of the session/new response to
+// decide whether to show its Model control; Zed uses it for /model.
+//
+// The `provider/modelId` id scheme and the enabled-list semantics are shared
+// with the app's own picker: renderer/lib/enabledModels.ts is pure,
+// dependency-free logic, and a second copy of its empty-selection and
+// no-match fallbacks would be a drift hazard rather than a decoupling win.
+
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import { filterEnabledModels, modelId, parseModelId } from "../renderer/lib/enabledModels";
+
+/** The slice of pi's Model this module needs. */
+export interface PiModel {
+  provider: string;
+  id: string;
+  name?: string;
+}
+
+/** ACP config id for the model selector. */
+export const MODEL_CONFIG_ID = "model";
+
+const toEntry = (m: PiModel) => ({ provider: m.provider, modelId: m.id, name: m.name });
+
+/** Models the user has enabled, in registry order. An empty or unmatched
+ *  selection means "all", so a client never gets an empty picker. */
+export function selectableModels(available: readonly PiModel[], enabledIds: readonly string[] | undefined): PiModel[] {
+  const enabled = filterEnabledModels(available.map(toEntry), enabledIds);
+  const allowed = new Set(enabled.map(modelId));
+  return available.filter((m) => allowed.has(modelId(toEntry(m))));
+}
+
+/** Build the `model` select option, or undefined when no model is available
+ *  (an unauthenticated workspace) so we advertise no picker at all. */
+export function modelConfigOption(
+  available: readonly PiModel[],
+  enabledIds: readonly string[] | undefined,
+  current: PiModel | undefined,
+): SessionConfigOption | undefined {
+  const models = selectableModels(available, enabledIds);
+  if (models.length === 0) return undefined;
+  const currentValue = current ? modelId(toEntry(current)) : modelId(toEntry(models[0]));
+  return {
+    id: MODEL_CONFIG_ID,
+    name: "Model",
+    category: "model",
+    type: "select",
+    currentValue,
+    options: models.map((m) => ({ value: modelId(toEntry(m)), name: m.name ?? m.id })),
+  };
+}
+
+/** Resolve a `provider/modelId` id against the available models. */
+export function findModel<T extends PiModel>(available: readonly T[], id: string): T | undefined {
+  const parsed = parseModelId(id);
+  if (!parsed) return undefined;
+  return available.find((m) => m.provider === parsed.provider && m.id === parsed.modelId);
+}

--- a/packages/desktop/src/acp/prompt.ts
+++ b/packages/desktop/src/acp/prompt.ts
@@ -1,0 +1,61 @@
+// ACP prompt content blocks → pi's prompt(text, { images }) arguments.
+//
+// The spec requires every agent to accept `text` and `resource_link`; we also
+// advertise `image` and `embeddedContext`, so `image` and `resource` are handled
+// here too. Anything else is ignored rather than rejected, so a client sending a
+// block type we do not know cannot fail the whole turn.
+
+import type { ContentBlock } from "@agentclientprotocol/sdk";
+
+/** pi's ImageContent, as accepted by AgentSession.prompt({ images }). */
+export interface PiImage {
+  type: "image";
+  mimeType: string;
+  data: string;
+}
+
+export interface PiPrompt {
+  message: string;
+  images: PiImage[];
+}
+
+export function toPiPrompt(blocks: ContentBlock[]): PiPrompt {
+  const parts: string[] = [];
+  const images: PiImage[] = [];
+
+  for (const block of blocks) {
+    switch (block.type) {
+      case "text":
+        if (block.text) parts.push(block.text);
+        break;
+
+      case "image":
+        images.push({ type: "image", mimeType: block.mimeType, data: block.data });
+        break;
+
+      // A link to context the client did not inline. The agent cannot fetch it,
+      // so pass the URI through as text and let the model ask about it.
+      case "resource_link":
+        parts.push(`[Context] ${block.uri}`);
+        break;
+
+      // Inlined context (an @-mention in Zed, say). Text resources become a
+      // fenced block tagged with their URI; binary ones only announce the URI,
+      // since pi has no way to consume the blob.
+      case "resource": {
+        const resource = block.resource;
+        if ("text" in resource) {
+          parts.push(`[Context] ${resource.uri}\n\`\`\`\n${resource.text}\n\`\`\``);
+        } else {
+          parts.push(`[Context] ${resource.uri}`);
+        }
+        break;
+      }
+
+      default:
+        break;
+    }
+  }
+
+  return { message: parts.join("\n\n"), images };
+}

--- a/packages/desktop/src/acp/server.ts
+++ b/packages/desktop/src/acp/server.ts
@@ -1,0 +1,193 @@
+// The ACP agent: the handlers an ACP client (Buzz, Zed, …) drives over stdio.
+//
+// Deliberate deviations from a generic coding agent, both documented in the
+// Connect docs page:
+//
+//   * `cwd` from session/new is ignored. Accountant24 is a ledger agent, so it
+//     always works on ~/Accountant24 rather than on whatever folder the client
+//     happens to be sitting in.
+//   * `mcpServers` is ignored (logged to stderr). The pi SDK has no MCP client.
+//
+// We never call the client's fs/* or terminal/* methods: our tools run inside
+// the workspace with the vendored binaries.
+
+import {
+  type AgentApp,
+  type AgentContext,
+  agent,
+  type InitializeResponse,
+  methods,
+  type NewSessionResponse,
+  PROTOCOL_VERSION,
+  type PromptResponse,
+  RequestError,
+  type SessionConfigOption,
+  type SetSessionConfigOptionResponse,
+} from "@agentclientprotocol/sdk";
+import type { AcpConfig } from "./config";
+import { toSessionUpdate } from "./events";
+import { findModel, MODEL_CONFIG_ID, modelConfigOption, type PiModel } from "./models";
+import { toPiPrompt } from "./prompt";
+import { SessionStore } from "./sessions";
+
+/** The slice of pi's ModelRegistry this module needs. */
+export interface AcpModelRegistry {
+  getAvailable(): PiModel[] | Promise<PiModel[]>;
+}
+
+export interface AcpDeps {
+  config: AcpConfig;
+  createRuntime: Parameters<SessionStore["open"]>[1];
+  modelRegistry: AcpModelRegistry;
+  /** Mints a fresh pi session-file path; the ACP sessionId. */
+  newSessionPath: () => string;
+  /** Diagnostics sink. stdout is the protocol stream, so this must not use it. */
+  log?: (message: string) => void;
+}
+
+/** Shown when the workspace has no configured provider. ACP's `terminal` and
+ *  `env_var` auth methods do not fit: credentials are set up in the app's UI. */
+const APP_AUTH_METHOD = {
+  id: "accountant24-app",
+  name: "Connect a provider in Accountant24",
+  description: "Open Accountant24, then go to Settings, Providers and connect a model provider.",
+};
+
+const NO_MODEL_MESSAGE =
+  "No model provider is configured. Open Accountant24, go to Settings, Providers and connect one, then try again.";
+
+export function createAcpAgent(deps: AcpDeps): AgentApp {
+  const { config, modelRegistry, newSessionPath } = deps;
+  const log = deps.log ?? (() => {});
+  const store = new SessionStore();
+  let client: AgentContext | undefined;
+
+  const available = async (): Promise<PiModel[]> => {
+    try {
+      return await modelRegistry.getAvailable();
+    } catch {
+      // A malformed models.json must not take down the handshake; it surfaces
+      // as "no provider configured" instead.
+      return [];
+    }
+  };
+
+  const currentModel = (session: { runtime: { session: { model?: unknown } } }): PiModel | undefined => {
+    const model = session.runtime.session.model as PiModel | undefined;
+    return model && typeof model.provider === "string" ? model : undefined;
+  };
+
+  const configOptions = async (session: Parameters<typeof currentModel>[0]): Promise<SessionConfigOption[]> => {
+    const option = modelConfigOption(await available(), config.enabledModels, currentModel(session));
+    return option ? [option] : [];
+  };
+
+  const require = (sessionId: string) => {
+    const session = store.get(sessionId);
+    if (!session) throw RequestError.invalidParams(undefined, `Unknown sessionId: ${sessionId}`);
+    return session;
+  };
+
+  return agent({ name: "accountant24" })
+    .onConnect((connection) => {
+      // Session updates are streamed outside any inbound request, so they need
+      // a connection-scoped context rather than a handler's.
+      client = connection.client;
+    })
+
+    .onRequest(methods.agent.initialize, async (): Promise<InitializeResponse> => {
+      const models = await available();
+      return {
+        protocolVersion: PROTOCOL_VERSION,
+        agentInfo: { name: "accountant24", title: "Accountant24", version: config.version },
+        agentCapabilities: {
+          // Sessions are replayable JSONL on disk, but replaying them as
+          // session/update notifications is not implemented yet.
+          loadSession: false,
+          promptCapabilities: { image: true, audio: false, embeddedContext: true },
+          mcpCapabilities: { http: false, sse: false },
+        },
+        // Advertising an auth method with no way to satisfy it in-protocol would
+        // be worse than none, so this only appears when auth is actually missing.
+        authMethods: models.length > 0 ? [] : [APP_AUTH_METHOD],
+      };
+    })
+
+    .onRequest(methods.agent.session.new, async (ctx): Promise<NewSessionResponse> => {
+      if (ctx.params.mcpServers?.length) {
+        log(`ignoring ${ctx.params.mcpServers.length} MCP server(s): the pi SDK has no MCP client`);
+      }
+      if (ctx.params.cwd && ctx.params.cwd !== config.workspace.workspaceDir) {
+        log(`ignoring client cwd ${ctx.params.cwd}; Accountant24 always works on ${config.workspace.workspaceDir}`);
+      }
+
+      const sessionId = newSessionPath();
+      const session = await store.open(sessionId, deps.createRuntime, (event) => {
+        const update = toSessionUpdate(event as Parameters<typeof toSessionUpdate>[0]);
+        if (!update || !client) return;
+        void client.notify(methods.client.session.update, { sessionId, update }).catch(() => {
+          // The client went away mid-turn; the connection close will clean up.
+        });
+      });
+
+      // Without this the session silently falls back to pi's first available
+      // model instead of the one chosen in the app.
+      if (config.defaultModel) {
+        const model = findModel(await available(), config.defaultModel);
+        if (model) await session.runtime.session.setModel(model as never);
+      }
+
+      return { sessionId, configOptions: await configOptions(session) };
+    })
+
+    .onRequest(methods.agent.session.prompt, async (ctx): Promise<PromptResponse> => {
+      const session = require(ctx.params.sessionId);
+      if ((await available()).length === 0) throw RequestError.authRequired(undefined, NO_MODEL_MESSAGE);
+
+      const { message, images } = toPiPrompt(ctx.params.prompt);
+      session.cancelled = false;
+      try {
+        await session.runtime.session.prompt(message, { images, source: "rpc" } as never);
+      } catch (error) {
+        // pi surfaces an abort as a thrown error; the spec wants a semantically
+        // meaningful stop reason instead.
+        if (!session.cancelled) {
+          // A plain throw would reach the client as a bare "Internal error".
+          // Re-wrap so the real reason (rate limit, bad key, context overflow)
+          // is what the user sees.
+          if (error instanceof RequestError) throw error;
+          throw RequestError.internalError(undefined, error instanceof Error ? error.message : String(error));
+        }
+      }
+      return { stopReason: session.cancelled ? "cancelled" : "end_turn" };
+    })
+
+    .onNotification(methods.agent.session.cancel, async (ctx) => {
+      const session = store.get(ctx.params.sessionId);
+      if (!session) return;
+      session.cancelled = true;
+      await session.runtime.session.abort();
+    })
+
+    .onRequest(methods.agent.session.setConfigOption, async (ctx): Promise<SetSessionConfigOptionResponse> => {
+      const session = require(ctx.params.sessionId);
+      if (ctx.params.configId !== MODEL_CONFIG_ID) {
+        throw RequestError.invalidParams(undefined, `Unknown config option: ${ctx.params.configId}`);
+      }
+      const value = ctx.params.value;
+      const model = typeof value === "string" ? findModel(await available(), value) : undefined;
+      if (!model) throw RequestError.invalidParams(undefined, `Unknown model: ${String(value)}`);
+
+      await session.runtime.session.setModel(model as never);
+      const options = await configOptions(session);
+      if (client) {
+        void client
+          .notify(methods.client.session.update, {
+            sessionId: session.id,
+            update: { sessionUpdate: "config_option_update", configOptions: options },
+          })
+          .catch(() => {});
+      }
+      return { configOptions: options };
+    });
+}

--- a/packages/desktop/src/acp/sessions.ts
+++ b/packages/desktop/src/acp/sessions.ts
@@ -1,0 +1,82 @@
+// One pi runtime per ACP session, plus the per-session cancel flag.
+//
+// The ACP sessionId IS the pi session-file path: it is opaque to the client by
+// spec, and using the real path means a chat started over ACP lands in
+// ~/Accountant24/sessions like any other and shows up in the app's chat list.
+
+import type { AgentSessionRuntime } from "@earendil-works/pi-coding-agent";
+import type { UiBridge } from "../main/agent/host/host";
+
+export interface AcpSession {
+  readonly id: string;
+  readonly runtime: AgentSessionRuntime;
+  /** Set by session/cancel so the in-flight prompt resolves as "cancelled". */
+  cancelled: boolean;
+  dispose(): Promise<void>;
+}
+
+/**
+ * The UI bridge handed to the pi runtime.
+ *
+ * pi's extension UI (confirm/input/select dialogs) has no ACP equivalent, and a
+ * blocking dialog with nobody to answer it would hang the turn. We auto-answer
+ * exactly as the desktop renderer does. This is a liveness guard, not a
+ * permission bypass: pi has no tool-permission prompts outside its interactive
+ * TUI, and neither pi core nor the accountant24 extension raises one today. If
+ * real approvals are ever added, they should become session/request_permission
+ * here rather than being answered blind.
+ */
+export function autoAnsweringUi(): UiBridge {
+  const pending: UiBridge["pending"] = new Map();
+  return {
+    pending,
+    emit(event) {
+      const id = typeof event.id === "string" ? event.id : undefined;
+      if (!id) return;
+      const waiter = pending.get(id);
+      // Display-only calls (notify/setStatus/setTitle/…) emit without ever
+      // registering a waiter; only real dialogs need an answer.
+      if (!waiter) return;
+      pending.delete(id);
+      waiter.resolve(event.method === "input" ? { confirmed: true, value: "" } : { confirmed: true });
+    },
+  };
+}
+
+export class SessionStore {
+  private readonly sessions = new Map<string, AcpSession>();
+
+  async open(
+    id: string,
+    createRuntime: (sessionPath: string, ui: UiBridge) => Promise<AgentSessionRuntime>,
+    onEvent: (event: object) => void,
+  ): Promise<AcpSession> {
+    const runtime = await createRuntime(id, autoAnsweringUi());
+    const unsubscribe = runtime.session.subscribe(onEvent);
+    const session: AcpSession = {
+      id,
+      runtime,
+      cancelled: false,
+      dispose: async () => {
+        this.sessions.delete(id);
+        unsubscribe();
+        try {
+          await runtime.session.abort();
+          await runtime.dispose();
+        } catch {
+          // Teardown is best-effort; the slot is gone either way.
+        }
+      },
+    };
+    this.sessions.set(id, session);
+    return session;
+  }
+
+  get(id: string): AcpSession | undefined {
+    return this.sessions.get(id);
+  }
+
+  async disposeAll(): Promise<void> {
+    await Promise.all([...this.sessions.values()].map((s) => s.dispose()));
+  }
+}

--- a/packages/desktop/src/acp/tools.ts
+++ b/packages/desktop/src/acp/tools.ts
@@ -1,0 +1,52 @@
+// Tool presentation for ACP clients: the human label and the ACP "kind" that
+// drives a client's icon and grouping (Zed renders an edit differently from a
+// search).
+//
+// The labels are deliberately DUPLICATED from packages/pi-extension/src/tool-labels.ts
+// so this node-side module never imports the agent package — the same rule the
+// renderer copy follows. __tests__/tools.test.ts asserts all three maps agree,
+// so a rename in one place fails the build rather than drifting silently.
+
+import type { ToolKind } from "@agentclientprotocol/sdk";
+
+interface ToolPresentation {
+  label: string;
+  kind: ToolKind;
+}
+
+/** The accountant24 extension's own tools. */
+export const EXTENSION_TOOLS: Record<string, ToolPresentation> = {
+  query: { label: "Query Ledger", kind: "search" },
+  add_transactions: { label: "Add Transactions", kind: "edit" },
+  add_balance_assertions: { label: "Add Balance Assertions", kind: "edit" },
+  add_prices: { label: "Add Prices", kind: "edit" },
+  extract_text: { label: "Extract Text", kind: "read" },
+  update_memory: { label: "Update Memory", kind: "edit" },
+  validate: { label: "Validate Ledger", kind: "think" },
+  commit_and_push: { label: "Commit & Push", kind: "execute" },
+};
+
+/** pi's built-in tools, which stay enabled alongside ours. */
+const BUILTIN_TOOLS: Record<string, ToolPresentation> = {
+  read: { label: "Read", kind: "read" },
+  write: { label: "Write", kind: "edit" },
+  edit: { label: "Edit", kind: "edit" },
+  ls: { label: "List", kind: "read" },
+  grep: { label: "Grep", kind: "search" },
+  glob: { label: "Glob", kind: "search" },
+  find: { label: "Find", kind: "search" },
+  bash: { label: "Bash", kind: "execute" },
+};
+
+/** Title shown by the ACP client. Unknown tools fall back to a prettified name,
+ *  matching the renderer's behavior, so a miss is cosmetic rather than broken. */
+export function toolTitle(toolName: string): string {
+  const known = EXTENSION_TOOLS[toolName] ?? BUILTIN_TOOLS[toolName];
+  if (known) return known.label;
+  return `${toolName.charAt(0).toUpperCase()}${toolName.slice(1)}`.replace(/[_-]+/g, " ");
+}
+
+/** ACP kind for the tool, defaulting to "other" for anything unrecognized. */
+export function toolKind(toolName: string): ToolKind {
+  return (EXTENSION_TOOLS[toolName] ?? BUILTIN_TOOLS[toolName])?.kind ?? "other";
+}

--- a/packages/desktop/src/main/__tests__/env.test.ts
+++ b/packages/desktop/src/main/__tests__/env.test.ts
@@ -206,6 +206,19 @@ describe("agentEnv()", () => {
   });
 });
 
+describe("extensionPath()", () => {
+  it("should resolve the bundled extension in the packaged resources dir", async () => {
+    const orig = process.resourcesPath;
+    Object.defineProperty(process, "resourcesPath", { value: "/pkg-res", configurable: true });
+    try {
+      const mod = await import("../env");
+      expect(mod.extensionPath()).toBe("/pkg-res/accountant24-extension.js");
+    } finally {
+      Object.defineProperty(process, "resourcesPath", { value: orig, configurable: true });
+    }
+  });
+});
+
 describe("systemPromptPath()", () => {
   it("should resolve system.md in the packaged resources dir", async () => {
     const orig = process.resourcesPath;
@@ -226,6 +239,19 @@ describe("nativeSkillsDir()", () => {
     try {
       const mod = await import("../env");
       expect(mod.nativeSkillsDir()).toBe("/pkg-res/skills");
+    } finally {
+      Object.defineProperty(process, "resourcesPath", { value: orig, configurable: true });
+    }
+  });
+});
+
+describe("acpCommandPath()", () => {
+  it("should resolve the ACP launcher in the packaged resources dir", async () => {
+    const orig = process.resourcesPath;
+    Object.defineProperty(process, "resourcesPath", { value: "/pkg-res", configurable: true });
+    try {
+      const mod = await import("../env");
+      expect(mod.acpCommandPath()).toBe("/pkg-res/accountant24-acp");
     } finally {
       Object.defineProperty(process, "resourcesPath", { value: orig, configurable: true });
     }

--- a/packages/desktop/src/main/agent/host/__tests__/workspace.test.ts
+++ b/packages/desktop/src/main/agent/host/__tests__/workspace.test.ts
@@ -1,0 +1,141 @@
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// workspace.ts derives every agent path from two independent inputs: the
+// workspace (from the env) and the resource dir (from the caller). The
+// filesystem and homedir are the faked I/O boundaries.
+
+const h = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  homedir: vi.fn(() => "/home/user"),
+}));
+
+vi.mock("node:fs", () => ({ existsSync: h.existsSync }));
+vi.mock("node:os", () => ({ homedir: h.homedir }));
+
+import { agentEnv, agentHostConfig, resolveWorkspaceDir, resourcePaths, workspacePaths } from "../workspace";
+
+/** Run `fn` with ACCOUNTANT24_HOME set, restoring whatever was there before. */
+function withHome<T>(value: string | undefined, fn: () => T): T {
+  const prev = process.env.ACCOUNTANT24_HOME;
+  if (value === undefined) delete process.env.ACCOUNTANT24_HOME;
+  else process.env.ACCOUNTANT24_HOME = value;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env.ACCOUNTANT24_HOME;
+    else process.env.ACCOUNTANT24_HOME = prev;
+  }
+}
+
+beforeEach(() => {
+  h.existsSync.mockReset();
+  h.existsSync.mockReturnValue(false);
+  h.homedir.mockReset();
+  h.homedir.mockReturnValue("/home/user");
+});
+
+describe("resolveWorkspaceDir()", () => {
+  it("should use ACCOUNTANT24_HOME verbatim when it is a non-empty path", () => {
+    expect(withHome("/custom/ws", resolveWorkspaceDir)).toBe("/custom/ws");
+  });
+
+  it("should fall back to <homedir>/Accountant24 when ACCOUNTANT24_HOME is unset", () => {
+    h.homedir.mockReturnValue("/home/alice");
+    expect(withHome(undefined, resolveWorkspaceDir)).toBe("/home/alice/Accountant24");
+  });
+
+  it("should fall back to the homedir default when ACCOUNTANT24_HOME is the empty string", () => {
+    h.homedir.mockReturnValue("/home/bob");
+    expect(withHome("", resolveWorkspaceDir)).toBe("/home/bob/Accountant24");
+  });
+});
+
+describe("workspacePaths()", () => {
+  it("should place every workspace path directly under the workspace", () => {
+    expect(withHome("/ws", workspacePaths)).toEqual({
+      workspaceDir: "/ws",
+      sessionsDir: "/ws/sessions",
+      skillsDir: "/ws/skills",
+      mainJournalPath: "/ws/ledger/main.journal",
+      appSettingsPath: "/ws/app-settings.json",
+      legacySettingsPath: "/ws/settings.json",
+    });
+  });
+
+  // Regression: the workspace derivation must not depend on the resource dir.
+  // When it did, reading sessionsDir in a context with no resolvable app bundle
+  // threw instead of returning a path.
+  it("should resolve without any resource dir being available", () => {
+    expect(() => withHome("/ws", workspacePaths)).not.toThrow();
+    expect(withHome("/ws", workspacePaths).sessionsDir).toBe("/ws/sessions");
+  });
+});
+
+describe("resourcePaths()", () => {
+  it("should place every bundled asset directly under the resource dir", () => {
+    expect(resourcePaths("/res")).toEqual({
+      resourceDir: "/res",
+      binDir: "/res/bin",
+      extensionPath: "/res/accountant24-extension.js",
+      systemPromptPath: "/res/system.md",
+      nativeSkillsDir: "/res/skills",
+      acpCommandPath: "/res/accountant24-acp",
+    });
+  });
+});
+
+describe("agentHostConfig()", () => {
+  it("should assemble the host config from both derivations", () => {
+    expect(agentHostConfig(withHome("/ws", workspacePaths), resourcePaths("/res"))).toEqual({
+      workspaceDir: "/ws",
+      sessionsDir: "/ws/sessions",
+      skillsDir: "/ws/skills",
+      nativeSkillsDir: "/res/skills",
+      extensionPath: "/res/accountant24-extension.js",
+      systemPromptPath: "/res/system.md",
+    });
+  });
+});
+
+describe("agentEnv()", () => {
+  const build = () => agentEnv(withHome("/ws", workspacePaths), resourcePaths("/res"));
+
+  it("should point ACCOUNTANT24_HOME and PI_CODING_AGENT_DIR at the workspace", () => {
+    const env = build();
+    expect(env.ACCOUNTANT24_HOME).toBe("/ws");
+    expect(env.PI_CODING_AGENT_DIR).toBe("/ws");
+  });
+
+  it("should prepend binDir to PATH when the bin directory exists", () => {
+    const prevPath = process.env.PATH;
+    process.env.PATH = "/usr/bin";
+    h.existsSync.mockImplementation((p: string) => p === `/res${path.sep}bin`);
+    try {
+      expect(build().PATH).toBe(`/res/bin${path.delimiter}/usr/bin`);
+    } finally {
+      process.env.PATH = prevPath;
+    }
+  });
+
+  it("should leave PATH untouched when the bin directory is missing", () => {
+    const prevPath = process.env.PATH;
+    process.env.PATH = "/usr/bin";
+    h.existsSync.mockReturnValue(false);
+    try {
+      expect(build().PATH).toBe("/usr/bin");
+    } finally {
+      process.env.PATH = prevPath;
+    }
+  });
+
+  it("should set TESSDATA_PREFIX to <resourceDir>/tessdata when it exists", () => {
+    h.existsSync.mockImplementation((p: string) => p === `/res${path.sep}tessdata`);
+    expect(build().TESSDATA_PREFIX).toBe("/res/tessdata");
+  });
+
+  it("should omit TESSDATA_PREFIX when the tessdata directory is missing", () => {
+    h.existsSync.mockReturnValue(false);
+    expect(build().TESSDATA_PREFIX).toBeUndefined();
+  });
+});

--- a/packages/desktop/src/main/agent/host/runtime.ts
+++ b/packages/desktop/src/main/agent/host/runtime.ts
@@ -14,6 +14,7 @@
 
 import { join } from "node:path";
 import {
+  type AgentSessionRuntime,
   AuthStorage,
   type CreateAgentSessionRuntimeFactory,
   createAgentSessionFromServices,
@@ -27,12 +28,40 @@ import type { AgentHostConfig } from "../../../shared/agentHost";
 import { enabledSkillPaths } from "../skills-store";
 import type { RuntimeFactory, UiBridge } from "./host";
 
+/** Same factory as {@link createRuntimeFactory}, typed as the real pi runtime.
+ *  The agent host only needs the narrowed `HostRuntime` slice (so its tests can
+ *  drive fakes), but the ACP entrypoint talks to the session directly and needs
+ *  the full type. */
+export type PiRuntimeFactory = (sessionPath: string, ui: UiBridge) => Promise<AgentSessionRuntime>;
+
+/** One auth/models registry pair, reading the workspace files the
+ *  llm-providers/ modules write. Shared by every session in a host — killing
+ *  the host (the agent_restart flow) is what picks up credential changes. The
+ *  ACP entrypoint creates its own and passes it in, so its model list and its
+ *  sessions agree. */
+export function createRegistries(workspaceDir: string): Registries {
+  const authStorage = AuthStorage.create(join(workspaceDir, "auth.json"));
+  return {
+    authStorage,
+    modelRegistry: ModelRegistry.create(authStorage, join(workspaceDir, "models.json")),
+  };
+}
+
+export interface Registries {
+  authStorage: AuthStorage;
+  modelRegistry: ModelRegistry;
+}
+
+/** The narrowed view the agent host consumes. */
 export function createRuntimeFactory(cfg: AgentHostConfig): RuntimeFactory {
-  // One auth/models registry shared by every session in this host — reading
-  // the workspace files the llm-providers/ modules write. Killing the host (the
-  // agent_restart flow) is what picks up credential changes.
-  const authStorage = AuthStorage.create(join(cfg.workspaceDir, "auth.json"));
-  const modelRegistry = ModelRegistry.create(authStorage, join(cfg.workspaceDir, "models.json"));
+  return createPiRuntimeFactory(cfg);
+}
+
+export function createPiRuntimeFactory(
+  cfg: AgentHostConfig,
+  registries: Registries = createRegistries(cfg.workspaceDir),
+): PiRuntimeFactory {
+  const { authStorage, modelRegistry } = registries;
 
   return async (sessionPath, ui) => {
     const factory: CreateAgentSessionRuntimeFactory = async ({ cwd, agentDir, sessionManager, sessionStartEvent }) => {

--- a/packages/desktop/src/main/agent/host/workspace.ts
+++ b/packages/desktop/src/main/agent/host/workspace.ts
@@ -1,0 +1,104 @@
+// Workspace path + env derivation, with no Electron imports.
+//
+// Everything here is a pure function of two inputs: the resource dir (where the
+// vendored tools, extension bundle and system prompt live) and the user's home.
+// Electron's `app` is the only thing that knows the resource dir, so main/env.ts
+// supplies it — and the ACP entrypoint, which runs outside Electron, resolves it
+// from its own module URL. Both then share this module.
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import type { AgentHostConfig } from "../../../shared/agentHost";
+
+// The two derivations are kept separate on purpose: workspace paths must not
+// depend on the resource dir, so a caller that only wants (say) sessionsDir
+// never has to resolve where the app bundle lives.
+
+/** Paths derived from the workspace (~/Accountant24). */
+export interface WorkspacePaths {
+  /** The agent's cwd and the home of the ledger/auth/models. */
+  workspaceDir: string;
+  /** One JSONL per chat thread. */
+  sessionsDir: string;
+  /** One self-contained folder per installed third-party skill. */
+  skillsDir: string;
+  /** The ledger's entry point (includes the other journal files). */
+  mainJournalPath: string;
+  /** App-owned settings, distinct from pi's own settings.json. */
+  appSettingsPath: string;
+  /** pi's settings file, which earlier app versions shared; a migration source. */
+  legacySettingsPath: string;
+}
+
+/** Paths derived from the resource dir (vendored tools + bundled agent assets). */
+export interface ResourcePaths {
+  /** Dir holding vendored bin/ + tessdata/ + the extension bundle. */
+  resourceDir: string;
+  /** Vendored native tools (hledger/pdftotext/tesseract). */
+  binDir: string;
+  /** The bundled extension passed to pi. */
+  extensionPath: string;
+  /** The static system prompt passed to pi. */
+  systemPromptPath: string;
+  /** Native (built-in) skills embedded in the app bundle. */
+  nativeSkillsDir: string;
+  /** The ACP launcher an external client is pointed at. */
+  acpCommandPath: string;
+}
+
+/** ~/Accountant24, or ACCOUNTANT24_HOME when set to a non-empty path. */
+export function resolveWorkspaceDir(): string {
+  const env = process.env.ACCOUNTANT24_HOME;
+  return env && env.length > 0 ? env : path.join(homedir(), "Accountant24");
+}
+
+export function workspacePaths(): WorkspacePaths {
+  const workspaceDir = resolveWorkspaceDir();
+  return {
+    workspaceDir,
+    sessionsDir: path.join(workspaceDir, "sessions"),
+    skillsDir: path.join(workspaceDir, "skills"),
+    mainJournalPath: path.join(workspaceDir, "ledger", "main.journal"),
+    appSettingsPath: path.join(workspaceDir, "app-settings.json"),
+    legacySettingsPath: path.join(workspaceDir, "settings.json"),
+  };
+}
+
+export function resourcePaths(resourceDir: string): ResourcePaths {
+  return {
+    resourceDir,
+    binDir: path.join(resourceDir, "bin"),
+    extensionPath: path.join(resourceDir, "accountant24-extension.js"),
+    systemPromptPath: path.join(resourceDir, "system.md"),
+    nativeSkillsDir: path.join(resourceDir, "skills"),
+    acpCommandPath: path.join(resourceDir, "accountant24-acp"),
+  };
+}
+
+/** Static config for the agent host / ACP runtime factory. */
+export function agentHostConfig(ws: WorkspacePaths, res: ResourcePaths): AgentHostConfig {
+  return {
+    workspaceDir: ws.workspaceDir,
+    sessionsDir: ws.sessionsDir,
+    skillsDir: ws.skillsDir,
+    nativeSkillsDir: res.nativeSkillsDir,
+    extensionPath: res.extensionPath,
+    systemPromptPath: res.systemPromptPath,
+  };
+}
+
+/** Env overrides for anything that runs the agent: workspace + vendored tools.
+ *  PI_CODING_AGENT_DIR is redundant when agentDir is passed explicitly but is
+ *  kept for parity in the agent's own subprocesses. */
+export function agentEnv(ws: WorkspacePaths, res: ResourcePaths): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ACCOUNTANT24_HOME: ws.workspaceDir,
+    PI_CODING_AGENT_DIR: ws.workspaceDir,
+  };
+  if (existsSync(res.binDir)) env.PATH = `${res.binDir}${path.delimiter}${env.PATH ?? ""}`;
+  const tessdata = path.join(res.resourceDir, "tessdata");
+  if (existsSync(tessdata)) env.TESSDATA_PREFIX = tessdata;
+  return env;
+}

--- a/packages/desktop/src/main/app-settings.ts
+++ b/packages/desktop/src/main/app-settings.ts
@@ -1,0 +1,89 @@
+// Reading and writing ~/Accountant24/app-settings.json — the app's OWN config,
+// the single source of truth the Settings UI reads/writes.
+//
+// It must NOT share pi's settings.json: pi reads/writes its own settings.json in
+// the same workspace (PI_CODING_AGENT_DIR), so sharing the file mixed pi's keys
+// (e.g. defaultProvider) into ours and risked clobbering. We keep a separate file
+// and only ever persist our own keys.
+//
+// No Electron imports: the paths come in as arguments, so both the settings IPC
+// module and the ACP entrypoint (which runs outside Electron, and reads
+// defaultModel to pick a model for new sessions) can use it.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import type { AppSettings } from "../shared/types";
+
+/** The paths this module needs. `WorkspacePaths` satisfies it structurally. */
+export interface SettingsPaths {
+  appSettingsPath: string;
+  legacySettingsPath: string;
+  workspaceDir: string;
+}
+
+function parseFile(path: string): Record<string, unknown> | undefined {
+  if (!existsSync(path)) return undefined;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Keep only the keys this app owns — ignores anything pi (or a hand-edit) added. */
+function pickAppKeys(raw: Record<string, unknown>): AppSettings {
+  const out: AppSettings = {};
+  const dm = raw.defaultModel;
+  if (typeof dm === "string" && dm.includes("/")) {
+    out.defaultModel = dm;
+  } else if (dm && typeof dm === "object" && "provider" in dm && "modelId" in dm) {
+    // Legacy object form ({ provider, modelId }) — fold it into the id string.
+    out.defaultModel = `${String((dm as { provider: unknown }).provider)}/${String((dm as { modelId: unknown }).modelId)}`;
+  }
+  if (Array.isArray(raw.enabledModels)) {
+    out.enabledModels = (raw.enabledModels as unknown[]).filter((x): x is string => typeof x === "string");
+  }
+  if (typeof raw.analyticsEnabled === "boolean") out.analyticsEnabled = raw.analyticsEnabled;
+  if (Array.isArray(raw.onceEvents)) {
+    out.onceEvents = (raw.onceEvents as unknown[]).filter((x): x is string => typeof x === "string");
+  }
+  return out;
+}
+
+/** One-time move of app keys out of the shared settings.json into app-settings.json,
+ *  leaving pi's own keys behind in settings.json. Best-effort. */
+function migrateFromLegacy(paths: SettingsPaths): AppSettings {
+  const legacy = parseFile(paths.legacySettingsPath);
+  if (!legacy) return {};
+  const app = pickAppKeys(legacy);
+  try {
+    mkdirSync(paths.workspaceDir, { recursive: true });
+    writeFileSync(paths.appSettingsPath, `${JSON.stringify(app, null, 2)}\n`);
+    // Strip our keys from pi's file so it's no longer a mix of both.
+    const cleaned = { ...legacy };
+    delete cleaned.defaultModel;
+    delete cleaned.enabledModels;
+    if (Object.keys(cleaned).length > 0) {
+      writeFileSync(paths.legacySettingsPath, `${JSON.stringify(cleaned, null, 2)}\n`);
+    }
+  } catch {
+    // Best-effort; the in-memory `app` is still correct for this session.
+  }
+  return app;
+}
+
+export function readAppSettings(paths: SettingsPaths): AppSettings {
+  const own = parseFile(paths.appSettingsPath);
+  if (own) return pickAppKeys(own);
+  return migrateFromLegacy(paths);
+}
+
+/** Merge-patch the settings file and return the merged result. */
+export function writeAppSettings(paths: SettingsPaths, patch: Partial<AppSettings>): AppSettings {
+  const merged: AppSettings = { ...readAppSettings(paths), ...patch };
+  // The workspace normally exists (the agent scaffolds it), but a save can race
+  // a fresh install — create it so the write can't fail with ENOENT.
+  mkdirSync(paths.workspaceDir, { recursive: true });
+  writeFileSync(paths.appSettingsPath, `${JSON.stringify(merged, null, 2)}\n`);
+  return merged;
+}

--- a/packages/desktop/src/main/env.ts
+++ b/packages/desktop/src/main/env.ts
@@ -3,49 +3,17 @@
 // The workspace (~/Accountant24) holds the ledger + auth.json + models.json;
 // PATH exposes the vendored native tools (hledger/pdftotext/tesseract) to the
 // agent's bash/tool subprocesses; TESSDATA_PREFIX points at the OCR data.
+//
+// The derivation itself lives in agent/host/workspace.ts, which has no Electron
+// imports so the ACP entrypoint (which runs outside Electron) can share it.
+// This module is the Electron-side binding: it supplies the resource dir, which
+// is the only thing `app` is needed for.
 
-import { existsSync } from "node:fs";
-import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { app } from "electron";
 import type { AgentHostConfig } from "../shared/agentHost";
-
-/** ~/Accountant24 — the agent's cwd and the home of the ledger/auth/models. */
-export function workspaceDir(): string {
-  const env = process.env.ACCOUNTANT24_HOME;
-  return env && env.length > 0 ? env : path.join(homedir(), "Accountant24");
-}
-
-/** ~/Accountant24/skills — one self-contained folder per installed skill
- *  (Agent Skills standard: a dir with SKILL.md). Each enabled skill is passed
- *  to the agent child via a `--skill` flag. */
-export function skillsDir(): string {
-  return path.join(workspaceDir(), "skills");
-}
-
-/** ~/Accountant24/sessions — pi's session files, one JSONL per chat thread.
- *  Passed to the agent child via `--session-dir`. */
-export function sessionsDir(): string {
-  return path.join(workspaceDir(), "sessions");
-}
-
-/** ~/Accountant24/ledger/main.journal — the ledger's entry point (includes the
- *  other journal files). */
-export function mainJournalPath(): string {
-  return path.join(workspaceDir(), "ledger", "main.journal");
-}
-
-/** ~/Accountant24/app-settings.json — app-owned settings (distinct from pi's). */
-export function appSettingsPath(): string {
-  return path.join(workspaceDir(), "app-settings.json");
-}
-
-/** ~/Accountant24/settings.json — pi's settings file, which earlier app
- *  versions shared; read once as a migration source. */
-export function legacySettingsPath(): string {
-  return path.join(workspaceDir(), "settings.json");
-}
+import * as workspace from "./agent/host/workspace";
 
 /** Dir holding vendored bin/ + tessdata/ + the extension bundle.
  *  Dev: packages/desktop/resources. Packaged: the app's resources dir
@@ -54,18 +22,56 @@ function resourceDir(): string {
   return app.isPackaged ? process.resourcesPath : path.join(app.getAppPath(), "resources");
 }
 
+const ws = (): workspace.WorkspacePaths => workspace.workspacePaths();
+const res = (): workspace.ResourcePaths => workspace.resourcePaths(resourceDir());
+
+/** ~/Accountant24 — the agent's cwd and the home of the ledger/auth/models. */
+export function workspaceDir(): string {
+  return workspace.resolveWorkspaceDir();
+}
+
+/** ~/Accountant24/skills — one self-contained folder per installed skill
+ *  (Agent Skills standard: a dir with SKILL.md). Each enabled skill is passed
+ *  to the agent child via a `--skill` flag. */
+export function skillsDir(): string {
+  return ws().skillsDir;
+}
+
+/** ~/Accountant24/sessions — pi's session files, one JSONL per chat thread.
+ *  Passed to the agent child via `--session-dir`. */
+export function sessionsDir(): string {
+  return ws().sessionsDir;
+}
+
+/** ~/Accountant24/ledger/main.journal — the ledger's entry point (includes the
+ *  other journal files). */
+export function mainJournalPath(): string {
+  return ws().mainJournalPath;
+}
+
+/** ~/Accountant24/app-settings.json — app-owned settings (distinct from pi's). */
+export function appSettingsPath(): string {
+  return ws().appSettingsPath;
+}
+
+/** ~/Accountant24/settings.json — pi's settings file, which earlier app
+ *  versions shared; read once as a migration source. */
+export function legacySettingsPath(): string {
+  return ws().legacySettingsPath;
+}
+
 /** Dir holding the vendored native tools (hledger/pdftotext/tesseract). Prepended
  *  to the agent child's PATH; also used to resolve a tool's absolute path when we
  *  run one directly from the main process (which does NOT inherit that PATH). */
 export function binDir(): string {
-  return path.join(resourceDir(), "bin");
+  return res().binDir;
 }
 
 /** The bundled extension passed to `pi -e`. Loaded as JS in both dev and
  *  packaged (Electron-as-Node can't parse the TS source); produced by
  *  scripts/bundle-extension.ts. */
 export function extensionPath(): string {
-  return path.join(resourceDir(), "accountant24-extension.js");
+  return res().extensionPath;
 }
 
 /** The static system prompt passed to `pi --system-prompt`. pi replaces its
@@ -74,7 +80,7 @@ export function extensionPath(): string {
  *  extension then appends the dynamic tools/context sections per turn. Copied
  *  next to the extension bundle by scripts/bundle-extension.ts. */
 export function systemPromptPath(): string {
-  return path.join(resourceDir(), "system.md");
+  return res().systemPromptPath;
 }
 
 /** Native (built-in) skills embedded in the app bundle — one folder per skill,
@@ -82,7 +88,13 @@ export function systemPromptPath(): string {
  *  `--skill` flag; pi recurses the directory), never present in the workspace
  *  skills folder, so users can't remove or disable them. */
 export function nativeSkillsDir(): string {
-  return path.join(resourceDir(), "skills");
+  return res().nativeSkillsDir;
+}
+
+/** The ACP launcher shipped alongside the other resources — the command an
+ *  external ACP client (Buzz, Zed, …) is pointed at. */
+export function acpCommandPath(): string {
+  return res().acpCommandPath;
 }
 
 /** Built agent-host utilityProcess entry — emitted as a sibling of the main
@@ -94,30 +106,10 @@ export function agentHostEntryPath(): string {
 
 /** Static config for the agent host, passed as JSON in argv[2] at fork time. */
 export function agentHostConfig(): AgentHostConfig {
-  return {
-    workspaceDir: workspaceDir(),
-    sessionsDir: sessionsDir(),
-    skillsDir: skillsDir(),
-    nativeSkillsDir: nativeSkillsDir(),
-    extensionPath: extensionPath(),
-    systemPromptPath: systemPromptPath(),
-  };
+  return workspace.agentHostConfig(ws(), res());
 }
 
-/** Env overrides for the agent host + in-process SDK: workspace + vendored
- *  tools. PI_CODING_AGENT_DIR is redundant for the host itself (agentDir is
- *  passed explicitly) but kept for env parity in the agent's subprocesses. */
+/** Env overrides for the agent host + in-process SDK: workspace + vendored tools. */
 export function agentEnv(): NodeJS.ProcessEnv {
-  const workspace = workspaceDir();
-  const env: NodeJS.ProcessEnv = {
-    ...process.env,
-    ACCOUNTANT24_HOME: workspace,
-    PI_CODING_AGENT_DIR: workspace,
-  };
-  const res = resourceDir();
-  const bin = binDir();
-  if (existsSync(bin)) env.PATH = `${bin}${path.delimiter}${env.PATH ?? ""}`;
-  const tessdata = path.join(res, "tessdata");
-  if (existsSync(tessdata)) env.TESSDATA_PREFIX = tessdata;
-  return env;
+  return workspace.agentEnv(ws(), res());
 }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import { killAllAgents, registerAgentIpc } from "./agent/router";
 import { registerSessionsIpc } from "./agent/sessions";
 import { registerSkillsIpc } from "./agent/skills";
 import { initAnalytics, registerAnalyticsIpc, trackAnalyticsToggle, trackLaunch, trackQuit } from "./analytics";
+import { acpCommandPath } from "./env";
 import { registerFilesIpc } from "./files";
 import { registerLedgerIpc } from "./ledger";
 import { registerAuthIpc } from "./llm-providers/auth";
@@ -45,6 +46,8 @@ app.whenReady().then(() => {
   // Version comes from the packaged app metadata (CI injects the release
   // version via extraMetadata), so it can't be read at renderer build time.
   ipcMain.handle("app_version", () => app.getVersion());
+  // The launcher path an external ACP client is pointed at (Settings, Connect).
+  ipcMain.handle("acp_command_path", () => acpCommandPath());
   registerAgentIpc(getWin);
   registerAuthIpc();
   registerOauthIpc(getWin);

--- a/packages/desktop/src/main/settings.ts
+++ b/packages/desktop/src/main/settings.ts
@@ -1,81 +1,22 @@
-// App settings — the app's OWN config, the single source of truth the Settings
-// UI reads/writes. Stored as ~/Accountant24/app-settings.json.
+// App settings IPC — the Settings UI's read/write surface.
 //
-// It must NOT share pi's settings.json: pi reads/writes its own settings.json in
-// the same workspace (PI_CODING_AGENT_DIR), so sharing the file mixed pi's keys
-// (e.g. defaultProvider) into ours and risked clobbering. We keep a separate file
-// and only ever persist our own keys.
+// The file format and migration live in app-settings.ts (Electron-free, shared
+// with the ACP entrypoint); this module only binds them to the workspace paths
+// and to ipcMain.
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { ipcMain } from "electron";
 import type { AppSettings } from "../shared/types";
+import { readAppSettings, type SettingsPaths, writeAppSettings } from "./app-settings";
 import { appSettingsPath, legacySettingsPath, workspaceDir } from "./env";
 
-function parseFile(path: string): Record<string, unknown> | undefined {
-  if (!existsSync(path)) return undefined;
-  try {
-    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
-    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : undefined;
-  } catch {
-    return undefined;
-  }
-}
+const paths = (): SettingsPaths => ({
+  appSettingsPath: appSettingsPath(),
+  legacySettingsPath: legacySettingsPath(),
+  workspaceDir: workspaceDir(),
+});
 
-/** Keep only the keys this app owns — ignores anything pi (or a hand-edit) added. */
-function pickAppKeys(raw: Record<string, unknown>): AppSettings {
-  const out: AppSettings = {};
-  const dm = raw.defaultModel;
-  if (typeof dm === "string" && dm.includes("/")) {
-    out.defaultModel = dm;
-  } else if (dm && typeof dm === "object" && "provider" in dm && "modelId" in dm) {
-    // Legacy object form ({ provider, modelId }) — fold it into the id string.
-    out.defaultModel = `${String((dm as { provider: unknown }).provider)}/${String((dm as { modelId: unknown }).modelId)}`;
-  }
-  if (Array.isArray(raw.enabledModels)) {
-    out.enabledModels = (raw.enabledModels as unknown[]).filter((x): x is string => typeof x === "string");
-  }
-  if (typeof raw.analyticsEnabled === "boolean") out.analyticsEnabled = raw.analyticsEnabled;
-  if (Array.isArray(raw.onceEvents)) {
-    out.onceEvents = (raw.onceEvents as unknown[]).filter((x): x is string => typeof x === "string");
-  }
-  return out;
-}
-
-/** One-time move of app keys out of the shared settings.json into app-settings.json,
- *  leaving pi's own keys behind in settings.json. Best-effort. */
-function migrateFromLegacy(): AppSettings {
-  const legacy = parseFile(legacySettingsPath());
-  if (!legacy) return {};
-  const app = pickAppKeys(legacy);
-  try {
-    mkdirSync(workspaceDir(), { recursive: true });
-    writeFileSync(appSettingsPath(), `${JSON.stringify(app, null, 2)}\n`);
-    // Strip our keys from pi's file so it's no longer a mix of both.
-    const cleaned = { ...legacy };
-    delete cleaned.defaultModel;
-    delete cleaned.enabledModels;
-    if (Object.keys(cleaned).length > 0) writeFileSync(legacySettingsPath(), `${JSON.stringify(cleaned, null, 2)}\n`);
-  } catch {
-    // Best-effort; the in-memory `app` is still correct for this session.
-  }
-  return app;
-}
-
-function readSettings(): AppSettings {
-  const own = parseFile(appSettingsPath());
-  if (own) return pickAppKeys(own);
-  return migrateFromLegacy();
-}
-
-/** Merge-patch the settings file and return the merged result. */
-function writeSettings(patch: Partial<AppSettings>): AppSettings {
-  const merged: AppSettings = { ...readSettings(), ...patch };
-  // The workspace normally exists (the agent scaffolds it), but a save can race
-  // a fresh install — create it so the write can't fail with ENOENT.
-  mkdirSync(workspaceDir(), { recursive: true });
-  writeFileSync(appSettingsPath(), `${JSON.stringify(merged, null, 2)}\n`);
-  return merged;
-}
+const readSettings = (): AppSettings => readAppSettings(paths());
+const writeSettings = (patch: Partial<AppSettings>): AppSettings => writeAppSettings(paths(), patch);
 
 /** Register settings IPC handlers.
  *  @param opts.onAnalyticsToggled called when `analyticsEnabled` actually flips,

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -6,6 +6,7 @@ import { contextBridge, type IpcRendererEvent, ipcRenderer } from "electron";
 
 const INVOKE_CHANNELS = new Set([
   "app_version",
+  "acp_command_path",
   "agent_create_session",
   "agent_send",
   "agent_restart",

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/user-message-text.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/user-message-text.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { afterEach, describe, expect, it } from "vitest";
 import { encodeAttachmentRef } from "@/lib/attachmentMarker";
@@ -48,5 +49,53 @@ describe("UserMessageText", () => {
     const { container } = renderText(":skill[pdf] file this under :account[Expenses:Food]");
     expect(container.querySelector('[data-directive-type="skill"]')?.textContent).toBe("pdf");
     expect(container.querySelector('[data-directive-type="account"]')?.textContent).toBe("Expenses:Food");
+  });
+});
+
+// Collapsing is by length, not provenance: a pasted log and a turn wrapped by
+// an external ACP client are the same case.
+describe("UserMessageText collapsing", () => {
+  const long = "x".repeat(1200);
+
+  it("should render an ordinary message with no toggle", () => {
+    renderText("short and sweet");
+    expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
+  });
+
+  it("should offer a toggle for an overlong message", () => {
+    renderText(long);
+    expect(screen.getByRole("button", { name: "Show more" })).toBeTruthy();
+  });
+
+  it("should offer a toggle for a message that is long by line count", () => {
+    renderText(Array.from({ length: 20 }, (_, i) => `line ${i}`).join("\n"));
+    expect(screen.getByRole("button", { name: "Show more" })).toBeTruthy();
+  });
+
+  it("should keep the full text in the DOM while collapsed, so copy still works", () => {
+    const { container } = renderText(long);
+    expect(container.textContent).toContain(long);
+  });
+
+  it("should switch the toggle to Show less once expanded", async () => {
+    const user = userEvent.setup();
+    renderText(long);
+    await user.click(screen.getByRole("button", { name: "Show more" }));
+    expect(screen.getByRole("button", { name: "Show less" })).toBeTruthy();
+  });
+
+  it("should collapse again on a second click", async () => {
+    const user = userEvent.setup();
+    renderText(long);
+    await user.click(screen.getByRole("button", { name: "Show more" }));
+    await user.click(screen.getByRole("button", { name: "Show less" }));
+    expect(screen.getByRole("button", { name: "Show more" })).toBeTruthy();
+  });
+
+  it("should still lift attachment chips out of a collapsed message", () => {
+    const marker = encodeAttachmentRef({ name: "receipt.pdf", path: "files/receipt.pdf" });
+    const { container } = renderText(`${long}\n${marker}`);
+    expect(screen.getByText("receipt.pdf")).toBeTruthy();
+    expect(container.querySelector("button")?.textContent).toBe("Show more");
   });
 });

--- a/packages/desktop/src/renderer/components/accountant24/attachment.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/attachment.tsx
@@ -17,6 +17,7 @@ import {
 } from "@assistant-ui/react";
 import { FileTextIcon, PaperclipIcon, XIcon } from "lucide-react";
 import { type FC, useEffect, useState } from "react";
+import { CollapsedText } from "@/components/accountant24/collapsed-text";
 import { DirectiveText } from "@/components/accountant24/directive-chips";
 import { TooltipIconButton } from "@/components/accountant24/tooltip-icon-button";
 import {
@@ -29,6 +30,7 @@ import {
 } from "@/components/shadcn/attachment";
 import { InputGroupAddon } from "@/components/shadcn/input-group";
 import { extractAttachmentRefs } from "@/lib/attachmentMarker";
+import { isLongText } from "@/lib/longText";
 import { cn } from "@/lib/utils";
 
 /** Object-URL preview for a pending image File, revoked on unmount. */
@@ -157,9 +159,14 @@ export const UserMessageImage: ImageMessagePartComponent = ({ image, filename })
  *  the human-written text, with any directives (@-mentions, picked skills)
  *  rendered as inline chips. A manual skill invocation reaches this component
  *  already collapsed to its `:skill[name]` directive (electronPiClient rewrites
- *  pi's expanded block on the way in), so no skill-specific handling lives here. */
+ *  pi's expanded block on the way in), so no skill-specific handling lives here.
+ *
+ *  An overlong message is clamped behind a Show more toggle. That covers a
+ *  pasted log just as much as a message an external ACP client wrapped in its
+ *  own turn scaffolding — the rule is length, not provenance. */
 export const UserMessageText: TextMessagePartComponent = (props) => {
   const { text: visible, refs } = extractAttachmentRefs(props.text);
+  const body = visible ? <DirectiveText {...props} text={visible} /> : null;
   return (
     <>
       {refs.length > 0 && (
@@ -169,7 +176,7 @@ export const UserMessageText: TextMessagePartComponent = (props) => {
           ))}
         </div>
       )}
-      {visible && <DirectiveText {...props} text={visible} />}
+      {body && (isLongText(visible) ? <CollapsedText>{body}</CollapsedText> : body)}
     </>
   );
 };

--- a/packages/desktop/src/renderer/components/accountant24/collapsed-text.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/collapsed-text.tsx
@@ -1,0 +1,30 @@
+// A long block of sent text, clamped to a few lines with a toggle to reveal it.
+//
+// Clamping is CSS (line-clamp), not truncation, so the full text stays in the
+// DOM: selection, copy and screen readers all still see the whole message, and
+// expanding is instant with no reflow of the text itself.
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+/** How much of an overlong message stays visible when collapsed. */
+const CLAMP_LINES = "line-clamp-8";
+
+export function CollapsedText({ children }: { children: React.ReactNode }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <>
+      <div className={cn(!expanded && CLAMP_LINES)}>{children}</div>
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        // Same affordance as the disclosure triggers: quiet by default, and it
+        // sits inside the bubble so it reads as part of the message.
+        className="text-muted-foreground hover:text-foreground mt-1 text-sm transition-[color,scale] active:scale-[0.98]"
+      >
+        {expanded ? "Show less" : "Show more"}
+      </button>
+    </>
+  );
+}

--- a/packages/desktop/src/renderer/components/accountant24/settings/__tests__/connect-settings.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/settings/__tests__/connect-settings.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import "../../../../test/jsdomPolyfills";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const h = vi.hoisted(() => ({ acpCommandPath: vi.fn() }));
+vi.mock("@/rpc/api", () => ({ appApi: { acpCommandPath: h.acpCommandPath } }));
+
+import { ConnectSettings } from "../connect-settings";
+
+const COMMAND = "/Applications/Accountant24.app/Contents/Resources/accountant24-acp";
+
+beforeEach(() => {
+  h.acpCommandPath.mockReset();
+  h.acpCommandPath.mockResolvedValue(COMMAND);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ConnectSettings", () => {
+  it("should show the launcher command once it loads", async () => {
+    render(<ConnectSettings />);
+    expect(await screen.findByText(COMMAND)).toBeInTheDocument();
+  });
+
+  it("should copy the command to the clipboard and confirm", async () => {
+    // userEvent installs its own clipboard stub, so read the value back through
+    // it rather than spying on a writeText that setup() would replace.
+    const user = userEvent.setup();
+    render(<ConnectSettings />);
+    await user.click(await screen.findByRole("button", { name: "Copy command" }));
+
+    await waitFor(async () => expect(await navigator.clipboard.readText()).toBe(COMMAND));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Copy command" })).toHaveTextContent("Copied"));
+  });
+
+  it("should link to the setup guide", async () => {
+    render(<ConnectSettings />);
+    const link = await screen.findByRole("link", { name: /setup guide/i });
+    expect(link).toHaveAttribute("href", "https://accountant24.ai/docs/connect-other-apps");
+  });
+
+  it("should render without a command rather than crash when the path cannot be read", async () => {
+    h.acpCommandPath.mockRejectedValue(new Error("nope"));
+    render(<ConnectSettings />);
+    expect(await screen.findByText("Connect other apps")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Copy command" })).not.toBeInTheDocument();
+  });
+});

--- a/packages/desktop/src/renderer/components/accountant24/settings/about-settings.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/settings/about-settings.tsx
@@ -9,7 +9,7 @@ import { Button } from "@/components/shadcn/button";
 import { ItemActions, ItemContent, ItemTitle } from "@/components/shadcn/item";
 import { useUpdateStatus } from "@/hooks/use-update-status";
 import { appApi, updateApi } from "@/rpc/api";
-import { Section, SettingsRow, SettingsRows } from "./parts";
+import { LinkRow, Section, SettingsRow, SettingsRows } from "./parts";
 
 const RESOURCES = [
   { label: "Documentation", href: "https://accountant24.ai" },
@@ -18,27 +18,6 @@ const RESOURCES = [
   { label: "Source code", href: "https://github.com/machulav/accountant24" },
   { label: "MIT license", href: "https://github.com/machulav/accountant24/blob/main/LICENSE" },
 ];
-
-/** A whole-row external link (the Item renders as an anchor, so the stock
- *  `[a]:hover:bg-muted` affordance applies). SettingsRow strips horizontal
- *  padding to align text with the section header; for an interactive row the
- *  hover bg would then hug the text, so restore padding and pull it back out
- *  with a negative margin (the shadcn menu-item idiom), and swap the stock
- *  rounded-2xl (a pill at this row height) for the rounded-xl the app's other
- *  interactive rows use (sidebar nav, dropdown items). */
-function LinkRow({ label, href }: { label: string; href: string }) {
-  return (
-    // biome-ignore lint/a11y/useAnchorContent: useRender injects the row children (incl. the title) into the anchor at runtime
-    <SettingsRow className="-mx-2 w-auto rounded-xl px-2" render={<a href={href} target="_blank" rel="noreferrer" />}>
-      <ItemContent>
-        <ItemTitle>{label}</ItemTitle>
-      </ItemContent>
-      <ItemActions>
-        <ExternalLinkIcon className="text-muted-foreground size-4" />
-      </ItemActions>
-    </SettingsRow>
-  );
-}
 
 export function AboutSettings() {
   const [version, setVersion] = useState<string>();

--- a/packages/desktop/src/renderer/components/accountant24/settings/connect-settings.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/settings/connect-settings.tsx
@@ -1,0 +1,79 @@
+// Connect — how to reach this agent from other apps over the Agent Client
+// Protocol. The launcher lives inside the app bundle, so its path is
+// undiscoverable without showing it here.
+
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/shadcn/button";
+import { appApi } from "@/rpc/api";
+import { LinkRow, Section, SettingsRows } from "./parts";
+
+const DOCS_HREF = "https://accountant24.ai/docs/connect-other-apps";
+
+/** How long the copy button stays in its confirmed state. */
+const COPIED_MS = 2000;
+
+function CommandRow({ path }: { path: string }) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), COPIED_MS);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  return (
+    <div className="flex items-center gap-2">
+      {/* break-all: the path is long and unbreakable at word boundaries, so
+          without it the row overflows the dialog horizontally. */}
+      <code className="bg-muted text-muted-foreground min-w-0 flex-1 rounded-md px-2.5 py-2 font-mono text-xs break-all">
+        {path}
+      </code>
+      <Button
+        size="sm"
+        variant="outline"
+        aria-label="Copy command"
+        onClick={() => {
+          void navigator.clipboard.writeText(path).then(() => setCopied(true));
+        }}
+      >
+        {copied ? <CheckIcon /> : <CopyIcon />}
+        {copied ? "Copied" : "Copy"}
+      </Button>
+    </div>
+  );
+}
+
+export function ConnectSettings() {
+  const [path, setPath] = useState<string>();
+
+  useEffect(() => {
+    appApi
+      .acpCommandPath()
+      .then(setPath)
+      .catch(() => undefined);
+  }, []);
+
+  return (
+    <div>
+      <Section
+        title="Connect other apps"
+        description="Accountant24 speaks the Agent Client Protocol, so other agent apps can chat with your ledger. Register this command in any ACP client."
+      >
+        {path && <CommandRow path={path} />}
+      </Section>
+
+      <Section
+        title="Good to know"
+        description="Other apps work on the same ledger in ~/Accountant24, so chats you start elsewhere show up in your chat list here. Accountant24 does not need to be running."
+      />
+
+      {/* Its own group: the link is a next step, not part of the note above. */}
+      <Section>
+        <SettingsRows>
+          <LinkRow label="Setup guide" href={DOCS_HREF} />
+        </SettingsRows>
+      </Section>
+    </div>
+  );
+}

--- a/packages/desktop/src/renderer/components/accountant24/settings/parts.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/settings/parts.tsx
@@ -1,9 +1,9 @@
 // Small building blocks shared across the Settings pages.
 
-import { AlertCircleIcon } from "lucide-react";
+import { AlertCircleIcon, ExternalLinkIcon } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/shadcn/alert";
 import { FieldDescription, FieldLegend, FieldSet } from "@/components/shadcn/field";
-import { Item, ItemGroup } from "@/components/shadcn/item";
+import { Item, ItemActions, ItemContent, ItemGroup, ItemTitle } from "@/components/shadcn/item";
 import { cn } from "@/lib/utils";
 
 export function Section({
@@ -13,7 +13,8 @@ export function Section({
 }: {
   title?: string;
   description?: string;
-  children: React.ReactNode;
+  /** Optional: a section may be prose only (a note with no rows). */
+  children?: React.ReactNode;
 }) {
   return (
     // Stock FieldSet spacing is form-scale (gap-6, legend mb-3), which reads as
@@ -63,6 +64,27 @@ export function SettingsRow({ className, ...props }: React.ComponentProps<typeof
       )}
       {...props}
     />
+  );
+}
+
+/** A whole-row external link (the Item renders as an anchor, so the stock
+ *  `[a]:hover:bg-muted` affordance applies). SettingsRow strips horizontal
+ *  padding to align text with the section header; for an interactive row the
+ *  hover bg would then hug the text, so restore padding and pull it back out
+ *  with a negative margin (the shadcn menu-item idiom), and swap the stock
+ *  rounded-2xl (a pill at this row height) for the rounded-xl the app's other
+ *  interactive rows use (sidebar nav, dropdown items). */
+export function LinkRow({ label, href }: { label: string; href: string }) {
+  return (
+    // biome-ignore lint/a11y/useAnchorContent: useRender injects the row children (incl. the title) into the anchor at runtime
+    <SettingsRow className="-mx-2 w-auto rounded-xl px-2" render={<a href={href} target="_blank" rel="noreferrer" />}>
+      <ItemContent>
+        <ItemTitle>{label}</ItemTitle>
+      </ItemContent>
+      <ItemActions>
+        <ExternalLinkIcon className="text-muted-foreground size-4" />
+      </ItemActions>
+    </SettingsRow>
   );
 }
 

--- a/packages/desktop/src/renderer/components/accountant24/settings/settings.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/settings/settings.tsx
@@ -3,7 +3,7 @@
 // stock Sidebar components rendered inline (collapsible="none") for the nav —
 // the same shadcn pattern as its settings-dialog example.
 
-import { CpuIcon, InfoIcon, KeyboardIcon, PlugIcon, ShieldIcon, ZapIcon } from "lucide-react";
+import { CpuIcon, InfoIcon, KeyboardIcon, LinkIcon, PlugIcon, ShieldIcon, ZapIcon } from "lucide-react";
 import { useState } from "react";
 import { Dialog, DialogContent, DialogTitle } from "@/components/shadcn/dialog";
 import {
@@ -20,18 +20,20 @@ import {
 } from "@/components/shadcn/sidebar";
 import { AboutSettings } from "./about-settings";
 import { AnalyticsSettings } from "./analytics-settings";
+import { ConnectSettings } from "./connect-settings";
 import { ModelsSettings } from "./models-settings";
 import { ProvidersSettings } from "./providers-settings";
 import { ShortcutsSettings } from "./shortcuts-settings";
 import { SkillsSettings } from "./skills-settings";
 import { StarCallout } from "./star-callout";
 
-export type SettingsSection = "providers" | "models" | "skills" | "shortcuts" | "privacy" | "about";
+export type SettingsSection = "providers" | "models" | "skills" | "connect" | "shortcuts" | "privacy" | "about";
 
 const NAV: { id: SettingsSection; label: string; icon: typeof CpuIcon }[] = [
   { id: "providers", label: "Providers", icon: PlugIcon },
   { id: "models", label: "Models", icon: CpuIcon },
   { id: "skills", label: "Skills", icon: ZapIcon },
+  { id: "connect", label: "Connect", icon: LinkIcon },
   { id: "privacy", label: "Privacy", icon: ShieldIcon },
   { id: "shortcuts", label: "Shortcuts", icon: KeyboardIcon },
   { id: "about", label: "About", icon: InfoIcon },
@@ -83,6 +85,7 @@ export function Settings({ open, onOpenChange }: { open: boolean; onOpenChange: 
             {section === "providers" && <ProvidersSettings />}
             {section === "models" && <ModelsSettings />}
             {section === "skills" && <SkillsSettings />}
+            {section === "connect" && <ConnectSettings />}
             {section === "shortcuts" && <ShortcutsSettings />}
             {section === "privacy" && <AnalyticsSettings />}
             {section === "about" && <AboutSettings />}

--- a/packages/desktop/src/renderer/lib/__tests__/longText.test.ts
+++ b/packages/desktop/src/renderer/lib/__tests__/longText.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { isLongText, LONG_TEXT_CHARS, LONG_TEXT_LINES, previewLine } from "../longText";
+
+const chars = (n: number) => "x".repeat(n);
+const lines = (n: number) => Array.from({ length: n }, (_, i) => `line ${i}`).join("\n");
+
+describe("isLongText()", () => {
+  it("should return false for an ordinary chat message", () => {
+    expect(isLongText("how much did I spend on groceries last month?")).toBe(false);
+  });
+
+  it("should return false for an empty string", () => {
+    expect(isLongText("")).toBe(false);
+  });
+
+  it("should return false at exactly the character limit", () => {
+    expect(isLongText(chars(LONG_TEXT_CHARS))).toBe(false);
+  });
+
+  it("should return true one character past the limit", () => {
+    expect(isLongText(chars(LONG_TEXT_CHARS + 1))).toBe(true);
+  });
+
+  it("should return false at exactly the line limit", () => {
+    expect(isLongText(lines(LONG_TEXT_LINES))).toBe(false);
+  });
+
+  it("should return true one line past the limit", () => {
+    expect(isLongText(lines(LONG_TEXT_LINES + 1))).toBe(true);
+  });
+
+  // Long by shape rather than volume: many short lines still fill the view.
+  it("should return true for many short lines well under the character limit", () => {
+    const text = lines(LONG_TEXT_LINES + 5);
+    expect(text.length).toBeLessThan(LONG_TEXT_CHARS);
+    expect(isLongText(text)).toBe(true);
+  });
+
+  // The case that prompted this: an ACP client wrapping each turn in its own
+  // context block. Nothing here knows that, it is just long.
+  it("should return true for a turn wrapped in a client's context scaffold", () => {
+    const wrapped = `[Context]\nScope: dm\nChannel: DM (#abc)\n\n${chars(900)}\n\nContent: hi`;
+    expect(isLongText(wrapped)).toBe(true);
+  });
+});
+
+describe("previewLine()", () => {
+  it("should return a single-line message unchanged", () => {
+    expect(previewLine("add 20 EUR for coffee")).toBe("add 20 EUR for coffee");
+  });
+
+  it("should keep only the first line of a multi-line message", () => {
+    expect(previewLine("first line\nsecond line\nthird line")).toBe("first line");
+  });
+
+  it("should skip leading blank lines", () => {
+    expect(previewLine("\n\n   \nreal content\nmore")).toBe("real content");
+  });
+
+  it("should trim surrounding whitespace", () => {
+    expect(previewLine("   padded   \nnext")).toBe("padded");
+  });
+
+  it("should return an empty string for blank input so callers can fall back", () => {
+    expect(previewLine("   \n\n  ")).toBe("");
+    expect(previewLine("")).toBe("");
+  });
+
+  it("should cap an overlong first line with an ellipsis", () => {
+    const result = previewLine(chars(500), 20);
+    expect(result).toBe(`${chars(20)}…`);
+  });
+
+  it("should not cap a line at exactly the maximum", () => {
+    expect(previewLine(chars(20), 20)).toBe(chars(20));
+  });
+
+  it("should not leave trailing whitespace before the ellipsis", () => {
+    // The cut at 12 lands inside the run of spaces: "aaaa bbbb   ".
+    expect(previewLine("aaaa bbbb   cccc dddd", 12)).toBe("aaaa bbbb…");
+  });
+});

--- a/packages/desktop/src/renderer/lib/longText.ts
+++ b/packages/desktop/src/renderer/lib/longText.ts
@@ -1,0 +1,42 @@
+// When a sent message is long enough that showing it in full would bury the
+// conversation.
+//
+// Deliberately client-agnostic: an ACP client may wrap every turn in a large
+// scaffold of its own (channel context, event metadata, replayed history), and
+// a pasted log or stack trace does the same thing. Both are just "too long to
+// show inline", so both collapse by the same rule and nothing here knows which
+// client, if any, produced the text.
+
+/** Roughly a screenful of chat at the thread's width. */
+export const LONG_TEXT_CHARS = 800;
+
+/** Long by shape rather than volume: many short lines still fill the view. */
+export const LONG_TEXT_LINES = 12;
+
+const countLines = (text: string): number => {
+  let lines = 1;
+  for (let i = 0; i < text.length; i++) if (text[i] === "\n") lines++;
+  return lines;
+};
+
+export function isLongText(text: string): boolean {
+  return text.length > LONG_TEXT_CHARS || countLines(text) > LONG_TEXT_LINES;
+}
+
+/** Default cap for {@link previewLine}; well past any sidebar width, so the
+ *  visual truncation stays CSS's job and this only bounds the string. */
+const PREVIEW_MAX = 160;
+
+/**
+ * A one-line stand-in for a block of text: its first non-empty line, bounded.
+ *
+ * Used for the thread-list title, where a multi-line first message would
+ * otherwise leak whatever happens to be on its first line. Returns an empty
+ * string for blank input so callers can fall back.
+ */
+export function previewLine(text: string, max: number = PREVIEW_MAX): string {
+  const first = text.split("\n").find((line) => line.trim().length > 0);
+  if (!first) return "";
+  const trimmed = first.trim();
+  return trimmed.length > max ? `${trimmed.slice(0, max).trimEnd()}…` : trimmed;
+}

--- a/packages/desktop/src/renderer/rpc/api.ts
+++ b/packages/desktop/src/renderer/rpc/api.ts
@@ -78,6 +78,8 @@ export const agentApi = {
 export const appApi = {
   /** The running app's version (packaged metadata; dev shows the repo version). */
   version: () => api.invoke<string>("app_version"),
+  /** Absolute path of the ACP launcher, to register in an external ACP client. */
+  acpCommandPath: () => api.invoke<string>("acp_command_path"),
 };
 
 export const updateApi = {

--- a/packages/desktop/src/renderer/runtime/electronPiClient.ts
+++ b/packages/desktop/src/renderer/runtime/electronPiClient.ts
@@ -36,6 +36,7 @@ import {
 } from "../lib/analyticsEvents";
 import { extractAttachmentRefs } from "../lib/attachmentMarker";
 import { parseModelId } from "../lib/enabledModels";
+import { previewLine } from "../lib/longText";
 import { mentionsToPlainText } from "../lib/mentions";
 import { collapseSkillText, hoistSkillDirective } from "../lib/skillBlock";
 import { agentApi, authApi, sessionsApi, settingsApi, skillsApi } from "../rpc/api";
@@ -226,18 +227,22 @@ export function createElectronPiClient(): PiClient {
   const client: PiClient = {
     async listThreads() {
       const res = await sessionsApi.list();
-      return (res.sessions ?? []).map(
-        (s: SessionSummary): PiThreadMetadata => ({
+      return (res.sessions ?? []).map((s: SessionSummary): PiThreadMetadata => {
+        // Unnamed sessions fall back to their first message, which for a skill
+        // invocation is pi's expanded block — collapse it first. The result may
+        // still be many lines (a pasted log, or a turn an external ACP client
+        // wrapped in its own context), so keep only the first one: the sidebar
+        // shows a single truncated line either way.
+        const label = mentionsToPlainText(collapseSkillText(s.name || s.firstMessage || baseName(s.path)));
+        return {
           id: s.path,
           status: "idle",
-          // Unnamed sessions fall back to their first message, which for a
-          // skill invocation is pi's expanded block — collapse it first.
-          title: mentionsToPlainText(collapseSkillText(s.name || s.firstMessage || baseName(s.path))),
+          title: previewLine(label) || baseName(s.path),
           sessionFile: s.path,
           messageCount: s.messageCount,
           updatedAt: s.modified,
-        }),
-      );
+        };
+      });
     },
 
     async createThread(input) {

--- a/packages/desktop/tsconfig.main.json
+++ b/packages/desktop/tsconfig.main.json
@@ -15,5 +15,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/main", "src/preload", "src/shared"]
+  "include": ["src/main", "src/preload", "src/shared", "src/acp"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -66,10 +66,10 @@ export default defineConfig({
       // Kept just under the current effective baseline so the gate is honest
       // (green today) and each new test suite raises it.
       thresholds: {
-        statements: 97.7,
-        branches: 92.1,
+        statements: 97.9,
+        branches: 92.9,
         functions: 97.7,
-        lines: 98.8,
+        lines: 98.9,
       },
     },
   },


### PR DESCRIPTION
## Summary

Accountant24 now speaks the [Agent Client Protocol](https://agentclientprotocol.com), so you can chat with your ledger from Buzz, Zed, or any other ACP client. Implementing the standard once covers all of them rather than any single app.

Three pieces:

- **A launcher** (`resources/accountant24-acp`) shipped inside the app bundle, which starts the agent headless over stdio. Registering Accountant24 elsewhere is "paste this one path". The desktop app does not need to be running.
- **A translator** (`src/acp/`) that turns ACP requests into pi calls and pi's event stream back into `session/update` notifications, so streaming text and tool runs render properly on the other side. It reuses the existing agent runtime unchanged.
- **A Settings section** with the command and a copy button, plus a docs page.

Everything points at the same `~/Accountant24` workspace, so a chat started elsewhere appears in the app's chat list.

Also collapses an overlong sent message in the transcript behind a Show more toggle. The rule is length, not provenance, so it covers a pasted log as much as a turn an external client wrapped in its own context.

## Protocol decisions

| Decision | Choice |
| --- | --- |
| Version | `protocolVersion: 1`, the current stable version (v2 is a draft, `experimental/v2` in the SDK) |
| `cwd` from `session/new` | Ignored. Accountant24 is a ledger agent, so it always works on the ledger |
| `mcpServers` | Ignored and logged to stderr; the pi SDK has no MCP client |
| `fs/*`, `terminal/*` | Never called; our tools run in the workspace with the vendored binaries |
| Models | Exposed as `configOptions` with `category: "model"`, honoring the app's default and enabled models |

## Verification

- `npm run verify` green: 2127 tests, coverage above the gate (thresholds ratcheted up).
- Full turn through the **packaged** app, spawned from an unrelated directory, against a local fake model server: `initialize` → `session/new` → streamed updates → `end_turn`. No real credentials or ledger data involved.
- Model discovery reproduced exactly as Buzz invokes it (`buzz-acp models --json`), including under a GUI-minimal PATH.
- `line-clamp` behavior for the collapse measured in the running app: 192px vs 1200px for a 50-line message.

## Notes

Two bugs were caught during verification and fixed here: workspace paths were being computed eagerly against the app bundle, and new session files recorded the spawning client's working directory, which would have hidden ACP chats from the app's chat list.

## Open follow-ups

Not blocking this PR, tracked separately:

- **Rename and polish the Connect page in Settings.** The nav label still reads "Connect", which in a finance app risks being taken as "connect your bank". "ACP" was considered and rejected as jargon that breaks the plain-word nav. Naming is undecided.
- **Test ACP with Buzz and other clients.** Buzz is verified end to end, including channel replies. Zed and the headless `acpx` client are not, nor are the paths Buzz never exercises: cancel mid-turn, image and resource content blocks, model switching via `session/set_config_option`, and the `auth_required` path on a workspace with no provider.
- **Add ACP client names to chats, to tell them apart from normal chats.** Both inputs are standard protocol and already readable: `initialize` carries `clientInfo` (Buzz reports `buzz-acp`), and `session/new` carries `_meta.sessionTitle`. Where to store the marker is undecided.
