### PR TITLE
feat: clearer net worth summaries for multiple currencies

### DIFF
--- a/packages/desktop/src/main/__tests__/ledger.test.ts
+++ b/packages/desktop/src/main/__tests__/ledger.test.ts
@@ -37,13 +37,17 @@ vi.mock("../env", () => ({
 type Response = string[] | Error;
 
 /** Program execFile so each `hledger <sub>` returns the given canned result.
- *  Balance-sheet variants are keyed by their flags: "bs" (native holdings),
- *  "bs:V" (at market value, `-X`). A sub without a canned result returns
- *  empty output. */
+ *  Variants are keyed by their flags: "bs" (native holdings), "bs:V" (at
+ *  market value, `-X` or `-V`), "prices" (declared P directives only),
+ *  "prices:inferred" (`--infer-market-prices` fallback probe). A sub without
+ *  a canned result returns empty output. */
 function stubHledger(bySub: Record<string, Response>) {
   h.execFile.mockImplementation((_bin: string, args: string[], _opts: unknown, cb: ExecCb) => {
     let sub = args[0] as string;
+    // The -X/-V check must win: the valued bs run also carries
+    // --infer-market-prices and must stay keyed "bs:V".
     if (args.includes("-X") || args.includes("-V")) sub += ":V";
+    else if (args.includes("--infer-market-prices")) sub += ":inferred";
     const r = bySub[sub];
     if (r instanceof Error) {
       cb(r, "", "boom");
@@ -284,6 +288,7 @@ describe("ledger_net_worth", () => {
         ],
         value: [{ quantity: 9690, commodity: "EUR", precision: 2 }],
       },
+      baseCommodity: "EUR",
     });
   });
 
@@ -298,6 +303,8 @@ describe("ledger_net_worth", () => {
     expect(argLists).toContainEqual([...base, "-X", "EUR", "--infer-market-prices"]);
     expect(argLists).toContainEqual(["print", "-O", "json", "-f", "/ws/ledger/main.journal"]);
     expect(argLists).toContainEqual(["prices", "-f", "/ws/ledger/main.journal"]);
+    // Declared prices exist, so the cost-inferred probe must not run.
+    expect(argLists).not.toContainEqual(["prices", "-f", "/ws/ledger/main.journal", "--infer-market-prices"]);
     for (const call of h.execFile.mock.calls) {
       const opts = call[2] as { cwd: string; env: unknown; maxBuffer: number };
       expect(opts.cwd).toBe("/ws");
@@ -306,11 +313,33 @@ describe("ledger_net_worth", () => {
     }
   });
 
-  it("should fall back to -V when the journal declares no prices", async () => {
-    stubHledger({ ...emptyStubs, prices: [] });
-    await netWorth();
+  it("should fall back to the cost-inferred base when the journal declares no prices", async () => {
+    stubHledger({ ...emptyStubs, prices: [], "prices:inferred": ["P 2026-07-20 WRLD 210.00 EUR"] });
+    const sheet = await netWorth();
+
+    expect(h.execFile.mock.calls).toHaveLength(5);
+    const argLists = h.execFile.mock.calls.map((c) => c[1] as string[]);
+    expect(argLists).toContainEqual(["prices", "-f", "/ws/ledger/main.journal"]);
+    expect(argLists).toContainEqual(["prices", "-f", "/ws/ledger/main.journal", "--infer-market-prices"]);
+    expect(argLists).toContainEqual([
+      "bs",
+      "-O",
+      "json",
+      "-f",
+      "/ws/ledger/main.journal",
+      "-X",
+      "EUR",
+      "--infer-market-prices",
+    ]);
+    expect(sheet.baseCommodity).toBe("EUR");
+  });
+
+  it("should fall back to -V when neither declared nor cost-inferred prices exist", async () => {
+    stubHledger({ ...emptyStubs, prices: [], "prices:inferred": [] });
+    const sheet = await netWorth();
     const argLists = h.execFile.mock.calls.map((c) => c[1] as string[]);
     expect(argLists).toContainEqual(["bs", "-O", "json", "-f", "/ws/ledger/main.journal", "-V"]);
+    expect(sheet.baseCommodity).toBeNull();
   });
 
   it("should graft only the date when the assertion carries no parseable amount", async () => {
@@ -343,18 +372,20 @@ describe("ledger_net_worth", () => {
       { quantity: 0.16, commodity: "BTC", precision: 8 },
       { quantity: -300, commodity: "EUR", precision: 2 },
     ]);
+    // The base still resolved from the prices probe; only the valuation failed.
+    expect(sheet.baseCommodity).toBe("EUR");
   });
 
   it("should return an empty sheet when hledger fails (no journal yet)", async () => {
     const err = new Error("hledger: no journal");
     stubHledger({ bs: err, "bs:V": err });
-    expect(await netWorth()).toEqual({ sections: [], net: { amounts: [], value: [] } });
+    expect(await netWorth()).toEqual({ sections: [], net: { amounts: [], value: [] }, baseCommodity: null });
   });
 
   it("should return an empty sheet when hledger is missing entirely", async () => {
     const enoent = Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" });
     stubHledger({ bs: enoent, "bs:V": enoent });
-    expect(await netWorth()).toEqual({ sections: [], net: { amounts: [], value: [] } });
+    expect(await netWorth()).toEqual({ sections: [], net: { amounts: [], value: [] }, baseCommodity: null });
   });
 
   it("should run the vendored hledger binary when it exists in binDir", async () => {

--- a/packages/desktop/src/main/ledger-json.ts
+++ b/packages/desktop/src/main/ledger-json.ts
@@ -172,8 +172,12 @@ export function parseAssertions(json: string): Record<string, Assertion> {
 /** Merge the raw and market-value (`-X`) runs of the same `bs` report. Both
  *  runs cover the identical sections and account lists, so everything pairs
  *  by position; if the valued run is missing or disagrees (partial hledger
- *  failure), the raw amounts stand in for the value. */
-export function mergeValuedBalanceSheet(raw: RawBalanceSheet, valued: RawBalanceSheet | null): NetWorth {
+ *  failure), the raw amounts stand in for the value. The base commodity is
+ *  the caller's to add — it comes from price resolution, not the merge. */
+export function mergeValuedBalanceSheet(
+  raw: RawBalanceSheet,
+  valued: RawBalanceSheet | null,
+): Omit<NetWorth, "baseCommodity"> {
   const orRaw = (amounts: LedgerAmount[], candidate: LedgerAmount[] | undefined): LedgerAmount[] =>
     candidate ?? amounts;
   const sections: NetWorthSection[] = raw.sections.map((section, s) => {

--- a/packages/desktop/src/main/ledger.ts
+++ b/packages/desktop/src/main/ledger.ts
@@ -55,11 +55,16 @@ async function ledgerMentions(): Promise<LedgerMentions> {
 /** The report's base commodity — the target of the journal's latest
  *  declared market price. The agent records prices toward the user's
  *  currency, so the journal itself answers "which currency is home" and no
- *  currency is hardcoded. Seam for the future default-currency setting: once
- *  it exists, resolve it here first and fall back to the derivation. Null
- *  when the journal declares no prices. */
+ *  currency is hardcoded. When the journal declares no prices, the latest
+ *  cost-inferred price (`--infer-market-prices`, e.g. `2 WRLD @ 210.00 EUR`)
+ *  answers instead. The probes stay sequential so a later-dated cost can
+ *  never out-rank a declared price. Seam for the future default-currency
+ *  setting: once it exists, resolve it here first and fall back to the
+ *  derivation. Null when the journal yields no prices at all. */
 async function resolveBaseCommodity(): Promise<string | null> {
-  return parseLatestPriceTarget(await hledgerRaw(["prices", "-f", mainJournalPath()]));
+  const declared = parseLatestPriceTarget(await hledgerRaw(["prices", "-f", mainJournalPath()]));
+  if (declared !== null) return declared;
+  return parseLatestPriceTarget(await hledgerRaw(["prices", "-f", mainJournalPath(), "--infer-market-prices"]));
 }
 
 /** The classic balance sheet, straight from `hledger bs`: Assets and
@@ -69,11 +74,13 @@ async function resolveBaseCommodity(): Promise<string | null> {
  *  base commodity the valued run is `-X <base> --infer-market-prices`, which
  *  collapses multi-commodity holdings to one base-currency figure wherever
  *  hledger finds any price path (direct, reverse, chained, or cost-
- *  inferred); with no prices declared there is nothing to aim at, and `-V`
- *  lets hledger value what it can. Each row also carries the date and amount
- *  of the account's latest balance assertion (from `print -O json`) — when
- *  the balance was last reconciled and what it was confirmed to be. Empty
- *  when there's no journal yet or hledger fails. */
+ *  inferred); with no prices at all there is nothing to aim at, and `-V`
+ *  lets hledger value what it can. The payload carries the base commodity
+ *  (the `-X` target; null on the `-V` path) so the renderer can lead a
+ *  multi-commodity figure with the home-currency leg. Each row also carries
+ *  the date and amount of the account's latest balance assertion (from
+ *  `print -O json`) — when the balance was last reconciled and what it was
+ *  confirmed to be. Empty when there's no journal yet or hledger fails. */
 async function ledgerNetWorth(): Promise<NetWorth> {
   const base = ["bs", "-O", "json", "-f", mainJournalPath()];
   const [native, printed, target] = await Promise.all([
@@ -83,11 +90,12 @@ async function ledgerNetWorth(): Promise<NetWorth> {
   ]);
   const valued = await hledgerRaw(target ? [...base, "-X", target, "--infer-market-prices"] : [...base, "-V"]);
   const raw = parseBalanceSheetJson(native);
-  if (raw === null) return { sections: [], net: { amounts: [], value: [] } };
+  if (raw === null) return { sections: [], net: { amounts: [], value: [] }, baseCommodity: null };
   const sheet = mergeValuedBalanceSheet(raw, parseBalanceSheetJson(valued));
   const asserted = parseAssertions(printed);
   return {
     ...sheet,
+    baseCommodity: target,
     sections: sheet.sections.map((section) => ({
       ...section,
       rows: section.rows.map((row) => {

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-badge.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-badge.test.tsx
@@ -39,7 +39,11 @@ function Chrome({ children, isRunning = false }: { children: ReactNode; isRunnin
   return <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>;
 }
 
-const sheet = (net: NetWorth["net"]): NetWorth => ({ sections: [], net });
+const sheet = (net: NetWorth["net"], baseCommodity: NetWorth["baseCommodity"] = null): NetWorth => ({
+  sections: [],
+  net,
+  baseCommodity,
+});
 
 const CONVERTED = sheet({
   amounts: [{ quantity: 1408.26, commodity: "UAH", precision: 2 }],
@@ -75,6 +79,39 @@ describe("<NetWorthBadge />", () => {
     );
     renderBadge();
     expect(await screen.findByText("2.7K EUR")).toBeInTheDocument();
+  });
+
+  it("should lead with the base leg and count the rest when the value spans several commodities", async () => {
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(
+      sheet(
+        {
+          amounts: [
+            { quantity: 2050, commodity: "UAH", precision: 2 },
+            { quantity: -50, commodity: "USD", precision: 2 },
+            { quantity: 2537.5, commodity: "EUR", precision: 2 },
+          ],
+          // hledger orders legs alphabetically: the EUR base leg is not first.
+          value: [
+            { quantity: 3033.5, commodity: "EUR", precision: 2 },
+            { quantity: 2050, commodity: "UAH", precision: 2 },
+            { quantity: -50, commodity: "USD", precision: 2 },
+          ],
+        },
+        "EUR",
+      ),
+    );
+    renderBadge();
+    expect(await screen.findByText("~3K EUR +2")).toBeInTheDocument();
+  });
+
+  it("should lead with the first leg when no base commodity is resolved", async () => {
+    const amounts = [
+      { quantity: 1200, commodity: "EUR", precision: 2 },
+      { quantity: 5000, commodity: "UAH", precision: 2 },
+    ];
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(sheet({ amounts, value: amounts }));
+    renderBadge();
+    expect(await screen.findByText("1.2K EUR +1")).toBeInTheDocument();
   });
 
   it("should render nothing when the report has no value (empty journal)", async () => {

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-view.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-view.test.tsx
@@ -88,9 +88,10 @@ const DATA: NetWorth = {
     },
   ],
   net: { amounts: [A("UAH", 1408.26), A("USD", 100), A("SXR8", 22.45), A("EUR", -296.75)], value: [A("EUR", 1738.97)] },
+  baseCommodity: "EUR",
 };
 
-const EMPTY: NetWorth = { sections: [], net: { amounts: [], value: [] } };
+const EMPTY: NetWorth = { sections: [], net: { amounts: [], value: [] }, baseCommodity: null };
 
 const renderView = (isRunning = false) =>
   render(
@@ -246,6 +247,7 @@ describe("<NetWorthView />", () => {
         },
       ],
       net: { amounts: [A("EUR", 10)], value: [A("EUR", 10)] },
+      baseCommodity: null,
     });
     renderView();
     await screen.findByTitle("assets:legacy");
@@ -267,10 +269,65 @@ describe("<NetWorthView />", () => {
     vi.mocked(ledgerApi.netWorth).mockResolvedValue({
       ...DATA,
       net: { amounts: [A("EUR", 7796.25), A("UAH", 1000)], value: [A("EUR", 7796.25), A("UAH", 1000)] },
+      baseCommodity: null,
     });
     renderView();
     expect(await screen.findByText("7,796.25 EUR, 1,000.00 UAH")).toBeInTheDocument();
     expect(screen.queryByText("~7,796.25 EUR, 1,000.00 UAH")).not.toBeInTheDocument();
+    // Unsplit bands carry no info marker.
+    expect(screen.queryByRole("button", { name: "About other currencies" })).not.toBeInTheDocument();
+  });
+
+  it("should lead the Net band with the base leg and mute the unconvertible rest", async () => {
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue({
+      ...DATA,
+      net: {
+        amounts: [A("EUR", 2537.5), A("UAH", 2050), A("USD", -50), A("WRLD", 2, 0)],
+        value: [A("EUR", 3033.5), A("UAH", 2050), A("USD", -50)],
+      },
+    });
+    renderView();
+    // The base leg and the leftover legs are separate elements, not one line.
+    expect(await screen.findByText("~3,033.50 EUR")).toBeInTheDocument();
+    expect(screen.getByText("2,050.00 UAH, -50.00 USD")).toBeInTheDocument();
+    expect(screen.queryByText("~3,033.50 EUR, 2,050.00 UAH, -50.00 USD")).not.toBeInTheDocument();
+  });
+
+  it("should split a section band the same way as the Net band", async () => {
+    const section = DATA.sections[0] as NetWorth["sections"][number];
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue({
+      ...DATA,
+      sections: [
+        {
+          ...section,
+          total: {
+            amounts: [A("UAH", 1408.26), A("USD", 100), A("EUR", 50)],
+            value: [A("EUR", 165.57), A("USD", 100)],
+          },
+        },
+      ],
+    });
+    renderView();
+    expect(await screen.findByText("~165.57 EUR")).toBeInTheDocument();
+    expect(screen.getByText("100.00 USD")).toBeInTheDocument();
+  });
+
+  it("should explain the muted legs behind their own info marker", async () => {
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue({
+      ...DATA,
+      net: {
+        amounts: [A("EUR", 2537.5), A("UAH", 2050)],
+        value: [A("EUR", 3033.5), A("UAH", 2050)],
+      },
+    });
+    renderView();
+    await screen.findByText("2,050.00 UAH");
+    await userEvent.hover(screen.getByRole("button", { name: "About other currencies" }));
+    expect(await screen.findByText("No rate recorded yet to value these in your main currency.")).toBeInTheDocument();
+    // The same how-to line as the Value column help: the fix, not just the fact.
+    expect(
+      screen.getByText(/To update a rate, tell the agent what one unit of the holding is worth/),
+    ).toBeInTheDocument();
   });
 
   it("should show no ~ anywhere when nothing was converted, totals included", async () => {
@@ -287,6 +344,7 @@ describe("<NetWorthView />", () => {
         },
       ],
       net: { amounts: [A("EUR", 7796.25), A("UAH", 1000)], value: [A("EUR", 7796.25), A("UAH", 1000)] },
+      baseCommodity: null,
     });
     renderView();
     await screen.findByTitle("assets:bank:mono");
@@ -400,6 +458,7 @@ describe("<NetWorthView />", () => {
           },
         ],
         net: { amounts: [], value: [A("EUR", 170)] },
+        baseCommodity: null,
       });
       renderView();
       await screen.findByTitle("assets:closed");

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth.integration.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth.integration.test.tsx
@@ -89,6 +89,7 @@ const DATA: NetWorth = {
     amounts: [{ quantity: 2736, commodity: "EUR", precision: 2 }],
     value: [{ quantity: 2736, commodity: "EUR", precision: 2 }],
   },
+  baseCommodity: "EUR",
 };
 
 beforeAll(() => {
@@ -208,7 +209,11 @@ describe("Net Worth view flow", () => {
   });
 
   it("should show the empty state when the report has no accounts", async () => {
-    bridge.setHandler("ledger_net_worth", () => ({ sections: [], net: { amounts: [], value: [] } }));
+    bridge.setHandler("ledger_net_worth", () => ({
+      sections: [],
+      net: { amounts: [], value: [] },
+      baseCommodity: null,
+    }));
     render(<ChatLayout />);
     openSheet();
 

--- a/packages/desktop/src/renderer/components/accountant24/chat-layout.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/chat-layout.tsx
@@ -157,7 +157,7 @@ export function ChatLayout() {
                 <SidebarMenuItem>
                   <SidebarMenuButton isActive={view === "net-worth"} onClick={() => setView("net-worth")}>
                     <LandmarkIcon className="size-4" />
-                    Net Worth
+                    <span className="whitespace-nowrap">Net Worth</span>
                     <NetWorthBadge />
                   </SidebarMenuButton>
                 </SidebarMenuItem>

--- a/packages/desktop/src/renderer/components/accountant24/net-worth-badge.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/net-worth-badge.tsx
@@ -15,7 +15,7 @@ import { useNetWorth } from "./use-net-worth";
 export const NetWorthBadge: FC = () => {
   const sheet = useNetWorth();
   if (sheet === null) return null;
-  const text = formatValueCompact(sheet.net, navigator.language);
+  const text = formatValueCompact(sheet.net, navigator.language, sheet.baseCommodity);
   if (!text) return null;
   // aria-hidden keeps the button's accessible name a stable "Net Worth"
   // instead of one that shifts with every ledger change.

--- a/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
@@ -39,8 +39,8 @@ import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/shadc
 import { Skeleton } from "@/components/shadcn/skeleton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/shadcn/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/tooltip";
-import { formatAmount, formatAmounts, formatValue } from "@/lib/amountFormat";
-import type { AccountBalance, NetWorthSection } from "@/rpc/types";
+import { formatAmount, formatAmounts, formatValue, splitValueLead } from "@/lib/amountFormat";
+import type { AccountBalance, NetWorthSection, NetWorthTotal } from "@/rpc/types";
 import { useNetWorth } from "./use-net-worth";
 
 /** Clickable column header driving the table's sorting; the icon mirrors
@@ -67,6 +67,16 @@ const ASSERTED_AMOUNT_LABEL = "Asserted Amount";
 
 /** What each money/meta column means, keyed by its label; shown behind the
  *  little info marker next to the header (the Account column needs none). */
+/** The how-to line for anything valued at a recorded rate — shared by the
+ *  Value column help and the bands' unpriced-legs tooltip so the copy stays
+ *  identical in both. */
+const RATE_HELP = (
+  <p className="mt-1.5">
+    To update a rate, tell the agent what one unit of the holding is worth now in your main currency, for example: "1
+    USD is 0.92 EUR."
+  </p>
+);
+
 const COLUMN_HELP: Record<string, ReactNode> = {
   Holding:
     "What the account actually holds: cash in its own currency, shares, or crypto. Exactly as recorded in the ledger, before any conversion.",
@@ -98,18 +108,16 @@ const COLUMN_HELP: Record<string, ReactNode> = {
         What the holding is worth in your main currency, at the latest rate recorded in the ledger. A ~ means the value
         was converted and is an estimate.
       </p>
-      <p className="mt-1.5">
-        To update a rate, tell the agent what one unit of the holding is worth now in your main currency, for example:
-        "1 USD is 0.92 EUR."
-      </p>
+      {RATE_HELP}
     </div>
   ),
 };
 
-/** A visible little info marker; hovering it explains the column. A separate
- *  target from the sort button, so the help is discoverable and sorting
- *  stays a plain click. */
-const InfoTip: FC<{ label: string }> = ({ label }) => (
+/** A visible little info marker; hovering it explains the spot it marks —
+ *  the column help for its label by default, or the given children. A
+ *  separate target from the text it explains, so the help is discoverable
+ *  and the text stays inert. */
+const InfoTip: FC<{ label: string; children?: ReactNode }> = ({ label, children }) => (
   <TooltipProvider>
     <Tooltip>
       <TooltipTrigger
@@ -125,7 +133,7 @@ const InfoTip: FC<{ label: string }> = ({ label }) => (
         <InfoIcon className="size-3.5" />
       </TooltipTrigger>
       <TooltipContent side="top" className="max-w-60">
-        {COLUMN_HELP[label]}
+        {children ?? COLUMN_HELP[label]}
       </TooltipContent>
     </Tooltip>
   </TooltipProvider>
@@ -317,22 +325,51 @@ const AccountsTable: FC<{
 };
 
 /** The soft summary-band surface shared by the section headers and the Net
- *  line: label left, hledger's figure right, on the app's muted panel. px-5
- *  inside mx-3 keeps the text on the px-8 line of the page title. */
-const BAND_CLASS = "mx-3 flex items-baseline justify-between gap-8 rounded-xl bg-muted/50 px-5 py-4";
+ *  line: label left, hledger's figure right, on the app's muted panel. The
+ *  label centers on the figure block, so it stays mid-band when the figure
+ *  grows a second (muted) line. px-5 inside mx-3 keeps the text on the px-8
+ *  line of the page title. */
+const BAND_CLASS = "mx-3 flex items-center justify-between gap-8 rounded-xl bg-muted/50 px-5 py-4";
+
+/** A summary band's figure. When the valuation could not fold every leg
+ *  into the base currency, the base leg leads at the band's weight and the
+ *  leftover legs sit smaller and muted on their own line under it, marked
+ *  with the same info icon as the column help. A figure with no split
+ *  renders exactly as before. */
+const BandValue: FC<{ figure: NetWorthTotal; baseCommodity: string | null }> = ({ figure, baseCommodity }) => {
+  const { lead, tail } = splitValueLead(figure, navigator.language, baseCommodity);
+  if (!tail) return <div className="shrink-0 text-right text-lg font-semibold tabular-nums">{lead}</div>;
+  return (
+    <div className="min-w-0 text-right tabular-nums">
+      <div className="text-lg font-semibold">{lead}</div>
+      {/* gap-1.5 + the icon button's own padding lands the icon-to-text
+          distance on the column headers' rhythm. */}
+      <div className="flex items-center justify-end gap-1.5">
+        <InfoTip label="other currencies">
+          {/* One wrapper like every COLUMN_HELP entry: the tooltip content
+              lays its direct children out in a row. */}
+          <div>
+            <p>No rate recorded yet to value these in your main currency.</p>
+            {RATE_HELP}
+          </div>
+        </InfoTip>
+        <span className="text-sm font-medium text-muted-foreground">{tail}</span>
+      </div>
+    </div>
+  );
+};
 
 /** One `bs` section: its hledger name and total over its accounts table. */
-const SheetSection: FC<{ section: NetWorthSection; search: string; columnVisibility: VisibilityState }> = ({
-  section,
-  search,
-  columnVisibility,
-}) => (
+const SheetSection: FC<{
+  section: NetWorthSection;
+  baseCommodity: string | null;
+  search: string;
+  columnVisibility: VisibilityState;
+}> = ({ section, baseCommodity, search, columnVisibility }) => (
   <section>
     <div className={`mt-8 mb-2 ${BAND_CLASS}`}>
       <h2 className="text-xl font-semibold">{section.name}</h2>
-      <div className="shrink-0 text-right text-lg font-semibold tabular-nums">
-        {formatValue(section.total, navigator.language)}
-      </div>
+      <BandValue figure={section.total} baseCommodity={baseCommodity} />
     </div>
     {/* px-5: with the cells' own px-3, the table text lines up with the px-8
         headings. */}
@@ -405,7 +442,7 @@ const SheetSkeleton: FC<{ columnVisibility: VisibilityState }> = ({ columnVisibi
       </div>
       <div className={`mt-8 ${BAND_CLASS}`}>
         <div className="text-xl font-semibold">Net Worth</div>
-        <Skeleton className="h-5 w-32 self-center" />
+        <Skeleton className="h-5 w-32" />
       </div>
     </div>
   );
@@ -454,10 +491,12 @@ export const NetWorthView: FC = () => {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className={`mx-auto flex w-full ${pageWidth} shrink-0 items-center justify-between gap-8 px-8 pt-16 pb-4`}>
-        <h1 className="text-3xl font-semibold">Net Worth</h1>
+        <h1 className="whitespace-nowrap text-3xl font-semibold">Net Worth</h1>
         {(sheet === null || sections.length > 0) && (
-          <div className="flex shrink-0 items-center gap-2">
-            <InputGroup className="w-64">
+          // min-w-0 (not shrink-0): when the window narrows, the search
+          // field gives way so the Columns button never clips.
+          <div className="flex min-w-0 items-center gap-2">
+            <InputGroup className="w-64 min-w-0">
               <InputGroupInput
                 type="search"
                 placeholder="Search accounts"
@@ -472,7 +511,7 @@ export const NetWorthView: FC = () => {
             <DropdownMenu>
               <DropdownMenuTrigger
                 render={
-                  <Button variant="outline">
+                  <Button variant="outline" className="shrink-0">
                     <Columns3Icon />
                     Columns
                   </Button>
@@ -518,6 +557,7 @@ export const NetWorthView: FC = () => {
                 <SheetSection
                   key={section.name}
                   section={section}
+                  baseCommodity={sheet.baseCommodity}
                   search={search}
                   columnVisibility={columnVisibility}
                 />
@@ -525,9 +565,7 @@ export const NetWorthView: FC = () => {
               {/* The closing Net band, straight from hledger's own net. */}
               <div className={`mt-8 ${BAND_CLASS}`}>
                 <div className="text-xl font-semibold">Net Worth</div>
-                <div className="shrink-0 text-right text-lg font-semibold tabular-nums">
-                  {formatValue(sheet.net, navigator.language)}
-                </div>
+                <BandValue figure={sheet.net} baseCommodity={sheet.baseCommodity} />
               </div>
             </>
           )}

--- a/packages/desktop/src/renderer/components/accountant24/use-net-worth.ts
+++ b/packages/desktop/src/renderer/components/accountant24/use-net-worth.ts
@@ -21,7 +21,7 @@ export function useNetWorth(): NetWorth | null {
         if (!cancelled) setData(d);
       })
       .catch(() => {
-        if (!cancelled) setData({ sections: [], net: { amounts: [], value: [] } });
+        if (!cancelled) setData({ sections: [], net: { amounts: [], value: [] }, baseCommodity: null });
       });
     return () => {
       cancelled = true;

--- a/packages/desktop/src/renderer/lib/__tests__/amountFormat.test.ts
+++ b/packages/desktop/src/renderer/lib/__tests__/amountFormat.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { LedgerAmount } from "@/rpc/types";
-import { formatAmount, formatAmounts, formatValue, formatValueCompact, isConverted } from "../amountFormat";
+import {
+  formatAmount,
+  formatAmounts,
+  formatValue,
+  formatValueCompact,
+  isConverted,
+  splitValueLead,
+} from "../amountFormat";
 
 // Spec for the Net Worth view's number presentation. Every commodity
 // reads the same way: locale-formatted number, commodity code as a suffix
@@ -157,6 +164,54 @@ describe("formatValue()", () => {
   });
 });
 
+describe("splitValueLead()", () => {
+  it("should split the base leg from the unconvertible rest, marking the lead as an estimate", () => {
+    const figure = {
+      amounts: [a("EUR", 2537.5), a("UAH", 2050), a("USD", -50), a("WRLD", 2, 0)],
+      value: [a("EUR", 3033.5), a("UAH", 2050), a("USD", -50)],
+    };
+    expect(splitValueLead(figure, "en-US", "EUR")).toEqual({
+      lead: "~3,033.50 EUR",
+      tail: "2,050.00 UAH, -50.00 USD",
+    });
+  });
+
+  it("should lead with the base leg, without ~, when nothing was converted", () => {
+    const amounts = [a("UAH", 5000), a("EUR", 1200)];
+    expect(splitValueLead({ amounts, value: amounts }, "en-US", "EUR")).toEqual({
+      lead: "1,200.00 EUR",
+      tail: "5,000.00 UAH",
+    });
+  });
+
+  it("should keep the whole line as the lead when no base is resolved", () => {
+    const amounts = [a("EUR", 1200), a("UAH", 5000)];
+    expect(splitValueLead({ amounts, value: amounts }, "en-US", null)).toEqual({
+      lead: "1,200.00 EUR, 5,000.00 UAH",
+      tail: "",
+    });
+  });
+
+  it("should keep the whole line as the lead when no leg matches the base", () => {
+    const amounts = [a("UAH", 5000), a("USD", 100)];
+    expect(splitValueLead({ amounts, value: amounts }, "en-US", "EUR")).toEqual({
+      lead: "5,000.00 UAH, 100.00 USD",
+      tail: "",
+    });
+  });
+
+  it("should not split a single-commodity figure", () => {
+    expect(splitValueLead({ amounts: [a("UAH", 1408.26)], value: [a("EUR", 333534.3)] }, "en-US", "EUR")).toEqual({
+      lead: "~333,534.30 EUR",
+      tail: "",
+    });
+  });
+
+  it("should render an empty figure as an empty lead", () => {
+    expect(splitValueLead({ amounts: [], value: [] }, "en-US", "EUR")).toEqual({ lead: "", tail: "" });
+  });
+});
+
 describe("formatValueCompact()", () => {
   it("should render a converted figure as ~ plus the compact number and code", () => {
     expect(
@@ -172,9 +227,36 @@ describe("formatValueCompact()", () => {
     expect(formatValueCompact({ amounts: [a("EUR", 988.54)], value: [a("EUR", 988.54)] }, "en-US")).toBe("989 EUR");
   });
 
-  it("should comma-join a multi-commodity figure compactly", () => {
+  it("should render the base leg plus the count of elided legs for a multi-commodity figure", () => {
+    const figure = {
+      amounts: [a("EUR", 2537.5), a("UAH", 2050), a("USD", -50), a("WRLD", 2, 0)],
+      value: [a("EUR", 3033.5), a("UAH", 2050), a("USD", -50), a("WRLD", 2, 0)],
+    };
+    expect(formatValueCompact(figure, "en-US", "EUR")).toBe("~3K EUR +3");
+  });
+
+  it("should lead with the base leg even when it is not first", () => {
+    const amounts = [a("UAH", 5000), a("EUR", 1200)];
+    expect(formatValueCompact({ amounts, value: amounts }, "en-US", "EUR")).toBe("1.2K EUR +1");
+  });
+
+  it("should lead with the first leg when no base is resolved", () => {
     const amounts = [a("EUR", 1200), a("UAH", 5000)];
-    expect(formatValueCompact({ amounts, value: [a("EUR", 1200), a("UAH", 5000)] }, "en-US")).toBe("1.2K EUR, 5K UAH");
+    expect(formatValueCompact({ amounts, value: amounts }, "en-US", null)).toBe("1.2K EUR +1");
+  });
+
+  it("should lead with the first leg when no leg matches the base", () => {
+    const amounts = [a("EUR", 1200), a("UAH", 5000)];
+    expect(formatValueCompact({ amounts, value: amounts }, "en-US", "USD")).toBe("1.2K EUR +1");
+  });
+
+  it("should format a negative leading leg with its minus", () => {
+    const amounts = [a("EUR", -1200), a("UAH", 5000)];
+    expect(formatValueCompact({ amounts, value: amounts }, "en-US", "EUR")).toBe("-1.2K EUR +1");
+  });
+
+  it("should format a commodity-less leg as a bare number", () => {
+    expect(formatValueCompact({ amounts: [a("", 42, 0)], value: [a("", 42, 0)] }, "en-US")).toBe("42");
   });
 
   it("should render an empty figure as an empty string", () => {

--- a/packages/desktop/src/renderer/lib/amountFormat.ts
+++ b/packages/desktop/src/renderer/lib/amountFormat.ts
@@ -64,14 +64,43 @@ export function formatValue(figure: ValuedFigure, locale?: string): string {
   return `${isConverted(figure) ? "~" : ""}${formatAmounts(figure.value, "value", locale)}`;
 }
 
+/** Split a figure's market-value line for the page's summary bands: the
+ *  base commodity's leg leads (carrying the "~" marker) and the legs the
+ *  valuation left in other commodities trail separately, so the band can
+ *  mute them. No split — the whole formatValue line as the lead, empty
+ *  tail — when the figure has one leg, no base is named, or no leg matches
+ *  it. */
+export function splitValueLead(
+  figure: ValuedFigure,
+  locale?: string,
+  baseCommodity?: string | null,
+): { lead: string; tail: string } {
+  const i = baseCommodity ? figure.value.findIndex((a) => a.commodity === baseCommodity) : -1;
+  if (figure.value.length <= 1 || i < 0) return { lead: formatValue(figure, locale), tail: "" };
+  return {
+    lead: `${isConverted(figure) ? "~" : ""}${formatAmount(figure.value[i], "value", locale)}`,
+    tail: formatAmounts(
+      figure.value.filter((_, j) => j !== i),
+      "value",
+      locale,
+    ),
+  };
+}
+
 /** The market-value line for tight chrome (the sidebar badge): the same "~"
  *  semantics as formatValue, the number in Intl's compact notation
- *  ("~334K EUR"). Empty when there is no value to show. */
-export function formatValueCompact(figure: ValuedFigure, locale?: string): string {
+ *  ("~334K EUR"). A figure that still holds several commodities shows one
+ *  leg plus the count of the elided rest ("~3K EUR +3") — the exact figure
+ *  lives on the page. The leading leg is the one matching `baseCommodity`;
+ *  hledger orders legs alphabetically, so the base leg is not
+ *  necessarily first. Empty when there is no value to show. */
+export function formatValueCompact(figure: ValuedFigure, locale?: string, baseCommodity?: string | null): string {
   if (figure.value.length === 0) return "";
   const compact = new Intl.NumberFormat(locale, { notation: "compact" });
-  const joined = figure.value
-    .map((a) => (a.commodity ? `${compact.format(a.quantity)} ${a.commodity}` : compact.format(a.quantity)))
-    .join(", ");
-  return `${isConverted(figure) ? "~" : ""}${joined}`;
+  const one = (a: LedgerAmount) =>
+    a.commodity ? `${compact.format(a.quantity)} ${a.commodity}` : compact.format(a.quantity);
+  const marker = isConverted(figure) ? "~" : "";
+  if (figure.value.length === 1) return `${marker}${one(figure.value[0])}`;
+  const lead = figure.value.find((a) => a.commodity === baseCommodity) ?? figure.value[0];
+  return `${marker}${one(lead)} +${figure.value.length - 1}`;
 }

--- a/packages/desktop/src/shared/types.ts
+++ b/packages/desktop/src/shared/types.ts
@@ -70,6 +70,11 @@ export interface NetWorthSection {
 export interface NetWorth {
   sections: NetWorthSection[];
   net: NetWorthTotal;
+  /** The valuation's base commodity: the `-X` target resolved from the
+   *  journal's declared or cost-inferred prices. Null when valuation fell
+   *  back to `-V`. Lets the renderer lead a multi-commodity figure with the
+   *  home-currency leg. */
+  baseCommodity: string | null;
 }
 
 // ---- App settings (app-owned config in ~/Accountant24/app-settings.json) ---


### PR DESCRIPTION
- Fall back to cost-inferred prices (`hledger prices --infer-market-prices`) for the report's base currency when the journal declares no `P` prices
- Return the resolved base currency in the `NetWorth` payload as `baseCommodity`
- Show the sidebar net worth as the home-currency figure plus a count of other currencies (`~3K EUR +2`) instead of a truncated list
- Lead the Assets and Net Worth bands with the home-currency figure and move the other currencies to a muted second line
- Add an info marker next to the second line with the same rate how-to as the Value column help
- Keep the page title and sidebar label on one line and stop the Columns button clipping in narrow windows