### PR TITLE
fix: rename the "Commit & Push" tool to "Commit"

### DIFF
--- a/packages/desktop/src/renderer/components/accountant24/__tests__/tool-fallback.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/tool-fallback.test.tsx
@@ -41,8 +41,8 @@ describe("toolLabel()", () => {
       expect(toolLabel("validate")).toBe("Validate Ledger");
     });
 
-    it("should return 'Commit & Push' when toolName is 'commit_and_push'", () => {
-      expect(toolLabel("commit_and_push")).toBe("Commit & Push");
+    it("should return 'Commit' when toolName is 'commit_and_push'", () => {
+      expect(toolLabel("commit_and_push")).toBe("Commit");
     });
   });
 

--- a/packages/desktop/src/renderer/lib/tool-labels.ts
+++ b/packages/desktop/src/renderer/lib/tool-labels.ts
@@ -11,7 +11,7 @@ export const TOOL_LABELS: Record<string, string> = {
   add_prices: "Add Prices",
   extract_text: "Extract Text",
   validate: "Validate Ledger",
-  commit_and_push: "Commit & Push",
+  commit_and_push: "Commit",
 
   // pi's built-in tools — pi only carries lowercase raw names for these, so
   // they are labeled here, renderer-side only.

--- a/packages/pi-extension/src/tool-labels.ts
+++ b/packages/pi-extension/src/tool-labels.ts
@@ -9,5 +9,5 @@ export const TOOL_LABELS: Record<string, string> = {
   add_prices: "Add Prices",
   extract_text: "Extract Text",
   validate: "Validate Ledger",
-  commit_and_push: "Commit & Push",
+  commit_and_push: "Commit",
 };


### PR DESCRIPTION
- Rename the `commit_and_push` tool label from "Commit & Push" to "Commit"