### PR TITLE
feat: optional assertion columns on the Net Worth page

### DIFF
--- a/packages/desktop/src/main/__tests__/ledger-json.test.ts
+++ b/packages/desktop/src/main/__tests__/ledger-json.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   mergeValuedBalanceSheet,
-  parseAssertionDates,
+  parseAssertions,
   parseBalanceSheetJson,
   parseLatestPriceTarget,
   type RawBalanceSheet,
@@ -261,38 +261,72 @@ describe("mergeValuedBalanceSheet()", () => {
   });
 });
 
-// parseAssertionDates turns `hledger print -O json` output (an array of
+// parseAssertions turns `hledger print -O json` output (an array of
 // transactions with postings; a posting carrying `pbalanceassertion` asserts
-// its account's balance on that date) into each account's latest assertion
-// date. Fixtures follow the documented shape.
+// its account's balance on that date) into each account's latest assertion:
+// its date and the asserted amount. Fixtures follow the documented shape.
 
-describe("parseAssertionDates()", () => {
-  const posting = (account: string, asserted: boolean, pdate: string | null = null) => ({
+describe("parseAssertions()", () => {
+  const posting = (
+    account: string,
+    asserted: boolean,
+    pdate: string | null = null,
+    baamount: unknown = amt("EUR", 200),
+  ) => ({
     paccount: account,
     pdate,
-    pbalanceassertion: asserted ? { baamount: {}, batotal: false } : null,
+    pbalanceassertion: asserted ? { baamount, batotal: false } : null,
   });
   const txn = (date: string, postings: unknown[]) => ({ tdate: date, tpostings: postings });
+  // What the default `baamount` fixture must parse to.
+  const EUR200 = { commodity: "EUR", quantity: 200, precision: 2 };
 
   it("should return {} for an empty string, garbage, or a non-array", () => {
-    expect(parseAssertionDates("")).toEqual({});
-    expect(parseAssertionDates("hledger: error")).toEqual({});
-    expect(parseAssertionDates('{"a": 1}')).toEqual({});
+    expect(parseAssertions("")).toEqual({});
+    expect(parseAssertions("hledger: error")).toEqual({});
+    expect(parseAssertions('{"a": 1}')).toEqual({});
   });
 
   it("should return {} when no posting carries an assertion", () => {
     const json = JSON.stringify([txn("2026-06-01", [posting("assets:bank", false)])]);
-    expect(parseAssertionDates(json)).toEqual({});
+    expect(parseAssertions(json)).toEqual({});
   });
 
   it("should record the transaction date of an asserting posting", () => {
     const json = JSON.stringify([txn("2026-06-15", [posting("assets:bank", true), posting("equity", false)])]);
-    expect(parseAssertionDates(json)).toEqual({ "assets:bank": "2026-06-15" });
+    expect(parseAssertions(json)).toEqual({ "assets:bank": { date: "2026-06-15", amount: EUR200 } });
+  });
+
+  it("should parse the asserted amount off the asserting posting", () => {
+    const json = JSON.stringify([txn("2026-06-15", [posting("assets:btc", true, null, amt("BTC", 0.16, 8))])]);
+    expect(parseAssertions(json)).toEqual({
+      "assets:btc": { date: "2026-06-15", amount: { commodity: "BTC", quantity: 0.16, precision: 8 } },
+    });
+  });
+
+  it("should default the amount's precision to 2 when the journal declares none", () => {
+    const bare = { acommodity: "EUR", aquantity: { floatingPoint: 77 } };
+    const json = JSON.stringify([txn("2026-06-15", [posting("assets:bank", true, null, bare)])]);
+    expect(parseAssertions(json)).toEqual({
+      "assets:bank": { date: "2026-06-15", amount: { commodity: "EUR", quantity: 77, precision: 2 } },
+    });
+  });
+
+  it("should record a null amount when the assertion's amount is missing or malformed, keeping the date", () => {
+    const json = JSON.stringify([
+      // An assertion object with no baamount at all.
+      txn("2026-06-15", [{ paccount: "assets:bare", pdate: null, pbalanceassertion: { batotal: false } }]),
+      txn("2026-06-16", [posting("assets:odd", true, null, { acommodity: 5 })]),
+    ]);
+    expect(parseAssertions(json)).toEqual({
+      "assets:bare": { date: "2026-06-15", amount: null },
+      "assets:odd": { date: "2026-06-16", amount: null },
+    });
   });
 
   it("should prefer the posting's own date over the transaction's", () => {
     const json = JSON.stringify([txn("2026-07-10", [posting("assets:bank", true, "2026-07-12")])]);
-    expect(parseAssertionDates(json)).toEqual({ "assets:bank": "2026-07-12" });
+    expect(parseAssertions(json)).toEqual({ "assets:bank": { date: "2026-07-12", amount: EUR200 } });
   });
 
   it("should keep the latest date per account regardless of journal order", () => {
@@ -301,7 +335,22 @@ describe("parseAssertionDates()", () => {
       txn("2026-06-15", [posting("assets:bank", true)]),
       txn("2026-05-01", [posting("assets:cash", true)]),
     ]);
-    expect(parseAssertionDates(json)).toEqual({ "assets:bank": "2026-07-01", "assets:cash": "2026-05-01" });
+    expect(parseAssertions(json)).toEqual({
+      "assets:bank": { date: "2026-07-01", amount: EUR200 },
+      "assets:cash": { date: "2026-05-01", amount: EUR200 },
+    });
+  });
+
+  it("should carry the amount together with the latest date when assertions repeat", () => {
+    // Journal order deliberately newest-first: the winning record must take
+    // BOTH its date and its amount from the same (latest) posting.
+    const json = JSON.stringify([
+      txn("2026-07-01", [posting("assets:bank", true, null, amt("EUR", 250))]),
+      txn("2026-06-01", [posting("assets:bank", true, null, amt("EUR", 100))]),
+    ]);
+    expect(parseAssertions(json)).toEqual({
+      "assets:bank": { date: "2026-07-01", amount: { commodity: "EUR", quantity: 250, precision: 2 } },
+    });
   });
 
   it("should skip malformed transactions and postings but keep the valid ones", () => {
@@ -311,7 +360,7 @@ describe("parseAssertionDates()", () => {
       txn("2026-06-02", ["not a posting", { pbalanceassertion: {}, paccount: "" }, posting("assets:ok", true)]),
       { tpostings: [posting("assets:dateless", true)] },
     ]);
-    expect(parseAssertionDates(json)).toEqual({ "assets:ok": "2026-06-02" });
+    expect(parseAssertions(json)).toEqual({ "assets:ok": { date: "2026-06-02", amount: EUR200 } });
   });
 });
 

--- a/packages/desktop/src/main/__tests__/ledger.test.ts
+++ b/packages/desktop/src/main/__tests__/ledger.test.ts
@@ -235,7 +235,7 @@ describe("ledger_net_worth", () => {
     print: printed([
       {
         tdate: "2026-07-05",
-        tpostings: [{ paccount: "assets:btc", pdate: null, pbalanceassertion: { baamount: {} } }],
+        tpostings: [{ paccount: "assets:btc", pdate: null, pbalanceassertion: { baamount: amt("BTC", 0.16, 8) } }],
       },
     ]),
     // The latest price in the stub journal targets EUR: the derived base.
@@ -254,6 +254,7 @@ describe("ledger_net_worth", () => {
               amounts: [{ quantity: 0.16, commodity: "BTC", precision: 8 }],
               value: [{ quantity: 9990, commodity: "EUR", precision: 2 }],
               assertedOn: "2026-07-05",
+              assertedAmount: { quantity: 0.16, commodity: "BTC", precision: 8 },
             },
           ],
           total: {
@@ -312,10 +313,26 @@ describe("ledger_net_worth", () => {
     expect(argLists).toContainEqual(["bs", "-O", "json", "-f", "/ws/ledger/main.journal", "-V"]);
   });
 
+  it("should graft only the date when the assertion carries no parseable amount", async () => {
+    stubHledger({
+      ...STUBS,
+      print: printed([
+        {
+          tdate: "2026-07-05",
+          tpostings: [{ paccount: "assets:btc", pdate: null, pbalanceassertion: { baamount: {} } }],
+        },
+      ]),
+    });
+    const row = (await netWorth()).sections[0]?.rows[0];
+    expect(row?.assertedOn).toBe("2026-07-05");
+    expect(row?.assertedAmount).toBeUndefined();
+  });
+
   it("should leave rows without assertions untouched when the print run fails", async () => {
     stubHledger({ ...STUBS, print: new Error("boom") });
     const sheet = await netWorth();
     expect(sheet.sections[0]?.rows[0]?.assertedOn).toBeUndefined();
+    expect(sheet.sections[0]?.rows[0]?.assertedAmount).toBeUndefined();
   });
 
   it("should fall back to the raw amounts as the value when the valued run fails", async () => {

--- a/packages/desktop/src/main/ledger-json.ts
+++ b/packages/desktop/src/main/ledger-json.ts
@@ -126,11 +126,19 @@ export function parseLatestPriceTarget(text: string): string | null {
   return symbol.length > 0 ? symbol : null;
 }
 
+/** An account's most recent balance assertion: when, and what balance was
+ *  asserted. The amount is null when the assertion's own Amount didn't parse
+ *  (both fields always come from the same winning posting). */
+export interface Assertion {
+  date: string;
+  amount: LedgerAmount | null;
+}
+
 /** Parse `hledger print -O json` output into each account's most recent
- *  balance-assertion date — the posting's own date when it has one, the
- *  transaction's otherwise. Accounts without assertions are absent; anything
- *  unparseable yields {}. */
-export function parseAssertionDates(json: string): Record<string, string> {
+ *  balance assertion — its date (the posting's own date when it has one, the
+ *  transaction's otherwise) and its asserted amount. Accounts without
+ *  assertions are absent; anything unparseable yields {}. */
+export function parseAssertions(json: string): Record<string, Assertion> {
   let data: unknown;
   try {
     data = JSON.parse(json);
@@ -138,7 +146,7 @@ export function parseAssertionDates(json: string): Record<string, string> {
     return {};
   }
   if (!Array.isArray(data)) return {};
-  const latest: Record<string, string> = {};
+  const latest: Record<string, Assertion> = {};
   for (const txn of data) {
     const t = txn as { tdate?: unknown; tpostings?: unknown };
     if (!Array.isArray(t?.tpostings)) continue;
@@ -148,7 +156,14 @@ export function parseAssertionDates(json: string): Record<string, string> {
       const date = typeof p.pdate === "string" && p.pdate ? p.pdate : t.tdate;
       if (typeof date !== "string" || !date) continue;
       const prev = latest[p.paccount];
-      if (!prev || date > prev) latest[p.paccount] = date;
+      if (!prev || date > prev.date) {
+        latest[p.paccount] = {
+          date,
+          // The asserted amount, when the assertion's Amount parses; an
+          // assertion pins one commodity, so baamount is a single Amount.
+          amount: parseAmount((p.pbalanceassertion as { baamount?: unknown }).baamount),
+        };
+      }
     }
   }
   return latest;

--- a/packages/desktop/src/main/ledger.ts
+++ b/packages/desktop/src/main/ledger.ts
@@ -14,12 +14,7 @@ import path from "node:path";
 import { ipcMain } from "electron";
 import type { LedgerMentions, NetWorth } from "../shared/types";
 import { agentEnv, binDir, mainJournalPath, workspaceDir } from "./env";
-import {
-  mergeValuedBalanceSheet,
-  parseAssertionDates,
-  parseBalanceSheetJson,
-  parseLatestPriceTarget,
-} from "./ledger-json";
+import { mergeValuedBalanceSheet, parseAssertions, parseBalanceSheetJson, parseLatestPriceTarget } from "./ledger-json";
 
 function hledgerBin(): string {
   const exe = path.join(binDir(), process.platform === "win32" ? "hledger.exe" : "hledger");
@@ -75,10 +70,10 @@ async function resolveBaseCommodity(): Promise<string | null> {
  *  collapses multi-commodity holdings to one base-currency figure wherever
  *  hledger finds any price path (direct, reverse, chained, or cost-
  *  inferred); with no prices declared there is nothing to aim at, and `-V`
- *  lets hledger value what it can. Each row also carries the date of the
- *  account's latest balance assertion (from `print -O json`) — when the
- *  balance was last reconciled. Empty when there's no journal yet or hledger
- *  fails. */
+ *  lets hledger value what it can. Each row also carries the date and amount
+ *  of the account's latest balance assertion (from `print -O json`) — when
+ *  the balance was last reconciled and what it was confirmed to be. Empty
+ *  when there's no journal yet or hledger fails. */
 async function ledgerNetWorth(): Promise<NetWorth> {
   const base = ["bs", "-O", "json", "-f", mainJournalPath()];
   const [native, printed, target] = await Promise.all([
@@ -90,12 +85,18 @@ async function ledgerNetWorth(): Promise<NetWorth> {
   const raw = parseBalanceSheetJson(native);
   if (raw === null) return { sections: [], net: { amounts: [], value: [] } };
   const sheet = mergeValuedBalanceSheet(raw, parseBalanceSheetJson(valued));
-  const asserted = parseAssertionDates(printed);
+  const asserted = parseAssertions(printed);
   return {
     ...sheet,
     sections: sheet.sections.map((section) => ({
       ...section,
-      rows: section.rows.map((row) => (asserted[row.name] ? { ...row, assertedOn: asserted[row.name] } : row)),
+      rows: section.rows.map((row) => {
+        const a = asserted[row.name];
+        if (!a) return row;
+        // Date always; the amount only when the assertion's Amount parsed —
+        // assertedAmount never appears without assertedOn.
+        return a.amount ? { ...row, assertedOn: a.date, assertedAmount: a.amount } : { ...row, assertedOn: a.date };
+      }),
     })),
   };
 }

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-view.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-view.test.tsx
@@ -6,9 +6,11 @@
 // hledger) with the section's own total, the hledger-computed Net as the
 // closing line, sorting on every column (A-Z on the account path by default,
 // independent per section), search filtering every section by path, the
-// empty state (no journal yet or hledger failed), and the refetch on the
-// agent's running → idle edge. jsdom pins navigator.language to en-US, so
-// formatted expectations are deterministic.
+// two assertion columns hidden by default behind the header's Columns menu
+// (the choice persisted in localStorage), the empty state (no journal yet
+// or hledger failed), and the refetch on the agent's running → idle edge.
+// jsdom pins navigator.language to en-US, so formatted expectations are
+// deterministic.
 
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -30,6 +32,8 @@ beforeAll(() => installJsdomPolyfills());
 afterEach(() => cleanup());
 beforeEach(() => {
   vi.mocked(ledgerApi.netWorth).mockReset();
+  // The Columns choice persists here; every spec starts from the default.
+  window.localStorage.clear();
 });
 
 /** Real assistant-ui chrome so the view's `useAuiState` reads an honest
@@ -60,9 +64,17 @@ const DATA: NetWorth = {
           amounts: [A("UAH", 1408.26), A("USD", 100)],
           value: [A("EUR", 115.573, 3)],
           assertedOn: "2026-06-15",
+          // The balance has drifted since the assertion — the realistic case.
+          assertedAmount: A("UAH", 1400),
         },
         { name: "assets:darka:etf:sxr8", amounts: [A("SXR8", 22.45)], value: [A("EUR", 1920.148, 3)] },
-        { name: "assets:bank", amounts: [A("EUR", 50)], value: [A("EUR", 50)], assertedOn: "2026-07-12" },
+        {
+          name: "assets:bank",
+          amounts: [A("EUR", 50)],
+          value: [A("EUR", 50)],
+          assertedOn: "2026-07-12",
+          assertedAmount: A("EUR", 45),
+        },
       ],
       total: {
         amounts: [A("UAH", 1408.26), A("USD", 100), A("SXR8", 22.45), A("EUR", 50)],
@@ -94,6 +106,15 @@ const accountOrder = (tableName: string) =>
     .getAllByRole("row")
     .slice(1) // the column-header row
     .map((row) => row.querySelector("td")?.getAttribute("title"));
+
+/** Turn both assertion columns on through the header's Columns menu, then
+ *  close it so the tables are clickable again. */
+const showAssertionColumns = async () => {
+  await userEvent.click(screen.getByRole("button", { name: "Columns" }));
+  await userEvent.click(await screen.findByRole("menuitemcheckbox", { name: "Asserted On" }));
+  await userEvent.click(screen.getByRole("menuitemcheckbox", { name: "Asserted Amount" }));
+  await userEvent.keyboard("{Escape}");
+};
 
 describe("<NetWorthView />", () => {
   it("should show the page chrome immediately and skeletons only for the loading data", () => {
@@ -187,18 +208,51 @@ describe("<NetWorthView />", () => {
     expect(screen.queryByText("~50.00 EUR")).not.toBeInTheDocument();
   });
 
-  it("should show each account's last balance assertion date, and an em dash when it was never asserted", async () => {
+  it("should show each account's last asserted date, and an em dash when it was never asserted, when toggled on", async () => {
     vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
     renderView();
-    // Settle on loaded data first — the skeleton also carries the header.
     await screen.findByTitle("assets:cash");
+    await showAssertionColumns();
     // One sortable header per section table.
-    expect(screen.getAllByRole("button", { name: "Last Balance Assertion" })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: "Asserted On" })).toHaveLength(2);
     // The journal's own ISO dates, verbatim.
     expect(screen.getByText("2026-07-12")).toBeInTheDocument();
     expect(screen.getByText("2026-06-15")).toBeInTheDocument();
-    // Never asserted: the SXR8 account and the liability.
-    expect(screen.getAllByText("\u2014")).toHaveLength(2);
+    // Never asserted (the SXR8 account and the liability): a dash in the
+    // date and in the amount column \u2014 two rows times two columns.
+    expect(screen.getAllByText("\u2014")).toHaveLength(4);
+  });
+
+  it("should show the last asserted amount in the account's own commodity when toggled on", async () => {
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
+    renderView();
+    await screen.findByTitle("assets:cash");
+    await showAssertionColumns();
+    expect(screen.getAllByRole("button", { name: "Asserted Amount" })).toHaveLength(2);
+    // Formatted like Holding: locale digits, commodity suffix, the amount's
+    // own precision \u2014 and distinct from the current holding (the balance
+    // moved since the assertion).
+    expect(screen.getByText("1,400.00 UAH")).toBeInTheDocument();
+    expect(screen.getByText("45.00 EUR")).toBeInTheDocument();
+  });
+
+  it("should show the date but a dash in the amount cell when the assertion carried no amount", async () => {
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue({
+      sections: [
+        {
+          name: "Assets",
+          rows: [{ name: "assets:legacy", amounts: [A("EUR", 10)], value: [A("EUR", 10)], assertedOn: "2026-05-01" }],
+          total: { amounts: [A("EUR", 10)], value: [A("EUR", 10)] },
+        },
+      ],
+      net: { amounts: [A("EUR", 10)], value: [A("EUR", 10)] },
+    });
+    renderView();
+    await screen.findByTitle("assets:legacy");
+    await showAssertionColumns();
+    expect(screen.getByText("2026-05-01")).toBeInTheDocument();
+    // Only the amount cell falls back to the dash.
+    expect(screen.getAllByText("\u2014")).toHaveLength(1);
   });
 
   it("should show a multi-commodity holding comma-joined on one line", async () => {
@@ -276,16 +330,31 @@ describe("<NetWorthView />", () => {
       expect(accountOrder("Assets")).toEqual(["assets:darka:etf:sxr8", "assets:bank", "assets:cash"]);
     });
 
-    it("should sort by assertion date, most recent first, with never-asserted rows last", async () => {
+    it("should sort by asserted date, most recent first, with never-asserted rows last", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
       await screen.findByTitle("assets:cash");
-      await userEvent.click(assetsButton("Last Balance Assertion"));
+      await showAssertionColumns();
+      await userEvent.click(assetsButton("Asserted On"));
       // bank (07-12) > cash (06-15) > darka (never asserted).
       expect(accountOrder("Assets")).toEqual(["assets:bank", "assets:cash", "assets:darka:etf:sxr8"]);
       // A second click flips: never-asserted first, then oldest.
-      await userEvent.click(assetsButton("Last Balance Assertion"));
+      await userEvent.click(assetsButton("Asserted On"));
       expect(accountOrder("Assets")).toEqual(["assets:darka:etf:sxr8", "assets:cash", "assets:bank"]);
+    });
+
+    it("should sort by the asserted amount, biggest first, with never-asserted rows counting as zero", async () => {
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
+      renderView();
+      await screen.findByTitle("assets:cash");
+      await showAssertionColumns();
+      // Asserted quantities: cash=1,400, bank=45, darka=0 (never asserted) —
+      // a plain number sort, like Holding.
+      await userEvent.click(assetsButton("Asserted Amount"));
+      expect(accountOrder("Assets")).toEqual(["assets:cash", "assets:bank", "assets:darka:etf:sxr8"]);
+      // A second click flips to smallest first.
+      await userEvent.click(assetsButton("Asserted Amount"));
+      expect(accountOrder("Assets")).toEqual(["assets:darka:etf:sxr8", "assets:bank", "assets:cash"]);
     });
 
     it("should keep each section's sorting independent", async () => {
@@ -361,16 +430,31 @@ describe("<NetWorthView />", () => {
       ).toBeInTheDocument();
     });
 
-    it("should explain the Last Balance Assertion column, including the dash", async () => {
+    it("should explain the Asserted On column, including the dash", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
       await screen.findByTitle("assets:cash");
-      await hoverInfo("Last Balance Assertion");
+      await showAssertionColumns();
+      await hoverInfo("Asserted On");
       expect(
         await screen.findByText(/When the ledger balance was last confirmed to match the real account balance/),
       ).toBeInTheDocument();
       expect(screen.getByText(/A dash means it was never confirmed/)).toBeInTheDocument();
       // The tooltip also teaches how to confirm one.
+      expect(screen.getByText(/My cash balance is 200 EUR/)).toBeInTheDocument();
+    });
+
+    it("should explain the Asserted Amount column, including the dash", async () => {
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
+      renderView();
+      await screen.findByTitle("assets:cash");
+      await showAssertionColumns();
+      await hoverInfo("Asserted Amount");
+      expect(
+        await screen.findByText(/The ledger balance that was last confirmed to match the real account balance/),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/A dash means it was never confirmed/)).toBeInTheDocument();
+      // The same how-to line as the date column's tooltip.
       expect(screen.getByText(/My cash balance is 200 EUR/)).toBeInTheDocument();
     });
 
@@ -419,6 +503,117 @@ describe("<NetWorthView />", () => {
       expect(screen.getAllByText("No matching accounts")).toHaveLength(2);
       await userEvent.clear(box);
       expect(accountOrder("Assets")).toHaveLength(3);
+    });
+  });
+
+  describe("column visibility", () => {
+    it("should hide both assertion columns by default", async () => {
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
+      renderView();
+      await screen.findByTitle("assets:cash");
+      expect(screen.queryByRole("button", { name: "Asserted On" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Asserted Amount" })).not.toBeInTheDocument();
+      expect(screen.queryByText("2026-07-12")).not.toBeInTheDocument();
+      expect(screen.queryByText("1,400.00 UAH")).not.toBeInTheDocument();
+    });
+
+    it("should list only the two assertion columns in the Columns menu, unchecked by default", async () => {
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
+      renderView();
+      await screen.findByTitle("assets:cash");
+      await userEvent.click(screen.getByRole("button", { name: "Columns" }));
+      const items = await screen.findAllByRole("menuitemcheckbox");
+      // Account, Holding, and Value are the page's spine: never listed.
+      expect(items.map((item) => item.textContent)).toEqual(["Asserted On", "Asserted Amount"]);
+      for (const item of items) {
+        expect(item).toHaveAttribute("aria-checked", "false");
+      }
+    });
+
+    it("should show the assertion columns in both section tables when toggled on", async () => {
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
+      renderView();
+      await screen.findByTitle("assets:cash");
+      await showAssertionColumns();
+      for (const table of ["Assets", "Liabilities"]) {
+        const scope = within(screen.getByRole("table", { name: table }));
+        expect(scope.getByRole("button", { name: "Asserted On" })).toBeInTheDocument();
+        expect(scope.getByRole("button", { name: "Asserted Amount" })).toBeInTheDocument();
+      }
+    });
+
+    it("should persist the column choice and restore it on remount", async () => {
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
+      const { unmount } = renderView();
+      await screen.findByTitle("assets:cash");
+      await showAssertionColumns();
+      expect(window.localStorage.getItem("accountant24.net-worth.columns")).toBe(
+        JSON.stringify({ asserted: true, assertedAmount: true }),
+      );
+      unmount();
+
+      // A fresh mount reads the stored choice: no menu interaction needed.
+      renderView();
+      await screen.findByTitle("assets:cash");
+      expect(screen.getAllByRole("button", { name: "Asserted On" })).toHaveLength(2);
+      expect(screen.getByText("1,400.00 UAH")).toBeInTheDocument();
+    });
+
+    it("should reflect the persisted columns in the loading skeleton, hidden by default", async () => {
+      window.localStorage.setItem(
+        "accountant24.net-worth.columns",
+        JSON.stringify({ asserted: true, assertedAmount: true }),
+      );
+      vi.mocked(ledgerApi.netWorth).mockReturnValue(new Promise(() => {}));
+      const { unmount } = renderView();
+      const skeleton = screen.getByRole("status", { name: "Loading accounts" });
+      expect(within(skeleton).getByText("Asserted On")).toBeInTheDocument();
+      expect(within(skeleton).getByText("Asserted Amount")).toBeInTheDocument();
+      unmount();
+
+      // Without a stored choice the skeleton shows only the default columns.
+      window.localStorage.clear();
+      renderView();
+      expect(screen.queryByText("Asserted On")).not.toBeInTheDocument();
+      expect(screen.queryByText("Asserted Amount")).not.toBeInTheDocument();
+    });
+
+    it("should show only the toggled column when just one is enabled", async () => {
+      window.localStorage.setItem(
+        "accountant24.net-worth.columns",
+        JSON.stringify({ asserted: true, assertedAmount: false }),
+      );
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
+      renderView();
+      await screen.findByTitle("assets:cash");
+      expect(screen.getAllByRole("button", { name: "Asserted On" })).toHaveLength(2);
+      expect(screen.queryByRole("button", { name: "Asserted Amount" })).not.toBeInTheDocument();
+      expect(screen.getByText("2026-07-12")).toBeInTheDocument();
+      expect(screen.queryByText("1,400.00 UAH")).not.toBeInTheDocument();
+    });
+
+    it("should fall back to hidden columns when the stored value is garbage", async () => {
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
+      for (const stored of ["not json", JSON.stringify({ asserted: "yes" }), JSON.stringify(null)]) {
+        window.localStorage.setItem("accountant24.net-worth.columns", stored);
+        const { unmount } = renderView();
+        await screen.findByTitle("assets:cash");
+        expect(screen.queryByRole("button", { name: "Asserted On" })).not.toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Asserted Amount" })).not.toBeInTheDocument();
+        unmount();
+      }
+    });
+
+    it("should span the empty-search row across only the visible columns", async () => {
+      vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
+      renderView();
+      await screen.findByTitle("assets:cash");
+      await userEvent.type(screen.getByRole("searchbox", { name: "Search accounts" }), "zzz");
+      const emptyCell = () => screen.getAllByText("No matching accounts")[0]?.closest("td");
+      expect(emptyCell()?.colSpan).toBe(3);
+      // With the assertion pair on, the row widens to match.
+      await showAssertionColumns();
+      expect(emptyCell()?.colSpan).toBe(5);
     });
   });
 

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth.integration.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth.integration.test.tsx
@@ -7,6 +7,7 @@
 // boundary is the fake bridge.
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { installJsdomPolyfills } from "@/test/jsdomPolyfills";
 
@@ -56,6 +57,7 @@ const DATA: NetWorth = {
           amounts: [{ quantity: 100, commodity: "USD", precision: 2 }],
           value: [{ quantity: 86, commodity: "EUR", precision: 2 }],
           assertedOn: "2026-07-01",
+          assertedAmount: { quantity: 95, commodity: "USD", precision: 2 },
         },
         {
           name: "assets:checking",
@@ -114,6 +116,8 @@ beforeEach(() => {
   bridge.reset();
   bridge.setHandler("update_pending", () => null);
   bridge.setHandler("ledger_net_worth", () => DATA);
+  // The Columns choice persists here; every spec starts from the default.
+  window.localStorage.clear();
 });
 
 afterEach(() => cleanup());
@@ -139,8 +143,32 @@ describe("Net Worth view flow", () => {
     expect(screen.getByTitle("assets:checking")).toBeInTheDocument();
     expect(screen.getByText("~86.00 EUR")).toBeInTheDocument();
     expect(screen.getByTitle("liabilities:card")).toBeInTheDocument();
-    expect(screen.getByText("2026-07-01")).toBeInTheDocument();
+    // The assertion columns stay hidden until toggled on.
+    expect(screen.queryByText("2026-07-01")).toBeNull();
     expect(bridge.callsFor("ledger_net_worth")).toHaveLength(2);
+  });
+
+  it("should reveal the assertion columns via the Columns menu and keep them when the page is reopened", async () => {
+    render(<ChatLayout />);
+    openSheet();
+    await screen.findByTitle("assets:cash");
+
+    await userEvent.click(screen.getByRole("button", { name: "Columns" }));
+    await userEvent.click(await screen.findByRole("menuitemcheckbox", { name: "Asserted On" }));
+    await userEvent.click(screen.getByRole("menuitemcheckbox", { name: "Asserted Amount" }));
+    await userEvent.keyboard("{Escape}");
+    expect(screen.getByText("2026-07-01")).toBeInTheDocument();
+    expect(screen.getByText("95.00 USD")).toBeInTheDocument();
+
+    // Leave and reopen: the choice comes back from localStorage, with the
+    // usual per-open fetch and no menu interaction.
+    fireEvent.keyDown(document.body, { key: "n", metaKey: true });
+    expect(screen.queryByTitle("assets:cash")).toBeNull();
+    openSheet();
+    await screen.findByTitle("assets:cash");
+    expect(screen.getByText("2026-07-01")).toBeInTheDocument();
+    expect(screen.getByText("95.00 USD")).toBeInTheDocument();
+    expect(bridge.callsFor("ledger_net_worth")).toHaveLength(3);
   });
 
   it("should mark the sidebar entry active and keep the chat mounted but hidden while open", async () => {

--- a/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
@@ -3,8 +3,10 @@
 // Full-page Net Worth view: `hledger bs` rendered as data — an Assets
 // and a Liabilities section (liabilities already sign-flipped positive by
 // hledger), each with hledger's own total, and the hledger-computed Net as
-// the classic bottom line. A pinned header carries the page title and a
-// search box filtering every section by account path. Each section is a
+// the classic bottom line. A pinned header carries the page title, a
+// search box filtering every section by account path, and a Columns menu
+// toggling the two assertion columns (hidden by default, remembered in
+// localStorage) across every section at once. Each section is a
 // shadcn-style data table (TanStack Table): complete account paths in one
 // color, every native holding in a muted Holding column, the market value
 // (hledger's `-X` valuation in the base currency) in the Value column;
@@ -21,16 +23,23 @@ import {
   getSortedRowModel,
   type SortingState,
   useReactTable,
+  type VisibilityState,
 } from "@tanstack/react-table";
-import { ArrowDownIcon, ArrowUpIcon, ChevronsUpDownIcon, InfoIcon, SearchIcon } from "lucide-react";
+import { ArrowDownIcon, ArrowUpIcon, ChevronsUpDownIcon, Columns3Icon, InfoIcon, SearchIcon } from "lucide-react";
 import { type FC, type ReactNode, useState } from "react";
 import { Button } from "@/components/shadcn/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/shadcn/dropdown-menu";
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@/components/shadcn/empty";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/shadcn/input-group";
 import { Skeleton } from "@/components/shadcn/skeleton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/shadcn/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/tooltip";
-import { formatAmounts, formatValue } from "@/lib/amountFormat";
+import { formatAmount, formatAmounts, formatValue } from "@/lib/amountFormat";
 import type { AccountBalance, NetWorthSection } from "@/rpc/types";
 import { useNetWorth } from "./use-net-worth";
 
@@ -51,16 +60,32 @@ const SortHeader: FC<{ column: Column<AccountBalance>; label: string; className?
   );
 };
 
+/** Assertion-column labels, defined once: the headers, the help keys, the
+ *  Columns menu, and the loading skeleton all read these. */
+const ASSERTED_ON_LABEL = "Asserted On";
+const ASSERTED_AMOUNT_LABEL = "Asserted Amount";
+
 /** What each money/meta column means, keyed by its label; shown behind the
  *  little info marker next to the header (the Account column needs none). */
 const COLUMN_HELP: Record<string, ReactNode> = {
   Holding:
     "What the account actually holds: cash in its own currency, shares, or crypto. Exactly as recorded in the ledger, before any conversion.",
-  "Last Balance Assertion": (
+  [ASSERTED_ON_LABEL]: (
     <div>
       <p>
         When the ledger balance was last confirmed to match the real account balance. A dash means it was never
         confirmed.
+      </p>
+      <p className="mt-1.5">
+        To confirm, tell the agent the actual account balance, for example: "My cash balance is 200 EUR."
+      </p>
+    </div>
+  ),
+  [ASSERTED_AMOUNT_LABEL]: (
+    <div>
+      <p>
+        The ledger balance that was last confirmed to match the real account balance, in the account's own currency. A
+        dash means it was never confirmed.
       </p>
       <p className="mt-1.5">
         To confirm, tell the agent the actual account balance, for example: "My cash balance is 200 EUR."
@@ -111,14 +136,20 @@ const InfoTip: FC<{ label: string }> = ({ label }) => (
  *  - Holding: by the primary native quantity — a plain number sort, so the
  *    column reads monotonic (commodity grouping was tried and read as
  *    disorder);
- *  - Last Balance Assertion: by date, most recent first on the first
- *    click; never-asserted rows sink to the end;
+ *  - Asserted On: by date, most recent first on the first click;
+ *    never-asserted rows sink to the end;
+ *  - Asserted Amount: by quantity, like Holding; never-asserted rows
+ *    count as zero;
  *  - Value: by market value.
- *  Money columns put the biggest figures first on the first click. */
+ *  Money columns put the biggest figures first on the first click. The two
+ *  assertion columns hide by default (the tables stay narrow) and toggle on
+ *  via the header's Columns menu; the other three are the page's spine and
+ *  cannot be hidden. */
 const columns: ColumnDef<AccountBalance>[] = [
   {
     id: "account",
     accessorFn: (row) => row.name,
+    enableHiding: false,
     header: ({ column }) => <SortHeader column={column} label="Account" className="-ml-3" />,
     cell: ({ row }) => row.original.name,
   },
@@ -128,8 +159,8 @@ const columns: ColumnDef<AccountBalance>[] = [
     sortDescFirst: true,
     header: ({ column }) => (
       <div className="flex items-center justify-end">
-        <InfoTip label="Last Balance Assertion" />
-        <SortHeader column={column} label="Last Balance Assertion" className="-mr-3" />
+        <InfoTip label={ASSERTED_ON_LABEL} />
+        <SortHeader column={column} label={ASSERTED_ON_LABEL} className="-mr-3" />
       </div>
     ),
     // The journal's own ISO date, verbatim — unambiguous, and what you see
@@ -138,9 +169,26 @@ const columns: ColumnDef<AccountBalance>[] = [
     cell: ({ row }) => row.original.assertedOn ?? "\u2014",
   },
   {
+    id: "assertedAmount",
+    accessorFn: (row) => row.assertedAmount?.quantity ?? 0,
+    sortDescFirst: true,
+    header: ({ column }) => (
+      <div className="flex items-center justify-end">
+        <InfoTip label={ASSERTED_AMOUNT_LABEL} />
+        <SortHeader column={column} label={ASSERTED_AMOUNT_LABEL} className="-mr-3" />
+      </div>
+    ),
+    // The asserted native amount, formatted like Holding; an em dash marks
+    // accounts never asserted (or an assertion whose amount the journal
+    // export didn't carry), the same placeholder as the date column.
+    cell: ({ row }) =>
+      row.original.assertedAmount ? formatAmount(row.original.assertedAmount, "native", navigator.language) : "\u2014",
+  },
+  {
     id: "holding",
     accessorFn: (row) => row.amounts[0]?.quantity ?? 0,
     sortDescFirst: true,
+    enableHiding: false,
     header: ({ column }) => (
       <div className="flex items-center justify-end">
         <InfoTip label="Holding" />
@@ -153,6 +201,7 @@ const columns: ColumnDef<AccountBalance>[] = [
     id: "value",
     accessorFn: (row) => row.value[0]?.quantity ?? 0,
     sortDescFirst: true,
+    enableHiding: false,
     header: ({ column }) => (
       <div className="flex items-center justify-end">
         <InfoTip label="Value" />
@@ -169,17 +218,50 @@ const CELL_CLASS: Record<string, string> = {
   account: "w-full py-2.5",
   holding: "py-2.5 text-right tabular-nums",
   asserted: "py-2.5 text-right tabular-nums",
+  assertedAmount: "py-2.5 text-right tabular-nums",
   value: "py-2.5 text-right tabular-nums",
 };
 
-const AccountsTable: FC<{ rows: AccountBalance[]; search: string; label: string }> = ({ rows, search, label }) => {
+/** The assertion pair starts hidden: the tables stay narrow and lead with
+ *  what you have now; the reconciliation trail is opt-in via the Columns
+ *  menu. The choice is remembered per user in localStorage and validated
+ *  key-by-key on load, so garbage or stale entries fall back to hidden. */
+const COLUMNS_STORAGE_KEY = "accountant24.net-worth.columns";
+const DEFAULT_COLUMN_VISIBILITY: VisibilityState = { asserted: false, assertedAmount: false };
+
+export function loadColumnVisibility(): VisibilityState {
+  try {
+    const parsed: unknown = JSON.parse(window.localStorage.getItem(COLUMNS_STORAGE_KEY) ?? "");
+    const pick = (key: string) => (parsed as Record<string, unknown>)[key] === true;
+    return { asserted: pick("asserted"), assertedAmount: pick("assertedAmount") };
+  } catch {
+    return { ...DEFAULT_COLUMN_VISIBILITY };
+  }
+}
+
+function saveColumnVisibility(visibility: VisibilityState): void {
+  try {
+    window.localStorage.setItem(COLUMNS_STORAGE_KEY, JSON.stringify(visibility));
+  } catch {
+    // Best-effort: without storage the toggle still works for the session.
+  }
+}
+
+const AccountsTable: FC<{
+  rows: AccountBalance[];
+  search: string;
+  label: string;
+  columnVisibility: VisibilityState;
+}> = ({ rows, search, label, columnVisibility }) => {
   // A-Z on the account path until the user picks another column; a click
   // always leaves some direction active (no unsorted third state).
   const [sorting, setSorting] = useState<SortingState>([{ id: "account", desc: false }]);
+  // Visibility is owned by the page (one Columns menu drives every section
+  // table) and fully controlled: nothing in here mutates it.
   const table = useReactTable({
     data: rows,
     columns,
-    state: { sorting, globalFilter: search },
+    state: { sorting, globalFilter: search, columnVisibility },
     onSortingChange: setSorting,
     enableSortingRemoval: false,
     // The account path is the only searchable field; substring match,
@@ -207,7 +289,10 @@ const AccountsTable: FC<{ rows: AccountBalance[]; search: string; label: string 
       <TableBody>
         {table.getRowModel().rows.length === 0 ? (
           <TableRow>
-            <TableCell colSpan={columns.length} className="h-24 text-center text-muted-foreground">
+            <TableCell
+              colSpan={table.getVisibleLeafColumns().length}
+              className="h-24 text-center text-muted-foreground"
+            >
               No matching accounts
             </TableCell>
           </TableRow>
@@ -237,7 +322,11 @@ const AccountsTable: FC<{ rows: AccountBalance[]; search: string; label: string 
 const BAND_CLASS = "mx-3 flex items-baseline justify-between gap-8 rounded-xl bg-muted/50 px-5 py-4";
 
 /** One `bs` section: its hledger name and total over its accounts table. */
-const SheetSection: FC<{ section: NetWorthSection; search: string }> = ({ section, search }) => (
+const SheetSection: FC<{ section: NetWorthSection; search: string; columnVisibility: VisibilityState }> = ({
+  section,
+  search,
+  columnVisibility,
+}) => (
   <section>
     <div className={`mt-8 mb-2 ${BAND_CLASS}`}>
       <h2 className="text-xl font-semibold">{section.name}</h2>
@@ -248,7 +337,7 @@ const SheetSection: FC<{ section: NetWorthSection; search: string }> = ({ sectio
     {/* px-5: with the cells' own px-3, the table text lines up with the px-8
         headings. */}
     <div className="px-5">
-      <AccountsTable rows={section.rows} search={search} label={section.name} />
+      <AccountsTable rows={section.rows} search={search} label={section.name} columnVisibility={columnVisibility} />
     </div>
   </section>
 );
@@ -258,63 +347,69 @@ const SKELETON_ROWS = ["s1", "s2", "s3", "s4", "s5", "s6"];
 /** The loading state mirrors the loaded page: everything that needs no data
  *  (the Assets band, the column labels, the Net band) is up immediately, and
  *  skeletons stand in only for the figures and rows hledger is still
- *  computing. Assets and Net always exist on a balance sheet; Liabilities
- *  may not, so no placeholder for it. */
-const SheetSkeleton: FC = () => (
-  <div role="status" aria-label="Loading accounts">
-    <div className={`mt-8 mb-2 ${BAND_CLASS}`}>
-      <h2 className="text-xl font-semibold">Assets</h2>
-      <Skeleton className="h-5 w-36 self-center" />
-    </div>
-    <div className="px-5">
-      <Table>
-        <TableHeader>
-          <TableRow className="hover:bg-transparent">
-            <TableHead className="w-full">
-              <Button variant="ghost" size="sm" className="-ml-3" disabled>
-                Account
-                <ChevronsUpDownIcon className="text-muted-foreground/60" />
-              </Button>
-            </TableHead>
-            {["Last Balance Assertion", "Holding", "Value"].map((label) => (
-              <TableHead key={label}>
-                <div className="flex items-center justify-end">
-                  <InfoTip label={label} />
-                  <Button variant="ghost" size="sm" className="-mr-3" disabled>
-                    {label}
-                    <ChevronsUpDownIcon className="text-muted-foreground/60" />
-                  </Button>
-                </div>
+ *  computing. The column set follows the page's visibility state (known
+ *  before any data arrives), so the header doesn't jump when rows land.
+ *  Assets and Net always exist on a balance sheet; Liabilities may not, so
+ *  no placeholder for it. */
+const SheetSkeleton: FC<{ columnVisibility: VisibilityState }> = ({ columnVisibility }) => {
+  const metaLabels = [
+    ...(columnVisibility.asserted ? [ASSERTED_ON_LABEL] : []),
+    ...(columnVisibility.assertedAmount ? [ASSERTED_AMOUNT_LABEL] : []),
+    "Holding",
+    "Value",
+  ];
+  return (
+    <div role="status" aria-label="Loading accounts">
+      <div className={`mt-8 mb-2 ${BAND_CLASS}`}>
+        <h2 className="text-xl font-semibold">Assets</h2>
+        <Skeleton className="h-5 w-36 self-center" />
+      </div>
+      <div className="px-5">
+        <Table>
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead className="w-full">
+                <Button variant="ghost" size="sm" className="-ml-3" disabled>
+                  Account
+                  <ChevronsUpDownIcon className="text-muted-foreground/60" />
+                </Button>
               </TableHead>
-            ))}
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {SKELETON_ROWS.map((row) => (
-            <TableRow key={row} className="hover:bg-transparent">
-              <TableCell className="w-full py-2.5">
-                <Skeleton className="h-4 w-56" />
-              </TableCell>
-              <TableCell className="py-2.5">
-                <Skeleton className="ml-auto h-4 w-20" />
-              </TableCell>
-              <TableCell className="py-2.5">
-                <Skeleton className="ml-auto h-4 w-24" />
-              </TableCell>
-              <TableCell className="py-2.5">
-                <Skeleton className="ml-auto h-4 w-24" />
-              </TableCell>
+              {metaLabels.map((label) => (
+                <TableHead key={label}>
+                  <div className="flex items-center justify-end">
+                    <InfoTip label={label} />
+                    <Button variant="ghost" size="sm" className="-mr-3" disabled>
+                      {label}
+                      <ChevronsUpDownIcon className="text-muted-foreground/60" />
+                    </Button>
+                  </div>
+                </TableHead>
+              ))}
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHeader>
+          <TableBody>
+            {SKELETON_ROWS.map((row) => (
+              <TableRow key={row} className="hover:bg-transparent">
+                <TableCell className="w-full py-2.5">
+                  <Skeleton className="h-4 w-56" />
+                </TableCell>
+                {metaLabels.map((label) => (
+                  <TableCell key={label} className="py-2.5">
+                    <Skeleton className="ml-auto h-4 w-24" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <div className={`mt-8 ${BAND_CLASS}`}>
+        <div className="text-xl font-semibold">Net Worth</div>
+        <Skeleton className="h-5 w-32 self-center" />
+      </div>
     </div>
-    <div className={`mt-8 ${BAND_CLASS}`}>
-      <div className="text-xl font-semibold">Net Worth</div>
-      <Skeleton className="h-5 w-32 self-center" />
-    </div>
-  </div>
-);
+  );
+};
 
 const SheetEmpty: FC = () => (
   <Empty>
@@ -335,41 +430,97 @@ const SheetEmpty: FC = () => (
 export const NetWorthView: FC = () => {
   const sheet = useNetWorth();
   const [search, setSearch] = useState("");
+  // The Columns choice, shared by every section table and the loading
+  // skeleton; owned here so one menu drives the whole page, saved on every
+  // toggle and restored on the next visit.
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(loadColumnVisibility);
+  const setColumnShown = (id: "asserted" | "assertedAmount", shown: boolean) =>
+    setColumnVisibility((prev) => {
+      const next = { ...prev, [id]: shown };
+      saveColumnVisibility(next);
+      return next;
+    });
   // hledger emits a section even when it has no accounts; an empty side
   // renders nothing rather than a fabricated zero.
   const sections = sheet?.sections.filter((s) => s.rows.length > 0) ?? [];
+  // The assertion columns push the table past the default page cap; widen
+  // the page one step per extra column so nothing gets clipped where the
+  // window has the room, without leaving a four-column table adrift on a
+  // six-column-wide page. Narrow windows still fall back to the table's own
+  // horizontal scroll.
+  const extraColumns = (columnVisibility.asserted ? 1 : 0) + (columnVisibility.assertedAmount ? 1 : 0);
+  const pageWidth = extraColumns === 2 ? "max-w-6xl" : extraColumns === 1 ? "max-w-5xl" : "max-w-4xl";
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="mx-auto flex w-full max-w-4xl shrink-0 items-center justify-between gap-8 px-8 pt-16 pb-4">
+      <div className={`mx-auto flex w-full ${pageWidth} shrink-0 items-center justify-between gap-8 px-8 pt-16 pb-4`}>
         <h1 className="text-3xl font-semibold">Net Worth</h1>
         {(sheet === null || sections.length > 0) && (
-          <InputGroup className="w-64">
-            <InputGroupInput
-              type="search"
-              placeholder="Search accounts"
-              aria-label="Search accounts"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-            />
-            <InputGroupAddon>
-              <SearchIcon />
-            </InputGroupAddon>
-          </InputGroup>
+          <div className="flex shrink-0 items-center gap-2">
+            <InputGroup className="w-64">
+              <InputGroupInput
+                type="search"
+                placeholder="Search accounts"
+                aria-label="Search accounts"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+              <InputGroupAddon>
+                <SearchIcon />
+              </InputGroupAddon>
+            </InputGroup>
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={
+                  <Button variant="outline">
+                    <Columns3Icon />
+                    Columns
+                  </Button>
+                }
+              />
+              {/* min-w-44: at the stock popup width the longest label wraps
+                  to two lines. */}
+              <DropdownMenuContent align="end" className="min-w-44">
+                {/* Only the assertion pair toggles; Account, Holding, and
+                    Value are the page's spine and never leave. closeOnClick
+                    stays off so checking one box doesn't dismiss the menu
+                    mid-choice. */}
+                <DropdownMenuCheckboxItem
+                  closeOnClick={false}
+                  checked={columnVisibility.asserted}
+                  onCheckedChange={(checked) => setColumnShown("asserted", checked)}
+                >
+                  {ASSERTED_ON_LABEL}
+                </DropdownMenuCheckboxItem>
+                <DropdownMenuCheckboxItem
+                  closeOnClick={false}
+                  checked={columnVisibility.assertedAmount}
+                  onCheckedChange={(checked) => setColumnShown("assertedAmount", checked)}
+                >
+                  {ASSERTED_AMOUNT_LABEL}
+                </DropdownMenuCheckboxItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         )}
       </div>
       {/* scroll-fade-t-6: content dissolves over 24px as it slides under the
           pinned search field, same as the chat viewport's top fade. */}
       <div className="scroll-fade-t scroll-fade-t-6 min-h-0 flex-1 overflow-y-auto">
-        <div className="mx-auto w-full max-w-4xl pb-12">
+        <div className={`mx-auto w-full ${pageWidth} pb-12`}>
           {sheet === null ? (
-            <SheetSkeleton />
+            <SheetSkeleton columnVisibility={columnVisibility} />
           ) : sections.length === 0 ? (
             <SheetEmpty />
           ) : (
             <>
               {sections.map((section) => (
-                <SheetSection key={section.name} section={section} search={search} />
+                <SheetSection
+                  key={section.name}
+                  section={section}
+                  search={search}
+                  columnVisibility={columnVisibility}
+                />
               ))}
               {/* The closing Net band, straight from hledger's own net. */}
               <div className={`mt-8 ${BAND_CLASS}`}>

--- a/packages/desktop/src/renderer/test/jsdomPolyfills.ts
+++ b/packages/desktop/src/renderer/test/jsdomPolyfills.ts
@@ -23,4 +23,24 @@ export function installJsdomPolyfills(): void {
   } as unknown as typeof ResizeObserver;
 
   Element.prototype.scrollIntoView ??= () => {};
+
+  // This jsdom build ships without Web Storage; back it with a Map so
+  // components persisting UI preferences (sidebar width, table columns)
+  // work under tests.
+  if (!window.localStorage) {
+    const backing = new Map<string, string>();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (k: string) => backing.get(k) ?? null,
+        setItem: (k: string, v: string) => void backing.set(k, String(v)),
+        removeItem: (k: string) => void backing.delete(k),
+        clear: () => backing.clear(),
+        key: (i: number) => [...backing.keys()][i] ?? null,
+        get length() {
+          return backing.size;
+        },
+      } satisfies Storage,
+    });
+  }
 }

--- a/packages/desktop/src/shared/types.ts
+++ b/packages/desktop/src/shared/types.ts
@@ -41,6 +41,11 @@ export interface AccountBalance {
    *  (the posting's own date when it has one) — when the balance was last
    *  reconciled. Absent when the account has no assertions. */
   assertedOn?: string;
+  /** The amount of that most recent balance assertion, verbatim from the
+   *  journal. An assertion pins a single commodity's balance, so this is one
+   *  amount, not a list. Absent when the account has no assertions or the
+   *  assertion's amount did not parse; present only alongside `assertedOn`. */
+  assertedAmount?: LedgerAmount;
 }
 
 /** A figure of the report that isn't an account row: a section total or the


### PR DESCRIPTION
- Add an `Asserted Amount` column showing the amount of each account's latest balance assertion, in the account's own currency
- Rename the `Last Balance Assertion` column to `Asserted On`
- Hide both assertion columns by default behind a `Columns` menu next to the search box
- Persist the column choice in localStorage and restore it on the next visit, including in the loading skeleton
- Widen the page one step per extra visible column so no column gets clipped
- Parse the asserted amount off `hledger print -O json` (`parseAssertions`) and carry it as `assertedAmount` on `AccountBalance`
- Cover the parser, report grafting, column toggling, sorting, and persistence with unit, component, and integration tests