### PR TITLE
feat: friendly labels for the built-in tool steps in the chat

### DIFF
--- a/packages/desktop/src/renderer/components/accountant24/__tests__/tool-fallback.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/tool-fallback.test.tsx
@@ -46,6 +46,36 @@ describe("toolLabel()", () => {
     });
   });
 
+  describe("built-in pi tool labels", () => {
+    it("should return 'Run Command' when toolName is 'bash'", () => {
+      expect(toolLabel("bash")).toBe("Run Command");
+    });
+
+    it("should return 'Read File' when toolName is 'read'", () => {
+      expect(toolLabel("read")).toBe("Read File");
+    });
+
+    it("should return 'Edit File' when toolName is 'edit'", () => {
+      expect(toolLabel("edit")).toBe("Edit File");
+    });
+
+    it("should return 'Write File' when toolName is 'write'", () => {
+      expect(toolLabel("write")).toBe("Write File");
+    });
+
+    it("should return 'List Files' when toolName is 'ls'", () => {
+      expect(toolLabel("ls")).toBe("List Files");
+    });
+
+    it("should return 'Search Files' when toolName is 'grep'", () => {
+      expect(toolLabel("grep")).toBe("Search Files");
+    });
+
+    it("should return 'Find Files' when toolName is 'find'", () => {
+      expect(toolLabel("find")).toBe("Find Files");
+    });
+  });
+
   describe("fallback for unknown tools", () => {
     it("should return the raw tool name when there is no label entry", () => {
       expect(toolLabel("fetch_exchange_rates")).toBe("fetch_exchange_rates");
@@ -221,9 +251,9 @@ describe("ToolFallback memory updates", () => {
     expect(screen.getByText("Update Memory")).toBeTruthy();
   });
 
-  it("should keep the raw tool name for edits of other files", () => {
+  it("should keep the plain edit label for edits of other files", () => {
     render(<ToolFallback {...partProps({ toolName: "edit", args: { path: "ledger/main.journal", edits: [] } })} />);
-    expect(screen.getByText("edit")).toBeTruthy();
+    expect(screen.getByText("Edit File")).toBeTruthy();
     expect(screen.queryByText("Update Memory")).toBeNull();
   });
 
@@ -232,9 +262,9 @@ describe("ToolFallback memory updates", () => {
     expect(screen.getByText("Read Memory")).toBeTruthy();
   });
 
-  it("should keep the raw tool name for reads of other files", () => {
+  it("should keep the plain read label for reads of other files", () => {
     render(<ToolFallback {...partProps({ toolName: "read", args: { path: "ledger/main.journal" } })} />);
-    expect(screen.getByText("read")).toBeTruthy();
+    expect(screen.getByText("Read File")).toBeTruthy();
     expect(screen.queryByText("Read Memory")).toBeNull();
   });
 });

--- a/packages/desktop/src/renderer/components/accountant24/tool-fallback.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/tool-fallback.tsx
@@ -30,7 +30,7 @@ const statusIconMap: Record<ToolStatus, React.ElementType> = {
   "requires-action": AlertCircleIcon,
 };
 
-// TOOL_LABELS mirrors the pi extension's `label` metadata (the event stream
+// TOOL_LABELS covers the custom tools and pi's built-ins (the event stream
 // only carries tool names). Tools without an entry show their raw name.
 export const toolLabel = (toolName: string) => TOOL_LABELS[toolName] ?? toolName;
 

--- a/packages/desktop/src/renderer/lib/tool-labels.ts
+++ b/packages/desktop/src/renderer/lib/tool-labels.ts
@@ -1,11 +1,10 @@
 // Human-readable labels for the agent's tools, keyed by tool name (the event
-// stream only carries tool names).
-//
-// Deliberately DUPLICATED from packages/pi-extension/src/tool-labels.ts so the
-// renderer never imports from the agent package. When a tool is added or
-// renamed there, update this map too — an unknown name falls back to a
-// prettified version of the raw tool name, so a miss is cosmetic, not broken.
+// stream only carries tool names). An unknown name falls back to the raw tool
+// name, so a miss is cosmetic, not broken.
 export const TOOL_LABELS: Record<string, string> = {
+  // Custom tools — deliberately DUPLICATED from
+  // packages/pi-extension/src/tool-labels.ts so the renderer never imports from
+  // the agent package. When a tool is added or renamed there, update this too.
   query: "Query Ledger",
   add_transactions: "Add Transactions",
   add_balance_assertions: "Add Balance Assertions",
@@ -13,4 +12,14 @@ export const TOOL_LABELS: Record<string, string> = {
   extract_text: "Extract Text",
   validate: "Validate Ledger",
   commit_and_push: "Commit & Push",
+
+  // pi's built-in tools — pi only carries lowercase raw names for these, so
+  // they are labeled here, renderer-side only.
+  bash: "Run Command",
+  read: "Read File",
+  edit: "Edit File",
+  write: "Write File",
+  ls: "List Files",
+  grep: "Search Files",
+  find: "Find Files",
 };


### PR DESCRIPTION
- Show friendly labels for pi's built-in tools in chat tool steps:
  - `bash` → Run Command
  - `read` → Read File
  - `edit` → Edit File
  - `write` → Write File
  - `ls` → List Files
  - `grep` → Search Files
  - `find` → Find Files
- Keep the raw-name fallback for tools without a label entry
- Add label tests for the built-in tools