### PR TITLE
feat: cleaner code blocks in the chat

### DIFF
--- a/packages/desktop/src/renderer/components/accountant24/__tests__/markdown-text.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/markdown-text.test.tsx
@@ -107,11 +107,25 @@ describe("MarkdownText", () => {
     expect(quote.closest("blockquote")).not.toBeNull();
   });
 
-  it("should render a fenced code block with its language label and code", async () => {
+  it("should render a fenced code block's code without a language header", async () => {
     draw("```js\nconst x = 1;\n```");
-    // CodeHeader shows the language (lowercased) and the code renders verbatim.
-    await screen.findByText("js");
-    expect(screen.getByText(/const x = 1;/)).toBeInTheDocument();
+    expect(await screen.findByText(/const x = 1;/)).toBeInTheDocument();
+    // Code blocks are headerless: no language label anywhere.
+    expect(screen.queryByText("js")).toBeNull();
+  });
+
+  it("should render an empty fenced block without a copy button", async () => {
+    draw("Before\n\n```js\n```");
+    await screen.findByText("Before");
+    // Nothing to copy, so the copy action must not render.
+    expect(screen.queryByRole("button", { name: "Copy" })).toBeNull();
+  });
+
+  it("should render an untagged fenced block without an unknown label", async () => {
+    draw("```\naccount assets:bank\n```");
+    expect(await screen.findByText(/account assets:bank/)).toBeInTheDocument();
+    // react-markdown reports untagged fences as "unknown"; no label must leak.
+    expect(screen.queryByText("unknown")).toBeNull();
   });
 
   it("should render a GFM table with column headers and cell values", async () => {
@@ -161,7 +175,7 @@ describe("MarkdownText", () => {
       stubClipboard(writeText);
 
       draw("```js\nconst x = 1;\n```");
-      await screen.findByText("js");
+      await screen.findByText(/const x = 1;/);
       fireEvent.click(screen.getByRole("button", { name: "Copy" }));
 
       expect(writeText).toHaveBeenCalledTimes(1);
@@ -173,7 +187,7 @@ describe("MarkdownText", () => {
       stubClipboard(writeText);
 
       draw("```js\nconst x = 1;\n```");
-      await screen.findByText("js");
+      await screen.findByText(/const x = 1;/);
       const copyButton = screen.getByRole("button", { name: "Copy" });
       fireEvent.click(copyButton);
       // Wait for the transient isCopied flag to flip before the second click.

--- a/packages/desktop/src/renderer/components/accountant24/code-block.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/code-block.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon, CopyIcon } from "lucide-react";
-import { Button } from "@/components/shadcn/button";
+import { HoverActionButton, HoverActions } from "@/components/accountant24/hover-actions";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { cn } from "@/lib/utils";
 
@@ -10,54 +10,50 @@ import { cn } from "@/lib/utils";
  * composer. Wide content (hledger reports) scrolls horizontally instead of
  * wrapping, so column alignment survives.
  *
- * A copy button sits in the top-right corner, revealed on hover or keyboard
- * focus (and pinned while the copied state shows). It copies `copyText`, or
- * the children when they are a plain string.
+ * A copy action pill (the shared HoverActions surface, as on markdown tables)
+ * sits in the top-right corner, revealed on hover or keyboard focus (and
+ * pinned while the copied state shows). It copies `copyText`, or the children
+ * when they are a plain string.
  */
 export function CodeBlock({
   className,
+  preClassName,
   children,
   copyText,
   ...props
-}: React.ComponentProps<"pre"> & { copyText?: string }) {
+}: React.ComponentProps<"pre"> & { copyText?: string; preClassName?: string }) {
   const { isCopied, copyToClipboard } = useCopyToClipboard();
   const textToCopy = copyText ?? (typeof children === "string" ? children : "");
 
   return (
-    <div className={cn("group/code-block relative", className)}>
+    <div className={cn("group/hover-actions relative", className)}>
       <pre
         // text-muted-foreground: these blocks live inside the muted
         // chain-of-thought log; full-strength foreground reads too heavy there.
+        // preClassName lets other surfaces (chat markdown) restyle the pre.
         className={cn(
           "bg-input/30 text-muted-foreground overflow-x-auto rounded-3xl px-4 py-3 text-xs leading-relaxed",
+          preClassName,
         )}
         {...props}
       >
         {children}
       </pre>
       {textToCopy && (
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label={isCopied ? "Copied" : "Copy"}
-          onClick={() => {
-            if (!isCopied) copyToClipboard(textToCopy);
-          }}
-          className={cn(
-            // Aligned with the block's py-3/px-4 padding; size-5 keeps the
-            // button inside the first line's box.
-            "text-muted-foreground hover:text-foreground absolute top-2 right-2.5 size-5 p-1 active:scale-90",
-            "opacity-0 transition-opacity duration-150",
-            "group-hover/code-block:opacity-100 focus-visible:opacity-100",
-            isCopied && "opacity-100",
-          )}
-        >
-          {isCopied ? (
-            <CheckIcon className="animate-in zoom-in-50 fade-in size-3 duration-200 ease-out" />
-          ) : (
-            <CopyIcon className="animate-in zoom-in-75 fade-in size-3 duration-150" />
-          )}
-        </Button>
+        <HoverActions className={cn(isCopied && "opacity-100")}>
+          <HoverActionButton
+            tooltip={isCopied ? "Copied" : "Copy"}
+            onClick={() => {
+              if (!isCopied) copyToClipboard(textToCopy);
+            }}
+          >
+            {isCopied ? (
+              <CheckIcon className="animate-in zoom-in-50 fade-in duration-200 ease-out" />
+            ) : (
+              <CopyIcon className="animate-in zoom-in-75 fade-in duration-150" />
+            )}
+          </HoverActionButton>
+        </HoverActions>
       )}
     </div>
   );

--- a/packages/desktop/src/renderer/components/accountant24/hover-actions.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/hover-actions.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import type { ComponentPropsWithoutRef } from "react";
+
+import { TooltipIconButton } from "@/components/accountant24/tooltip-icon-button";
+import { cn } from "@/lib/utils";
+
+/**
+ * Floating action pill for hoverable content surfaces (markdown tables, code
+ * blocks). Hugs the host's top-right corner and fades in on hover or keyboard
+ * focus, so the content stays clean at rest. Styled as a floating surface with
+ * the same tokens as popovers/menus so it reads as part of the app.
+ *
+ * The host wrapper must be `relative` and carry the `group/hover-actions`
+ * class; put the pill on a non-scrolling wrapper so it stays put while the
+ * content scrolls.
+ */
+export function HoverActions({ className, ...props }: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      className={cn(
+        // has-[:focus-visible] (not focus-within): reveal for keyboard focus
+        // only — a mouse click also focuses the button, which would pin the
+        // pill visible after the pointer leaves.
+        "bg-popover text-popover-foreground ring-foreground/5 dark:ring-foreground/10 absolute end-2 top-2 z-10 flex items-center gap-0.5 rounded-full p-1 opacity-0 shadow-lg ring-1 transition-opacity group-hover/hover-actions:opacity-100 has-[:focus-visible]:opacity-100",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+/** An icon button inside HoverActions: muted at rest, full-strength on hover. */
+export function HoverActionButton({ className, ...props }: ComponentPropsWithoutRef<typeof TooltipIconButton>) {
+  return <TooltipIconButton className={cn("text-muted-foreground hover:text-foreground", className)} {...props} />;
+}

--- a/packages/desktop/src/renderer/components/accountant24/markdown-table.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/markdown-table.tsx
@@ -4,7 +4,7 @@ import { DownloadIcon, Maximize2Icon } from "lucide-react";
 import { type ComponentPropsWithoutRef, useCallback, useRef, useState } from "react";
 
 import { AppDialogHeader } from "@/components/accountant24/app-dialog-header";
-import { TooltipIconButton } from "@/components/accountant24/tooltip-icon-button";
+import { HoverActionButton, HoverActions } from "@/components/accountant24/hover-actions";
 import { Dialog, DialogContent } from "@/components/shadcn/dialog";
 import { tableToCsv } from "@/lib/table-csv";
 import { cn } from "@/lib/utils";
@@ -39,34 +39,21 @@ export function MarkdownTable({ className, children, ...props }: ComponentPropsW
   }, []);
 
   return (
-    <div className="aui-md-table-wrapper group/md-table relative my-3 w-full">
+    <div className="aui-md-table-wrapper group/hover-actions relative my-3 w-full">
       <div ref={scrollRef} className="scroll-fade-x w-full overflow-x-auto">
         <table className={cn(tableClassName, className)} {...props}>
           {children}
         </table>
       </div>
 
-      {/* Actions hug the table's top-right corner and fade in on hover (or
-          keyboard focus), so the table stays clean at rest. Styled as a
-          floating surface with the same tokens as popovers/menus so it reads
-          as part of the app; sits on the non-scrolling wrapper so it stays put
-          as the table scrolls. */}
-      <div className="bg-popover text-popover-foreground ring-foreground/5 dark:ring-foreground/10 absolute end-2 top-2 z-10 flex items-center gap-0.5 rounded-full p-1 opacity-0 shadow-lg ring-1 transition-opacity group-hover/md-table:opacity-100 focus-within:opacity-100">
-        <TooltipIconButton
-          tooltip="Expand table"
-          onClick={() => setExpanded(true)}
-          className="text-muted-foreground hover:text-foreground"
-        >
+      <HoverActions>
+        <HoverActionButton tooltip="Expand table" onClick={() => setExpanded(true)}>
           <Maximize2Icon />
-        </TooltipIconButton>
-        <TooltipIconButton
-          tooltip="Download CSV"
-          onClick={downloadCsv}
-          className="text-muted-foreground hover:text-foreground"
-        >
+        </HoverActionButton>
+        <HoverActionButton tooltip="Download CSV" onClick={downloadCsv}>
           <DownloadIcon />
-        </TooltipIconButton>
-      </div>
+        </HoverActionButton>
+      </HoverActions>
 
       <Dialog open={expanded} onOpenChange={setExpanded}>
         {/* The dialog sizes to the table's natural width and height, so a

--- a/packages/desktop/src/renderer/components/accountant24/markdown-text.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/markdown-text.tsx
@@ -3,19 +3,16 @@
 import "@assistant-ui/react-markdown/styles/dot.css";
 
 import {
-  type CodeHeaderProps,
   MarkdownTextPrimitive,
   unstable_memoizeMarkdownComponents as memoizeMarkdownComponents,
   useIsMarkdownCodeBlock,
 } from "@assistant-ui/react-markdown";
-import { CheckIcon, CopyIcon } from "lucide-react";
-import { type FC, memo } from "react";
+import { isValidElement, memo, type ReactNode } from "react";
 import remarkGfm from "remark-gfm";
 
+import { CodeBlock } from "@/components/accountant24/code-block";
 import { DirectivePill } from "@/components/accountant24/directive-chips";
 import { MarkdownTable } from "@/components/accountant24/markdown-table";
-import { TooltipIconButton } from "@/components/accountant24/tooltip-icon-button";
-import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { remarkMentions } from "@/lib/remark-mentions";
 import { cn } from "@/lib/utils";
 
@@ -32,22 +29,12 @@ const MarkdownTextImpl = () => {
 
 export const MarkdownText = memo(MarkdownTextImpl);
 
-const CodeHeader: FC<CodeHeaderProps> = ({ language, code }) => {
-  const { isCopied, copyToClipboard } = useCopyToClipboard();
-  const onCopy = () => {
-    if (!code || isCopied) return;
-    copyToClipboard(code);
-  };
-
-  return (
-    <div className="aui-code-header-root bg-input/50 mt-chat-rhythm flex items-center justify-between rounded-t-xl px-3.5 py-1.5 text-xs">
-      <span className="aui-code-header-language text-muted-foreground font-medium lowercase">{language}</span>
-      <TooltipIconButton tooltip="Copy" onClick={onCopy}>
-        {!isCopied && <CopyIcon className="animate-in zoom-in-75 fade-in duration-150" />}
-        {isCopied && <CheckIcon className="animate-in zoom-in-50 fade-in duration-200 ease-out" />}
-      </TooltipIconButton>
-    </div>
-  );
+/** Raw source of a fenced block: the pre's child is the rendered <code>
+ *  element whose only child is the code string (absent for an empty block). */
+const codeText = (node: ReactNode): string => {
+  if (typeof node === "string") return node;
+  if (isValidElement<{ children?: ReactNode }>(node)) return codeText(node.props.children);
+  return "";
 };
 
 const defaultComponents = memoizeMarkdownComponents({
@@ -153,14 +140,17 @@ const defaultComponents = memoizeMarkdownComponents({
   sup: ({ className, ...props }) => (
     <sup className={cn("aui-md-sup [&>a]:text-xs [&>a]:no-underline", className)} {...props} />
   ),
-  pre: ({ className, ...props }) => (
-    <pre
-      className={cn(
-        "aui-md-pre bg-input/30 overflow-x-auto rounded-t-none rounded-b-xl p-3.5 text-[13px] leading-relaxed",
-        className,
-      )}
+  // Headerless code block: the shared CodeBlock surface (hover copy button),
+  // restyled for the chat body (full foreground, chat type size).
+  pre: ({ className, children, ...props }) => (
+    <CodeBlock
+      className="my-chat-rhythm first:mt-0 last:mb-0"
+      copyText={codeText(children)}
+      preClassName={cn("aui-md-pre text-foreground rounded-xl p-3.5 text-[13px]", className)}
       {...props}
-    />
+    >
+      {children}
+    </CodeBlock>
   ),
   // Mention directives (`:account[…]` etc.) are rewritten by remarkMentions into
   // `<span data-mention-type data-mention-label>`; render those as the shared
@@ -185,5 +175,4 @@ const defaultComponents = memoizeMarkdownComponents({
       />
     );
   },
-  CodeHeader,
 });


### PR DESCRIPTION
- Remove the language header bar from chat code blocks
- Render chat code blocks through the shared `CodeBlock` component with a copy button on hover
- Extract the table hover actions into reusable `HoverActions`/`HoverActionButton` components and use them in `MarkdownTable` and `CodeBlock`
- Reveal the actions pill on keyboard focus only (`has-[:focus-visible]`) so it hides after a mouse click
- Update the markdown component tests for headerless code blocks