### PR TITLE
feat: cleaner file attachment cards in the chat and composer

### DIFF
--- a/packages/desktop/src/renderer/components/accountant24/__tests__/attachment.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/attachment.test.tsx
@@ -14,7 +14,13 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-libra
 import type { ComponentProps, ReactNode } from "react";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { encodeAttachmentRef } from "@/lib/attachmentMarker";
-import { ComposerAddAttachment, ComposerAttachments, UserMessageImage, UserMessageText } from "../attachment";
+import {
+  ComposerAddAttachment,
+  ComposerAttachments,
+  UserMessageFileCards,
+  UserMessageImage,
+  UserMessageText,
+} from "../attachment";
 
 beforeAll(() => {
   window.matchMedia ??= ((query: string) => ({
@@ -70,7 +76,7 @@ describe("ComposerAttachments", () => {
     expect(document.querySelectorAll('[data-slot="attachment"]')).toHaveLength(0);
   });
 
-  it("should show a chip with the file name after attaching", async () => {
+  it("should show a card with the file name after attaching", async () => {
     render(
       <Chrome>
         <ComposerAttachments />
@@ -79,6 +85,17 @@ describe("ComposerAttachments", () => {
     await addImage("receipt.png");
     await screen.findByText("receipt.png");
     expect(document.querySelectorAll('[data-slot="attachment"]')).toHaveLength(1);
+  });
+
+  it("should describe an attached image with its type and size", async () => {
+    render(
+      <Chrome>
+        <ComposerAttachments />
+      </Chrome>,
+    );
+    // addImage writes 3 bytes ([1, 2, 3]).
+    await addImage("receipt.png");
+    expect(await screen.findByText("PNG · 3 B")).toBeInTheDocument();
   });
 
   it("should remove the chip when its remove button is clicked", async () => {
@@ -105,7 +122,7 @@ describe("ComposerAttachments", () => {
     expect(document.querySelectorAll('[data-slot="attachment"]')).toHaveLength(2);
   });
 
-  it("should render a non-image attachment as a file chip (no thumbnail)", async () => {
+  it("should render a non-image attachment as a file card (no thumbnail)", async () => {
     render(
       <Chrome image={false}>
         <ComposerAttachments />
@@ -113,8 +130,19 @@ describe("ComposerAttachments", () => {
     );
     await addTextFile("statement.csv");
     await screen.findByText("statement.csv");
-    // A document attachment shows the file-chip, not an <img> preview.
+    // A document attachment shows the file card, not an <img> preview.
     expect(document.querySelector('[data-slot="attachment"] img')).toBeNull();
+  });
+
+  it("should describe a non-image attachment with its type and size", async () => {
+    render(
+      <Chrome image={false}>
+        <ComposerAttachments />
+      </Chrome>,
+    );
+    // addTextFile writes "hello" (5 bytes).
+    await addTextFile("statement.csv");
+    expect(await screen.findByText("CSV · 5 B")).toBeInTheDocument();
   });
 
   it("should remove a non-image chip when its remove button is clicked", async () => {
@@ -157,23 +185,65 @@ describe("UserMessageImage", () => {
   });
 });
 
+describe("UserMessageFileCards", () => {
+  const Cards = UserMessageFileCards as TextMessagePartComponent;
+  const render_ = (text: string) => render(<Cards {...({ text } as ComponentProps<typeof Cards>)} />);
+
+  it("should render a file card with the name and type for a marker", () => {
+    const marker = encodeAttachmentRef({ name: "statement.pdf", path: "/ws/statement.pdf" });
+    render_(`Here is my file\n${marker}`);
+    expect(screen.getByText("statement.pdf")).toBeInTheDocument();
+    expect(screen.getByText("PDF")).toBeInTheDocument();
+    // Only the cards — the text belongs to UserMessageText.
+    expect(screen.queryByText("Here is my file")).toBeNull();
+  });
+
+  it("should render one card per marker", () => {
+    const a = encodeAttachmentRef({ name: "a.pdf", path: "/ws/a.pdf" });
+    const b = encodeAttachmentRef({ name: "b.csv", path: "/ws/b.csv" });
+    render_(`${a}\n${b}`);
+    expect(document.querySelectorAll('[data-slot="attachment"]')).toHaveLength(2);
+  });
+
+  it("should show the file size when the marker carries one", () => {
+    const marker = encodeAttachmentRef({ name: "statement.pdf", path: "/ws/statement.pdf", size: 245_000 });
+    render_(marker);
+    expect(screen.getByText("PDF · 245 KB")).toBeInTheDocument();
+  });
+
+  it("should render a card without a type line when the name has no extension", () => {
+    const marker = encodeAttachmentRef({ name: "receipt", path: "/ws/receipt" });
+    render_(marker);
+    expect(screen.getByText("receipt")).toBeInTheDocument();
+    expect(document.querySelector('[data-slot="attachment-description"]')).toBeNull();
+  });
+
+  it("should render nothing when the text has no markers", () => {
+    render_("just a note");
+    expect(document.querySelector('[data-slot="attachment"]')).toBeNull();
+    expect(screen.queryByText("just a note")).toBeNull();
+  });
+});
+
 describe("UserMessageText", () => {
   const Text = UserMessageText as TextMessagePartComponent;
   const render_ = (text: string) => render(<Text {...({ text } as ComponentProps<typeof Text>)} />);
 
-  it("should lift a file marker into a chip and show only the human text", () => {
+  it("should strip a file marker and show only the human text", () => {
     const marker = encodeAttachmentRef({ name: "statement.pdf", path: "/ws/statement.pdf" });
     render_(`Here is my file\n${marker}`);
-    expect(screen.getByText("statement.pdf")).toBeInTheDocument();
     expect(screen.getByText("Here is my file")).toBeInTheDocument();
-    // The raw marker line is never shown as text.
+    // The marker renders neither as raw text nor as a chip — the attachment
+    // row above the bubble owns the cards.
     expect(screen.queryByText(marker)).toBeNull();
+    expect(screen.queryByText("statement.pdf")).toBeNull();
+    expect(document.querySelector('[data-slot="attachment"]')).toBeNull();
   });
 
-  it("should render only the chips when the message is a bare attachment", () => {
+  it("should render nothing when the message is a bare attachment", () => {
     const marker = encodeAttachmentRef({ name: "photo.png", path: "/ws/photo.png" });
-    render_(marker);
-    expect(screen.getByText("photo.png")).toBeInTheDocument();
+    const { container } = render_(marker);
+    expect(container).toBeEmptyDOMElement();
   });
 
   it("should render plain text with no chips when there are no attachments", () => {

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/thread.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/thread.test.tsx
@@ -36,6 +36,7 @@ vi.mock("@assistant-ui/react-pi", async (importOriginal) => ({
 }));
 
 import { AssistantRuntimeProvider, type ExternalStoreAdapter, useExternalStoreRuntime } from "@assistant-ui/react";
+import { encodeAttachmentRef } from "@/lib/attachmentMarker";
 import { addPendingCompactionMarker, resetPendingCompactionMarkers } from "@/runtime/pendingCompaction";
 import { Thread, type ThreadComponents } from "../thread";
 
@@ -137,6 +138,50 @@ describe("Thread welcome vs. messages", () => {
       </Chrome>,
     );
     expect(await screen.findByText("Your balance is 100.")).toBeInTheDocument();
+  });
+});
+
+describe("Thread user message attachments", () => {
+  const marker = encodeAttachmentRef({ name: "07 Beleg.pdf", path: "files/2026/08/20260806120000.pdf" });
+  const attachmentsRow = () => document.querySelector('[data-slot="aui_user-attachments"]');
+  const bubbleContent = () => document.querySelector('[data-role="user"] [data-slot="bubble-content"]');
+
+  it("should render a file-only message as a card in the attachment row with an empty bubble", async () => {
+    render(
+      <Chrome messages={[userMsg(marker)]}>
+        <Thread />
+      </Chrome>,
+    );
+    expect(await screen.findByText("07 Beleg.pdf")).toBeInTheDocument();
+    expect(screen.getByText("PDF")).toBeInTheDocument();
+    // The card lives in the row above the bubble, never inside it.
+    expect(attachmentsRow()?.querySelector('[data-slot="attachment"]')).not.toBeNull();
+    // The bubble has nothing left to say (its CSS hides it when empty).
+    expect(bubbleContent()).toBeEmptyDOMElement();
+  });
+
+  it("should render the card above the bubble and the text inside it for a mixed message", async () => {
+    render(
+      <Chrome messages={[userMsg(`paid this from my checking account\n${marker}`)]}>
+        <Thread />
+      </Chrome>,
+    );
+    expect(await screen.findByText("paid this from my checking account")).toBeInTheDocument();
+    expect(attachmentsRow()?.querySelector('[data-slot="attachment"]')).not.toBeNull();
+    expect(bubbleContent()?.textContent).toBe("paid this from my checking account");
+    // The raw marker line never shows.
+    expect(screen.queryByText(marker)).toBeNull();
+  });
+
+  it("should render a sent image in the attachment row, not in the bubble", async () => {
+    render(
+      <Chrome messages={[{ id: "u1", role: "user", content: [{ type: "image", image: "data:image/png;base64,AA" }] }]}>
+        <Thread />
+      </Chrome>,
+    );
+    expect(await screen.findByAltText("attachment")).toBeInTheDocument();
+    expect(attachmentsRow()?.querySelector("img")).not.toBeNull();
+    expect(bubbleContent()?.querySelector("img")).toBeNull();
   });
 });
 

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/user-message-text.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/user-message-text.test.tsx
@@ -35,11 +35,14 @@ describe("UserMessageText", () => {
     expect(container.querySelector('[data-directive-type="skill"]')?.textContent).toBe("pdf");
   });
 
-  it("should lift attachment markers and keep the skill chip inline", () => {
+  it("should strip attachment markers and keep the skill chip inline", () => {
     // Markers ride on their own line (the attachment adapter appends them).
+    // The file cards themselves render in the attachment row above the bubble
+    // (UserMessageAttachments), not here.
     const marker = encodeAttachmentRef({ name: "receipt.pdf", path: "files/receipt.pdf" });
     const { container } = renderText(`:skill[pdf] summarize the attached file\n${marker}`);
-    expect(screen.getByText("receipt.pdf")).toBeTruthy();
+    expect(screen.queryByText("receipt.pdf")).toBeNull();
+    expect(container.textContent).not.toContain("[[attachment]]");
     expect(container.querySelector('[data-directive-type="skill"]')?.textContent).toBe("pdf");
     expect(screen.getByText(/summarize the attached file/)).toBeTruthy();
   });

--- a/packages/desktop/src/renderer/components/accountant24/attachment.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/attachment.tsx
@@ -3,19 +3,22 @@
 // File/attachment UI: assistant-ui's attachment primitives wired to the stock
 // shadcn Attachment components. Images go to the model as image content. PDFs
 // (and other docs) are copied into the workspace by the app and travel to the
-// agent as a one-line marker carrying the workspace path; here we strip that
-// marker and render a file chip instead of the raw text (see
-// lib/attachmentMarker + runtime/fileAttachmentAdapter).
+// agent as a one-line marker carrying the workspace path (see
+// lib/attachmentMarker + runtime/fileAttachmentAdapter). In a sent message,
+// attachments render as cards in a row above the bubble (UserMessageAttachments)
+// rather than inside it, so a file-only message is just its card — never an
+// empty bubble wrapping a chip.
 
 import {
   AttachmentPrimitive,
   type Attachment as AuiAttachment,
   ComposerPrimitive,
   type ImageMessagePartComponent,
+  MessagePrimitive,
   type TextMessagePartComponent,
   useAuiState,
 } from "@assistant-ui/react";
-import { FileTextIcon, PaperclipIcon, XIcon } from "lucide-react";
+import { FileImageIcon, FileSpreadsheetIcon, FileTextIcon, PaperclipIcon, XIcon } from "lucide-react";
 import { type FC, useEffect, useState } from "react";
 import { DirectiveText } from "@/components/accountant24/directive-chips";
 import { TooltipIconButton } from "@/components/accountant24/tooltip-icon-button";
@@ -24,11 +27,13 @@ import {
   AttachmentAction,
   AttachmentActions,
   AttachmentContent,
+  AttachmentDescription,
   AttachmentMedia,
   AttachmentTitle,
 } from "@/components/shadcn/attachment";
 import { InputGroupAddon } from "@/components/shadcn/input-group";
 import { extractAttachmentRefs } from "@/lib/attachmentMarker";
+import { type FileKind, fileKind, fileTypeLabel, formatFileSize } from "@/lib/fileInfo";
 import { cn } from "@/lib/utils";
 
 /** Object-URL preview for a pending image File, revoked on unmount. */
@@ -46,27 +51,62 @@ const useImagePreview = (file: File | undefined): string | undefined => {
   return url;
 };
 
-/** Shared presentational file chip (icon + name), used both for pending
- *  composer attachments and sent ones in a message. Forwards rest props so it
- *  can sit under an assistant-ui `asChild` primitive. */
-const FileChip: FC<React.ComponentProps<typeof Attachment> & { name: string }> = ({
-  name,
-  className,
-  children,
-  ...props
-}) => (
-  <Attachment size="sm" className={cn("bg-background", className)} {...props}>
-    <AttachmentMedia>
-      <FileTextIcon />
-    </AttachmentMedia>
-    <AttachmentContent>
-      <AttachmentTitle title={name}>{name}</AttachmentTitle>
-    </AttachmentContent>
-    {children}
-  </Attachment>
+const KIND_ICONS: Record<FileKind, typeof FileTextIcon> = {
+  document: FileTextIcon,
+  spreadsheet: FileSpreadsheetIcon,
+  image: FileImageIcon,
+};
+
+/** The card's muted second line: file type, plus the size when known
+ *  ("PDF · 245 KB"). Sent messages only carry the name, so size is optional. */
+const cardDescription = (name: string, sizeBytes?: number): string =>
+  [fileTypeLabel(name), sizeBytes === undefined ? "" : formatFileSize(sizeBytes)].filter(Boolean).join(" · ");
+
+/** Shared card geometry for every attachment (file chips and composer image
+ *  tiles). Fixed w-72 instead of the stock w-fit: content-hugging cards give a
+ *  multi-file row ragged widths, while uniform cards wrap into a tidy grid
+ *  (the cva's own max-w-full still caps them on narrow containers). rounded-xl
+ *  instead of the stock pill rounding: it matches the sent image cards, and
+ *  the pill read as a second bubble nested inside the message bubble. */
+const AttachmentCard: FC<React.ComponentProps<typeof Attachment>> = ({ className, ...props }) => (
+  // font-normal on the description: it sets no weight of its own, so inside
+  // the composer it inherits the InputGroupAddon's font-medium and renders
+  // bolder than the same card in a message.
+  <Attachment
+    className={cn("w-72 rounded-xl **:data-[slot=attachment-description]:font-normal", className)}
+    {...props}
+  />
 );
 
-/** A single pending attachment in the composer: image thumbnail or a file chip,
+/** Presentational file card: type icon + name + muted type line. The type line
+ *  keeps the file identifiable when the name is an opaque id and truncation
+ *  hides the extension. Forwards rest props so it can sit under an assistant-ui
+ *  `asChild` primitive. */
+const FileCard: FC<React.ComponentProps<typeof Attachment> & { name: string; sizeBytes?: number }> = ({
+  name,
+  sizeBytes,
+  children,
+  ...props
+}) => {
+  const Icon = KIND_ICONS[fileKind(name)];
+  const description = cardDescription(name, sizeBytes);
+  return (
+    <AttachmentCard {...props}>
+      {/* rounded-lg: near-concentric with the card's rounded-xl, where the
+          stock rounding turns the icon box into a circle. */}
+      <AttachmentMedia className="rounded-lg">
+        <Icon />
+      </AttachmentMedia>
+      <AttachmentContent>
+        <AttachmentTitle title={name}>{name}</AttachmentTitle>
+        {description && <AttachmentDescription>{description}</AttachmentDescription>}
+      </AttachmentContent>
+      {children}
+    </AttachmentCard>
+  );
+};
+
+/** A single pending attachment in the composer: image thumbnail or a file card,
  *  each with a remove button. Reads the current attachment from context, so it
  *  must render inside ComposerPrimitive.Attachments. */
 const ComposerAttachmentTile: FC = () => {
@@ -75,6 +115,7 @@ const ComposerAttachmentTile: FC = () => {
   if (!attachment) return null;
 
   const isImage = attachment.type === "image" && preview;
+  const sizeBytes = attachment.file?.size;
 
   const removeButton = (
     <AttachmentActions>
@@ -87,35 +128,42 @@ const ComposerAttachmentTile: FC = () => {
   );
 
   if (isImage) {
+    const description = sizeBytes === undefined ? "" : cardDescription(attachment.name, sizeBytes);
     return (
       <AttachmentPrimitive.Root asChild>
-        <Attachment size="sm" className="bg-background">
-          <AttachmentMedia variant="image">
+        <AttachmentCard>
+          <AttachmentMedia variant="image" className="rounded-lg">
             <img src={preview} alt={attachment.name} />
           </AttachmentMedia>
           <AttachmentContent>
             <AttachmentTitle title={attachment.name}>{attachment.name}</AttachmentTitle>
+            {description && <AttachmentDescription>{description}</AttachmentDescription>}
           </AttachmentContent>
           {removeButton}
-        </Attachment>
+        </AttachmentCard>
       </AttachmentPrimitive.Root>
     );
   }
 
   return (
     <AttachmentPrimitive.Root asChild>
-      <FileChip name={attachment.name}>{removeButton}</FileChip>
+      <FileCard name={attachment.name} sizeBytes={sizeBytes}>
+        {removeButton}
+      </FileCard>
     </AttachmentPrimitive.Root>
   );
 };
 
 /** Pending attachments shown above the composer input, as a top row of the
- *  composer's InputGroup. Hidden entirely while there are no attachments. */
+ *  composer's InputGroup. Hidden entirely while there are no attachments.
+ *  pb-0: the addon's own bottom padding would stack on the Lexical input's
+ *  16px top padding, pushing the input text ~10px farther from the cards
+ *  above it than from the action row below. */
 export const ComposerAttachments: FC = () => (
   <InputGroupAddon
     align="block-start"
     data-slot="aui_composer-attachments"
-    className="hidden flex-wrap gap-2 has-data-[slot=attachment]:flex"
+    className="hidden flex-wrap gap-2 pb-0 has-data-[slot=attachment]:flex"
   >
     <ComposerPrimitive.Attachments>{() => <ComposerAttachmentTile />}</ComposerPrimitive.Attachments>
   </InputGroupAddon>
@@ -141,35 +189,44 @@ export const ComposerAddAttachment: FC = () => (
   </ComposerPrimitive.AddAttachment>
 );
 
-/** Renders a sent image inside a user message. react-pi projects sent images as
- *  `image` content parts, so this plugs into MessagePrimitive.Parts as the
- *  `Image` component (the built-in default renders nothing). */
+/** Renders a sent image inside the message's attachment row. react-pi projects
+ *  sent images as `image` content parts, so this plugs into
+ *  MessagePrimitive.Parts as the `Image` component. */
 export const UserMessageImage: ImageMessagePartComponent = ({ image, filename }) => (
   <img
     src={image}
     alt={filename ?? "attachment"}
-    className="border-border/60 mb-2 max-h-80 max-w-full rounded-xl border object-contain"
+    className="border-border/60 max-h-80 max-w-full rounded-xl border object-contain"
   />
 );
 
-/** Renders a sent user-message text part. Non-image attachments arrive inlined
- *  as `[[attachment]]{…}` markers; we lift them out as file chips and show only
- *  the human-written text, with any directives (@-mentions, picked skills)
- *  rendered as inline chips. A manual skill invocation reaches this component
- *  already collapsed to its `:skill[name]` directive (electronPiClient rewrites
- *  pi's expanded block on the way in), so no skill-specific handling lives here. */
+/** A text part projected down to its attachment markers: one file card per
+ *  marker, none of the text. The counterpart of UserMessageText, for the
+ *  attachment row above the bubble. */
+export const UserMessageFileCards: TextMessagePartComponent = ({ text }) => (
+  <>
+    {extractAttachmentRefs(text).refs.map((ref, i) => (
+      <FileCard key={`${ref.path}-${i}`} name={ref.name} sizeBytes={ref.size} />
+    ))}
+  </>
+);
+
+/** The sent attachments of a user message, lifted out of the bubble: images and
+ *  file cards in a right-aligned row above the message text. Hidden while the
+ *  message has no attachments. Must render inside MessagePrimitive.Root. */
+export const UserMessageAttachments: FC = () => (
+  <div data-slot="aui_user-attachments" className="flex max-w-[80%] flex-wrap justify-end gap-2 empty:hidden">
+    <MessagePrimitive.Parts components={{ Image: UserMessageImage, Text: UserMessageFileCards }} />
+  </div>
+);
+
+/** Renders a sent user-message text part: only the human-written text, with any
+ *  directives (@-mentions, picked skills) as inline chips. Attachment markers
+ *  are stripped — UserMessageAttachments renders them above the bubble. A
+ *  manual skill invocation reaches this component already collapsed to its
+ *  `:skill[name]` directive (electronPiClient rewrites pi's expanded block on
+ *  the way in), so no skill-specific handling lives here. */
 export const UserMessageText: TextMessagePartComponent = (props) => {
-  const { text: visible, refs } = extractAttachmentRefs(props.text);
-  return (
-    <>
-      {refs.length > 0 && (
-        <div className="mb-2 flex flex-wrap gap-2 empty:hidden">
-          {refs.map((ref, i) => (
-            <FileChip key={`${ref.path}-${i}`} name={ref.name} className="max-w-full" />
-          ))}
-        </div>
-      )}
-      {visible && <DirectiveText {...props} text={visible} />}
-    </>
-  );
+  const { text: visible } = extractAttachmentRefs(props.text);
+  return visible ? <DirectiveText {...props} text={visible} /> : null;
 };

--- a/packages/desktop/src/renderer/components/accountant24/thread.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/thread.tsx
@@ -11,7 +11,7 @@ import {
 } from "@assistant-ui/react";
 import { ArrowDownIcon } from "lucide-react";
 import { type ComponentType, createContext, type FC, memo, useContext } from "react";
-import { UserMessageImage, UserMessageText } from "@/components/accountant24/attachment";
+import { UserMessageAttachments, UserMessageText } from "@/components/accountant24/attachment";
 import {
   ChainOfThoughtRoot,
   ChainOfThoughtStep,
@@ -243,6 +243,10 @@ const AssistantMessage: FC = () => {
   );
 };
 
+/** Suppresses a part in this Parts pass: image parts show only in the
+ *  attachment row above the bubble, never as bubble content. */
+const NoPart: FC = () => null;
+
 const UserMessage: FC = () => {
   return (
     <MessagePrimitive.Root
@@ -256,14 +260,22 @@ const UserMessage: FC = () => {
     >
       <Message align="end">
         <MessageContent>
+          {/* Attachments (images, file cards) render above the bubble, not in
+              it — a file-only message is just its card, never a bubble-in-a-
+              bubble. The bubble hides itself when the remaining text is empty. */}
+          <UserMessageAttachments />
           {/* bg-input/50 (same child-selector pattern as the variant, so it wins
               via tailwind-merge): exactly the composer's surface color, per the
               "user input surfaces look identical" rule. */}
-          <Bubble variant="secondary" align="end" className="*:data-[slot=bubble-content]:bg-input/50">
+          <Bubble
+            variant="secondary"
+            align="end"
+            className="*:data-[slot=bubble-content]:bg-input/50 has-[>[data-slot=bubble-content]:empty]:hidden"
+          >
             {/* text-base: conversation content is 16px (composer, assistant
                 replies); the stock 14px would shrink the text after sending. */}
-            <BubbleContent className="text-base empty:hidden">
-              <MessagePrimitive.Parts components={{ Image: UserMessageImage, Text: UserMessageText }} />
+            <BubbleContent className="text-base">
+              <MessagePrimitive.Parts components={{ Image: NoPart, Text: UserMessageText }} />
             </BubbleContent>
           </Bubble>
         </MessageContent>

--- a/packages/desktop/src/renderer/lib/__tests__/attachmentMarker.test.ts
+++ b/packages/desktop/src/renderer/lib/__tests__/attachmentMarker.test.ts
@@ -48,6 +48,21 @@ describe("extractAttachmentRefs()", () => {
     expect(extractAttachmentRefs(missingName).refs).toEqual([]);
   });
 
+  it("should round-trip the file size when the ref carries one", () => {
+    const withSize: AttachmentRef = { name: "statement.pdf", path: "files/statement.pdf", size: 245_000 };
+    expect(extractAttachmentRefs(encodeAttachmentRef(withSize)).refs).toEqual([withSize]);
+  });
+
+  it("should accept a size-less marker (written before size existed)", () => {
+    const line = `[[attachment]]${JSON.stringify({ name: "old.pdf", path: "files/old.pdf" })}`;
+    expect(extractAttachmentRefs(line).refs).toEqual([{ name: "old.pdf", path: "files/old.pdf" }]);
+  });
+
+  it("should drop a size that is not a finite number", () => {
+    const bogus = `[[attachment]]${JSON.stringify({ name: "x.pdf", path: "files/x.pdf", size: "big" })}`;
+    expect(extractAttachmentRefs(bogus).refs).toEqual([{ name: "x.pdf", path: "files/x.pdf" }]);
+  });
+
   it("should trim surrounding whitespace from the remaining text", () => {
     const input = `\n\n${encodeAttachmentRef(REF)}\n\n`;
     expect(extractAttachmentRefs(input).text).toBe("");

--- a/packages/desktop/src/renderer/lib/__tests__/fileInfo.test.ts
+++ b/packages/desktop/src/renderer/lib/__tests__/fileInfo.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { fileKind, fileTypeLabel, formatFileSize } from "../fileInfo";
+
+describe("fileTypeLabel()", () => {
+  it("should return the uppercase extension for a regular filename", () => {
+    expect(fileTypeLabel("07 Beleg.pdf")).toBe("PDF");
+  });
+
+  it("should use only the last extension of a multi-dot name", () => {
+    expect(fileTypeLabel("archive.tar.gz")).toBe("GZ");
+  });
+
+  it("should return an empty string when the name has no extension", () => {
+    expect(fileTypeLabel("README")).toBe("");
+  });
+
+  it("should not treat a leading dot as an extension", () => {
+    expect(fileTypeLabel(".env")).toBe("");
+  });
+
+  it("should return an empty string for a trailing dot", () => {
+    expect(fileTypeLabel("draft.")).toBe("");
+  });
+
+  it("should reject an implausibly long extension", () => {
+    expect(fileTypeLabel("weird.notanextension")).toBe("");
+  });
+
+  it("should reject an extension with non-alphanumeric characters", () => {
+    expect(fileTypeLabel("doc.p df")).toBe("");
+  });
+});
+
+describe("fileKind()", () => {
+  it("should classify csv as spreadsheet", () => {
+    expect(fileKind("statement.csv")).toBe("spreadsheet");
+  });
+
+  it("should classify xlsx as spreadsheet", () => {
+    expect(fileKind("Budget.XLSX")).toBe("spreadsheet");
+  });
+
+  it("should classify heic as image", () => {
+    expect(fileKind("photo.heic")).toBe("image");
+  });
+
+  it("should classify pdf as document", () => {
+    expect(fileKind("07 Beleg.pdf")).toBe("document");
+  });
+
+  it("should classify an extension-less name as document", () => {
+    expect(fileKind("README")).toBe("document");
+  });
+});
+
+describe("formatFileSize()", () => {
+  it("should show bytes without decimals when below 1000", () => {
+    expect(formatFileSize(532)).toBe("532 B");
+  });
+
+  it("should show 0 bytes as 0 B", () => {
+    expect(formatFileSize(0)).toBe("0 B");
+  });
+
+  it("should switch to KB at 1000 bytes", () => {
+    expect(formatFileSize(1000)).toBe("1 KB");
+  });
+
+  it("should keep one decimal for small unit values", () => {
+    expect(formatFileSize(1500)).toBe("1.5 KB");
+  });
+
+  it("should drop a trailing .0 decimal", () => {
+    expect(formatFileSize(2000)).toBe("2 KB");
+  });
+
+  it("should drop decimals once the value reaches two digits", () => {
+    expect(formatFileSize(245_000)).toBe("245 KB");
+  });
+
+  it("should round 9.95 up to the next integer instead of showing 10.0", () => {
+    expect(formatFileSize(9_950)).toBe("10 KB");
+  });
+
+  it("should format megabytes with one decimal", () => {
+    expect(formatFileSize(1_234_567)).toBe("1.2 MB");
+  });
+
+  it("should cap the unit at TB for huge values", () => {
+    expect(formatFileSize(5_000_000_000_000_000)).toBe("5000 TB");
+  });
+});

--- a/packages/desktop/src/renderer/lib/attachmentMarker.ts
+++ b/packages/desktop/src/renderer/lib/attachmentMarker.ts
@@ -4,7 +4,7 @@
 // a file chip instead of showing the raw line. Kept framework-free so both the
 // attachment adapter (encode) and the message renderer (decode) can share it.
 
-export type AttachmentRef = { name: string; path: string };
+export type AttachmentRef = { name: string; path: string; size?: number };
 
 const MARKER = "[[attachment]]";
 
@@ -24,11 +24,13 @@ export function extractAttachmentRefs(text: string): {
   for (const line of text.split("\n")) {
     if (line.startsWith(MARKER)) {
       // A marker line is never shown as raw text: emit a ref if it's well-formed,
-      // otherwise drop it.
+      // otherwise drop it. `size` is optional — markers from before it existed
+      // don't carry it — and is dropped when it isn't a plain finite number.
       try {
-        const ref = JSON.parse(line.slice(MARKER.length)) as AttachmentRef;
+        const ref = JSON.parse(line.slice(MARKER.length)) as Partial<Record<keyof AttachmentRef, unknown>>;
         if (ref && typeof ref.name === "string" && typeof ref.path === "string") {
-          refs.push(ref);
+          const size = typeof ref.size === "number" && Number.isFinite(ref.size) ? ref.size : undefined;
+          refs.push({ name: ref.name, path: ref.path, ...(size === undefined ? {} : { size }) });
         }
       } catch {
         // malformed marker — drop it

--- a/packages/desktop/src/renderer/lib/fileInfo.ts
+++ b/packages/desktop/src/renderer/lib/fileInfo.ts
@@ -1,0 +1,60 @@
+// Display metadata for attachment cards, derived from a filename: the type
+// label shown under the name, a coarse kind for picking an icon, and a human
+// file size. Framework-free so both the composer (which knows the byte size)
+// and the message renderer (which only has the name) share one vocabulary.
+
+/** Lowercase extension of a filename, or "" when there is none. Hidden files
+ *  (".env") and trailing dots don't count as extensions. */
+function extensionOf(name: string): string {
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0 || dot === name.length - 1) return "";
+  const ext = name.slice(dot + 1);
+  return /^[a-z0-9]{1,8}$/i.test(ext) ? ext.toLowerCase() : "";
+}
+
+/** Uppercase type label for the card's description line ("PDF"), or "" when
+ *  the name carries no extension. */
+export function fileTypeLabel(name: string): string {
+  return extensionOf(name).toUpperCase();
+}
+
+export type FileKind = "document" | "spreadsheet" | "image";
+
+const SPREADSHEET_EXTENSIONS = new Set(["csv", "tsv", "xls", "xlsx", "numbers", "ods"]);
+const IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "avif",
+  "bmp",
+  "heic",
+  "heif",
+  "svg",
+  "tif",
+  "tiff",
+]);
+
+/** Coarse bucket for choosing the card's icon. Image kinds still occur for
+ *  files: formats the model can't read (heic, svg, …) travel as files. */
+export function fileKind(name: string): FileKind {
+  const ext = extensionOf(name);
+  if (SPREADSHEET_EXTENSIONS.has(ext)) return "spreadsheet";
+  if (IMAGE_EXTENSIONS.has(ext)) return "image";
+  return "document";
+}
+
+/** Human file size in decimal units, macOS-style: "532 B", "245 KB", "1.2 MB". */
+export function formatFileSize(bytes: number): string {
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1000 && unit < units.length - 1) {
+    value /= 1000;
+    unit += 1;
+  }
+  const rounded =
+    unit === 0 ? String(value) : value >= 9.95 ? String(Math.round(value)) : value.toFixed(1).replace(/\.0$/, "");
+  return `${rounded} ${units[unit]}`;
+}

--- a/packages/desktop/src/renderer/runtime/__tests__/fileAttachmentAdapter.test.ts
+++ b/packages/desktop/src/renderer/runtime/__tests__/fileAttachmentAdapter.test.ts
@@ -162,9 +162,10 @@ describe("WorkspaceFileAttachmentAdapter.send()", () => {
     const complete = await adapter.send(pending);
     const text = (complete.content as { text: string }[])[0]!.text;
 
+    // size 1: the test file holds the single byte "x".
     expect(extractAttachmentRefs(text)).toEqual({
       text: "",
-      refs: [{ name: "statement.pdf", path: "attachments/statement.pdf" }],
+      refs: [{ name: "statement.pdf", path: "attachments/statement.pdf", size: 1 }],
     });
   });
 

--- a/packages/desktop/src/renderer/runtime/fileAttachmentAdapter.ts
+++ b/packages/desktop/src/renderer/runtime/fileAttachmentAdapter.ts
@@ -38,7 +38,12 @@ abstract class ArchivingAttachmentAdapter implements AttachmentAdapter {
   abstract accept: string;
   protected abstract type: PendingAttachment["type"];
   /** How the archived file is presented to the agent. */
-  protected abstract toContent(name: string, path: string, dataUrl: string): CompleteAttachment["content"];
+  protected abstract toContent(
+    name: string,
+    path: string,
+    dataUrl: string,
+    sizeBytes: number,
+  ): CompleteAttachment["content"];
 
   async add({ file }: { file: File }): Promise<PendingAttachment> {
     trackAttachmentAdded(attachmentKind(file.type));
@@ -58,7 +63,7 @@ abstract class ArchivingAttachmentAdapter implements AttachmentAdapter {
     return {
       ...attachment,
       status: { type: "complete" },
-      content: this.toContent(attachment.name, path, dataUrl),
+      content: this.toContent(attachment.name, path, dataUrl, attachment.file.size),
     };
   }
 
@@ -95,7 +100,7 @@ export class WorkspaceFileAttachmentAdapter extends ArchivingAttachmentAdapter {
     super();
   }
 
-  protected toContent(name: string, path: string) {
-    return [{ type: "text" as const, text: encodeAttachmentRef({ name, path }) }];
+  protected toContent(name: string, path: string, _dataUrl: string, sizeBytes: number) {
+    return [{ type: "text" as const, text: encodeAttachmentRef({ name, path, size: sizeBytes }) }];
   }
 }

--- a/packages/pi-extension/src/system-prompt/system.md
+++ b/packages/pi-extension/src/system-prompt/system.md
@@ -56,7 +56,7 @@ Your workspace is `~/Accountant24`. All file operations stay within this directo
 
 # Imports and attachments
 
-- When the user attaches a non-image file (PDF, CSV, …), the message carries an `[[attachment]]{"name":…,"path":…}` marker. The file is already saved in the workspace at `path` (e.g., `files/2026/04/20260417160112.pdf`); pass that path to `extract_text` or other tools — never use absolute paths with `extract_text`. (Images are attached directly as content; they are archived too but need no path.)
+- When the user attaches a non-image file (PDF, CSV, …), the message carries an `[[attachment]]{"name":…,"path":…,"size":…}` marker. The file is already saved in the workspace at `path` (e.g., `files/2026/04/20260417160112.pdf`); pass that path to `extract_text` or other tools — never use absolute paths with `extract_text`. (Images are attached directly as content; they are archived too but need no path.)
 - On import (bank statements, receipts), preserve the original bank payee using the `original_payee_name` tag, store the bank description with the `original_description` tag, and link the source document with the `related_file` tag (path relative to workspace).
 
 # Account balances


### PR DESCRIPTION
- Show sent attachments as file cards in a row above the message bubble instead of chips inside it
- Render a file-only message as just its card, hiding the empty bubble
- Give attachment cards a uniform width so multiple files wrap into a tidy grid
- Add a muted type and size line ("PDF · 245 KB") under the file name
- Pick the card icon by file kind: document, spreadsheet, or image
- Carry the file byte size in the `[[attachment]]` marker
- Remove the attachment row's bottom padding so the composer input sits evenly between it and the action row
- Keep the description line `font-normal` inside the composer's `InputGroupAddon`
- Add `fileInfo` helpers (`fileTypeLabel`, `fileKind`, `formatFileSize`) with unit tests