### PR TITLE
feat: clearer empty states on the Transactions and Net Worth pages

### DIFF
--- a/packages/desktop/e2e/net-worth.e2e.ts
+++ b/packages/desktop/e2e/net-worth.e2e.ts
@@ -33,7 +33,7 @@ test("opens the Net Worth view from the sidebar and returns to the chat", async 
 
   await window.getByRole("button", { name: "Net Worth" }).click();
   await expect(window.getByRole("heading", { name: "Net Worth" })).toBeVisible();
-  await expect(window.getByText("No accounts yet")).toBeVisible();
+  await expect(window.getByText("No transactions yet")).toBeVisible();
 
   // New Chat brings the composer back (sidebar entries select, not toggle —
   // a second click on the active entry is a no-op).

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-view.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-view.test.tsx
@@ -700,11 +700,15 @@ describe("<NetWorthView />", () => {
     });
   });
 
-  it("should show the empty state when the report has no accounts", async () => {
+  it("should show the empty state when the report has no balances", async () => {
     vi.mocked(ledgerApi.netWorth).mockResolvedValue(EMPTY);
     renderView();
-    expect(await screen.findByText("No accounts yet")).toBeInTheDocument();
-    expect(screen.getByText(/Ask the agent to record your first transaction/)).toBeInTheDocument();
+    // "No transactions yet", not "no accounts": the default workspace
+    // already declares accounts — transactions are what's missing.
+    expect(await screen.findByText("No transactions yet")).toBeInTheDocument();
+    expect(
+      screen.getByText("Ask the agent to record your first transactions and your net worth will show up here"),
+    ).toBeInTheDocument();
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
     // No rows — nothing to search either.
     expect(screen.queryByRole("searchbox")).not.toBeInTheDocument();
@@ -713,7 +717,7 @@ describe("<NetWorthView />", () => {
   it("should fall back to the empty state when the report query rejects", async () => {
     vi.mocked(ledgerApi.netWorth).mockRejectedValue(new Error("bridge down"));
     renderView();
-    expect(await screen.findByText("No accounts yet")).toBeInTheDocument();
+    expect(await screen.findByText("No transactions yet")).toBeInTheDocument();
   });
 
   it("should refetch the report when the agent goes from running to idle", async () => {

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth.integration.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth.integration.test.tsx
@@ -208,7 +208,7 @@ describe("Net Worth view flow", () => {
     expect(bridge.callsFor("ledger_net_worth")).toHaveLength(3);
   });
 
-  it("should show the empty state when the report has no accounts", async () => {
+  it("should show the empty state when the report has no balances", async () => {
     bridge.setHandler("ledger_net_worth", () => ({
       sections: [],
       net: { amounts: [], value: [] },
@@ -217,7 +217,7 @@ describe("Net Worth view flow", () => {
     render(<ChatLayout />);
     openSheet();
 
-    expect(await screen.findByText("No accounts yet")).toBeInTheDocument();
+    expect(await screen.findByText("No transactions yet")).toBeInTheDocument();
     expect(screen.queryByRole("table")).toBeNull();
   });
 });

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/page-empty.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/page-empty.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+
+// Spec for the shared full-page empty view: the icon, title, and
+// description all come straight from the props — the pages (Transactions,
+// Net Worth) differ only in what they pass.
+
+import { cleanup, render, screen } from "@testing-library/react";
+import type { FC } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { PageEmpty } from "../page-empty";
+
+afterEach(() => cleanup());
+
+const TestIcon: FC<{ className?: string }> = ({ className }) => (
+  <svg role="img" aria-label="Test icon" className={className} />
+);
+
+describe("<PageEmpty />", () => {
+  it("should render the given icon, title, and description", () => {
+    render(<PageEmpty icon={TestIcon} title="Nothing here yet" description="Ask the agent and it will show up" />);
+    expect(screen.getByRole("img", { name: "Test icon" })).toBeInTheDocument();
+    expect(screen.getByText("Nothing here yet")).toBeInTheDocument();
+    expect(screen.getByText("Ask the agent and it will show up")).toBeInTheDocument();
+  });
+});

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/transactions-view.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/transactions-view.test.tsx
@@ -792,21 +792,66 @@ describe("<TransactionsView />", () => {
     });
   });
 
-  it("should show the stock empty message when the journal has no transactions", async () => {
+  it("should show the dedicated empty view when the journal has no transactions", async () => {
     vi.mocked(ledgerApi.transactions).mockResolvedValue([]);
     renderView();
-    expect(await screen.findByText(/No transactions yet/)).toBeInTheDocument();
-    expect(screen.getByText(/Ask the agent to record your first transaction/)).toBeInTheDocument();
+    expect(await screen.findByText("No transactions yet")).toBeInTheDocument();
+    expect(
+      screen.getByText("Ask the agent to record your first transactions and they will show up here"),
+    ).toBeInTheDocument();
   });
 
-  it("should show the unreadable-journal message, not the empty state, when the register query rejects", async () => {
+  it("should hide the toolbar, the grid, and the count while the register is empty", async () => {
+    // Nothing to search, filter, sort, or count: the table chrome steps
+    // aside for the empty view, and the title carries no "0" (the empty
+    // view's title already says so).
+    vi.mocked(ledgerApi.transactions).mockResolvedValue([]);
+    renderView();
+    await screen.findByText("No transactions yet");
+    expect(screen.queryByRole("searchbox", { name: "Search transactions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Columns" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("combobox", { name: "Payee" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    expect(screen.queryByText("0")).not.toBeInTheDocument();
+  });
+
+  it("should replace the empty view with the register once a refetch returns rows", async () => {
+    // The first transaction usually lands mid-session (the agent records
+    // it): the running -> idle refetch must swap the empty view for the
+    // full page, chrome and all.
+    vi.mocked(ledgerApi.transactions).mockResolvedValueOnce([]).mockResolvedValueOnce(DATA);
+    const { rerender } = renderView(false);
+    await screen.findByText("No transactions yet");
+
+    rerender(
+      <Chrome isRunning={true}>
+        <TransactionsView now={NOW} />
+      </Chrome>,
+    );
+    await act(async () => {});
+    rerender(
+      <Chrome isRunning={false}>
+        <TransactionsView now={NOW} />
+      </Chrome>,
+    );
+
+    await screen.findByText("Bookshop");
+    expect(screen.queryByText("No transactions yet")).not.toBeInTheDocument();
+    expect(screen.getByRole("searchbox", { name: "Search transactions" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Columns" })).toBeInTheDocument();
+    expect(screen.getByText("6")).toBeInTheDocument();
+  });
+
+  it("should show the unreadable-journal view, not the empty state, when the register query rejects", async () => {
     // The main process rejects when the journal exists but hledger fails
     // (e.g. a syntax error, or output past the stdout cap): an unreadable
     // journal must never read as "no transactions yet".
     vi.mocked(ledgerApi.transactions).mockRejectedValue(new Error("register query failed"));
     renderView();
-    expect(await screen.findByText(/The journal could not be read/)).toBeInTheDocument();
+    expect(await screen.findByText("The journal could not be read")).toBeInTheDocument();
+    expect(screen.getByText("Ask the agent to check the journal")).toBeInTheDocument();
     expect(screen.queryByText(/No transactions yet/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
   });
 
   it("should refetch the register when the agent goes from running to idle", async () => {

--- a/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
@@ -15,12 +15,12 @@
 // here. Data refreshes when the agent finishes a turn.
 
 import { type Column, type ColumnDef, flexRender, type SortingState } from "@tanstack/react-table";
-import { ArrowDownIcon, ArrowUpIcon, ChevronsUpDownIcon, InfoIcon } from "lucide-react";
+import { ArrowDownIcon, ArrowUpIcon, ChevronsUpDownIcon, InfoIcon, WalletIcon } from "lucide-react";
 import { type FC, type ReactNode, useState } from "react";
+import { PageEmpty } from "@/components/accountant24/page-empty";
 import { useAppTable } from "@/components/accountant24/use-app-table";
 import type { DataGridFeatures } from "@/components/reui/data-grid/data-grid";
 import { Button } from "@/components/shadcn/button";
-import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@/components/shadcn/empty";
 import { Skeleton } from "@/components/shadcn/skeleton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/shadcn/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/tooltip";
@@ -445,15 +445,15 @@ const SheetSkeleton: FC<{ columnVisibility: ColumnVisibility }> = ({ columnVisib
   );
 };
 
+// "No transactions yet", not "no accounts": the default workspace already
+// declares accounts on first start — what an empty report is missing is
+// postings to give them balances.
 const SheetEmpty: FC = () => (
-  <Empty>
-    <EmptyHeader>
-      <EmptyTitle>No accounts yet</EmptyTitle>
-      <EmptyDescription>
-        Ask the agent to record your first transaction and your accounts will show up here
-      </EmptyDescription>
-    </EmptyHeader>
-  </Empty>
+  <PageEmpty
+    icon={WalletIcon}
+    title="No transactions yet"
+    description="Ask the agent to record your first transactions and your net worth will show up here"
+  />
 );
 
 /** The Net Worth page, shown in place of the chat thread. Laid out like
@@ -510,30 +510,34 @@ export const NetWorthView: FC = () => {
       {/* scroll-fade-t-6: content dissolves over 24px as it slides under the
           pinned search field, same as the chat viewport's top fade. */}
       <div className="scroll-fade-t scroll-fade-t-6 min-h-0 flex-1 overflow-y-auto">
-        <div className={`mx-auto w-full ${pageWidth} pb-12`}>
-          {sheet === null ? (
-            <SheetSkeleton columnVisibility={columnVisibility} />
-          ) : sections.length === 0 ? (
-            <SheetEmpty />
-          ) : (
-            <>
-              {sections.map((section) => (
-                <SheetSection
-                  key={section.name}
-                  section={section}
-                  baseCommodity={sheet.baseCommodity}
-                  search={search}
-                  columnVisibility={columnVisibility}
-                />
-              ))}
-              {/* The closing Net band, straight from hledger's own net. */}
-              <div className={`mt-8 ${BAND_CLASS}`}>
-                <div className="text-xl font-semibold">Net Worth</div>
-                <BandValue figure={sheet.net} baseCommodity={sheet.baseCommodity} />
-              </div>
-            </>
-          )}
-        </div>
+        {/* The empty view sits directly in the scroll container (not the
+            width column) so it can center itself in the body's height. */}
+        {sheet !== null && sections.length === 0 ? (
+          <SheetEmpty />
+        ) : (
+          <div className={`mx-auto w-full ${pageWidth} pb-12`}>
+            {sheet === null ? (
+              <SheetSkeleton columnVisibility={columnVisibility} />
+            ) : (
+              <>
+                {sections.map((section) => (
+                  <SheetSection
+                    key={section.name}
+                    section={section}
+                    baseCommodity={sheet.baseCommodity}
+                    search={search}
+                    columnVisibility={columnVisibility}
+                  />
+                ))}
+                {/* The closing Net band, straight from hledger's own net. */}
+                <div className={`mt-8 ${BAND_CLASS}`}>
+                  <div className="text-xl font-semibold">Net Worth</div>
+                  <BandValue figure={sheet.net} baseCommodity={sheet.baseCommodity} />
+                </div>
+              </>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/desktop/src/renderer/components/accountant24/page-empty.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/page-empty.tsx
@@ -1,0 +1,31 @@
+// The dedicated empty view shared by the full-page views (Transactions,
+// Net Worth): the stock shadcn Empty — icon, title, one-line description —
+// vertically centered in the page body. Rendered directly inside the page's
+// scroll container, in place of the content it stands in for.
+
+import type { FC } from "react";
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/shadcn/empty";
+
+export const PageEmpty: FC<{
+  icon: FC<{ className?: string }>;
+  title: string;
+  description: string;
+}> = ({ icon: Icon, title, description }) => (
+  // min-h-full (not h-full): Empty is flex-1, so the column centers it in
+  // the body's height; a window too short to fit it grows the column past
+  // 100% and scrolls instead of clipping the top. The pb-12 biases the
+  // block just above true center (optical center).
+  <div className="mx-auto flex min-h-full w-full max-w-4xl flex-col pb-12">
+    <Empty>
+      <EmptyHeader>
+        {/* rounded-full: the app's icon-medallion idiom is a circle on
+            bg-muted (see onboarding's OptionCard), not the stock rounded-xl. */}
+        <EmptyMedia variant="icon" className="rounded-full">
+          <Icon />
+        </EmptyMedia>
+        <EmptyTitle>{title}</EmptyTitle>
+        <EmptyDescription>{description}</EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  </div>
+);

--- a/packages/desktop/src/renderer/components/accountant24/transactions-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/transactions-view.tsx
@@ -4,17 +4,27 @@
 // data grid (TanStack v9), used stock. The grid owns the table mechanics:
 // the two-state sort headers, resizable columns (widths persisted with the
 // column visibility in localStorage), the virtualized row list, loading
-// skeletons, and empty states. The page owns the rest: the toolbar (title +
-// register count, search and the shared Columns menu, and the filter chips
-// — Date, Payee, Account, Amount, Commodity, Status, Tags, with Reset — on
-// their own row), the search haystack (every leg of every transaction), the
-// collapsed-row rule (lead with the legs money left from, the expander
-// unfolds the rest in place), and the chat's mention pills.
+// skeletons, and the filtered-out empty state. The page owns the rest: the
+// toolbar (title + register count, search and the shared Columns menu, and
+// the filter chips — Date, Payee, Account, Amount, Commodity, Status, Tags,
+// with Reset — on their own row), the search haystack (every leg of every
+// transaction), the collapsed-row rule (lead with the legs money left from,
+// the expander unfolds the rest in place), the chat's mention pills, and
+// the dedicated empty view that stands in for the toolbar and the grid
+// while the register has nothing to show.
 // Data refreshes when the agent finishes a turn while the page is visible.
 
 import type { Column, ColumnDef, ExpandedState, SortingState, Updater } from "@tanstack/react-table";
 import { functionalUpdate } from "@tanstack/react-table";
-import { CalendarIcon, CircleCheckIcon, CoinsIcon, DollarSignIcon, XIcon } from "lucide-react";
+import {
+  CalendarIcon,
+  CircleCheckIcon,
+  CoinsIcon,
+  DollarSignIcon,
+  FileWarningIcon,
+  ReceiptTextIcon,
+  XIcon,
+} from "lucide-react";
 import { type ComponentProps, type FC, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { ColumnsMenu } from "@/components/accountant24/columns-menu";
 import {
@@ -26,6 +36,7 @@ import {
   filterChipTriggerClass,
 } from "@/components/accountant24/filter-chip";
 import { MentionPill } from "@/components/accountant24/mentions";
+import { PageEmpty } from "@/components/accountant24/page-empty";
 import { useAppTable } from "@/components/accountant24/use-app-table";
 import { DataGrid, DataGridContainer, type DataGridFeatures } from "@/components/reui/data-grid/data-grid";
 import { DataGridColumnHeader } from "@/components/reui/data-grid/data-grid-column-header";
@@ -525,6 +536,26 @@ const DateFilterChip: FC<{
   );
 };
 
+/** The register's empty view, shown in place of the toolbar and the grid
+ *  while there is nothing to show: search, chips, and column headers say
+ *  nothing about an empty journal, so they step aside — the same treatment
+ *  as the Net Worth page. An unreadable journal reports an empty register
+ *  too, so it lands here with its own wording. */
+const RegisterEmpty: FC<{ failed: boolean }> = ({ failed }) =>
+  failed ? (
+    <PageEmpty
+      icon={FileWarningIcon}
+      title="The journal could not be read"
+      description="Ask the agent to check the journal"
+    />
+  ) : (
+    <PageEmpty
+      icon={ReceiptTextIcon}
+      title="No transactions yet"
+      description="Ask the agent to record your first transactions and they will show up here"
+    />
+  );
+
 /** The Transactions page, shown in place of the chat thread: pinned title
  *  over the data-table toolbar (search, filter chips, Reset, View) and the
  *  stock data grid. `now` anchors the Date chip's presets (injectable so
@@ -573,6 +604,10 @@ export const TransactionsView: FC<{ now?: Date; active?: boolean }> = ({ now, ac
   }, [config]);
 
   const rows = data ?? NO_ROWS;
+
+  // Loaded with nothing to show (an unreadable journal also reports an
+  // empty register): the toolbar and the grid step aside for RegisterEmpty.
+  const empty = data !== null && data.length === 0;
 
   // commodity is filter-only: never rendered, whatever storage says. Memoized
   // because the grid keys its own memos (header groups, visible cells, the
@@ -668,99 +703,110 @@ export const TransactionsView: FC<{ now?: Date; active?: boolean }> = ({ now, ac
             {data === null ? (
               <Skeleton className="h-5 w-10 rounded-3xl" />
             ) : (
-              <Badge variant="secondary" className="bg-muted px-1.5 font-normal text-muted-foreground tabular-nums">
-                {filtersActive
-                  ? `${recordCount.toLocaleString(navigator.language)} of ${totalCount.toLocaleString(navigator.language)}`
-                  : totalCount.toLocaleString(navigator.language)}
-              </Badge>
+              // No "0" alongside the empty view — its title already says so.
+              !empty && (
+                <Badge variant="secondary" className="bg-muted px-1.5 font-normal text-muted-foreground tabular-nums">
+                  {filtersActive
+                    ? `${recordCount.toLocaleString(navigator.language)} of ${totalCount.toLocaleString(navigator.language)}`
+                    : totalCount.toLocaleString(navigator.language)}
+                </Badge>
+              )
             )}
           </div>
           {/* min-w-0 (not shrink-0): when the window narrows, the search
               field gives way so the Columns button never clips. */}
-          <div className="flex min-w-0 items-center gap-2">
-            <SearchField subject="transactions" value={search} onValueChange={setSearch} className="w-64 min-w-0" />
-            <ColumnsMenu
-              columns={TOGGLEABLE_COLUMNS}
-              visibility={config.visibility}
-              onToggle={(id, shown) => {
-                table.getColumn(id)?.toggleVisibility(shown);
-                // A hidden column takes its filter chip with it; clearing
-                // the filter keeps rows from being filtered invisibly.
-                if (!shown) {
-                  table.getColumn(id)?.setFilterValue(undefined);
-                  // The Commodity chip rides with the Amount column.
-                  if (id === "amount") table.getColumn("commodity")?.setFilterValue(undefined);
-                }
-              }}
-            />
-          </div>
+          {!empty && (
+            <div className="flex min-w-0 items-center gap-2">
+              <SearchField subject="transactions" value={search} onValueChange={setSearch} className="w-64 min-w-0" />
+              <ColumnsMenu
+                columns={TOGGLEABLE_COLUMNS}
+                visibility={config.visibility}
+                onToggle={(id, shown) => {
+                  table.getColumn(id)?.toggleVisibility(shown);
+                  // A hidden column takes its filter chip with it; clearing
+                  // the filter keeps rows from being filtered invisibly.
+                  if (!shown) {
+                    table.getColumn(id)?.setFilterValue(undefined);
+                    // The Commodity chip rides with the Amount column.
+                    if (id === "amount") table.getColumn("commodity")?.setFilterValue(undefined);
+                  }
+                }}
+              />
+            </div>
+          )}
         </div>
         {/* The filter chips on their own row, following the column order:
             Date, Payee, Account, Amount, Commodity, Status, Tags. Each chip
             shows only while its column does. */}
-        <div className="flex flex-wrap items-center gap-2 pt-4">
-          {config.visibility.date && <DateFilterChip column={table.getColumn("date")} now={now ?? new Date()} />}
-          {config.visibility.payee && (
-            <ColumnChip
-              column={table.getColumn("payee")}
-              title="Payee"
-              subject="payees"
-              mentionType="payee"
-              options={payeeOptions}
-            />
-          )}
-          {config.visibility.account && (
-            <ColumnChip
-              column={table.getColumn("account")}
-              title="Account"
-              subject="accounts"
-              mentionType="account"
-              options={accountOptions}
-            />
-          )}
-          {config.visibility.amount && (
-            <>
-              <AmountFilterChip column={table.getColumn("amount")} />
+        {!empty && (
+          <div className="flex flex-wrap items-center gap-2 pt-4">
+            {config.visibility.date && <DateFilterChip column={table.getColumn("date")} now={now ?? new Date()} />}
+            {config.visibility.payee && (
               <ColumnChip
-                column={table.getColumn("commodity")}
-                title="Commodity"
-                subject="commodities"
-                icon={DollarSignIcon}
-                options={commodityOptions}
+                column={table.getColumn("payee")}
+                title="Payee"
+                subject="payees"
+                mentionType="payee"
+                options={payeeOptions}
               />
-            </>
-          )}
-          {config.visibility.status && (
-            <ColumnChip
-              column={table.getColumn("status")}
-              title="Status"
-              subject="statuses"
-              icon={CircleCheckIcon}
-              options={statusOptions}
-            />
-          )}
-          {config.visibility.tags && (
-            <ColumnChip
-              column={table.getColumn("tags")}
-              title="Tags"
-              subject="tags"
-              mentionType="tag"
-              options={tagOptions}
-            />
-          )}
-          {filtersActive && (
-            <Button variant="outline" size="sm" className="border-dashed" onClick={resetFilters}>
-              <XIcon />
-              Reset
-            </Button>
-          )}
-        </div>
+            )}
+            {config.visibility.account && (
+              <ColumnChip
+                column={table.getColumn("account")}
+                title="Account"
+                subject="accounts"
+                mentionType="account"
+                options={accountOptions}
+              />
+            )}
+            {config.visibility.amount && (
+              <>
+                <AmountFilterChip column={table.getColumn("amount")} />
+                <ColumnChip
+                  column={table.getColumn("commodity")}
+                  title="Commodity"
+                  subject="commodities"
+                  icon={DollarSignIcon}
+                  options={commodityOptions}
+                />
+              </>
+            )}
+            {config.visibility.status && (
+              <ColumnChip
+                column={table.getColumn("status")}
+                title="Status"
+                subject="statuses"
+                icon={CircleCheckIcon}
+                options={statusOptions}
+              />
+            )}
+            {config.visibility.tags && (
+              <ColumnChip
+                column={table.getColumn("tags")}
+                title="Tags"
+                subject="tags"
+                mentionType="tag"
+                options={tagOptions}
+              />
+            )}
+            {filtersActive && (
+              <Button variant="outline" size="sm" className="border-dashed" onClick={resetFilters}>
+                <XIcon />
+                Reset
+              </Button>
+            )}
+          </div>
+        )}
       </div>
       {/* No top scroll-fade here: the sticky column header sits at the very
           top of the scroller and would be eaten by the mask; its own
           backdrop covers the rows sliding beneath instead. */}
       <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
-        {/* The table area is exactly as wide as its columns (never below
+        {empty ? (
+          <RegisterEmpty failed={failed} />
+        ) : (
+          <>
+            {/* The table area is exactly as wide as its columns (never below
             the header's content width, so the default view stays aligned);
             past the window width the PAGE scrolls horizontally (both
             scrollbars live at the window edge), so a scrollbar appears only
@@ -768,54 +814,53 @@ export const TransactionsView: FC<{ now?: Date; active?: boolean }> = ({ now, ac
             scrolling, gutters would read as torn white bands at the ends.
             Width comes from the column sizes, not the DOM, so the grid's
             fill machinery cannot feed back into it. */}
-        <div className="mx-auto" style={{ width: `max(52rem, ${table.getTotalSize()}px)` }}>
-          <DataGrid
-            table={table}
-            recordCount={recordCount}
-            isLoading={data === null}
-            emptyMessage={
-              failed
-                ? "The journal could not be read. Ask the agent to check it."
-                : data !== null && data.length === 0
-                  ? "No transactions yet. Ask the agent to record your first transaction and it will show up here."
-                  : "No matching transactions"
-            }
-            // No columnsVisibility flag: it would only arm the header
-            // dropdown's own hide submenu (and even then each header must
-            // opt in), which toggles columns behind ColumnsMenu's back —
-            // bypassing its filter-clearing, so a hidden column could keep
-            // filtering invisibly. The toolbar's Columns menu is the one
-            // visibility control.
-            tableLayout={{
-              dense: true,
-              columnsResizable: true,
-              columnsResizeMode: "onChange",
-              headerSticky: true,
-              width: "fixed",
-            }}
-          >
-            {/* One virtualized list for the whole register — no pagination.
+            <div className="mx-auto" style={{ width: `max(52rem, ${table.getTotalSize()}px)` }}>
+              <DataGrid
+                table={table}
+                recordCount={recordCount}
+                isLoading={data === null}
+                // The loaded-and-empty cases never reach the grid (RegisterEmpty
+                // replaces it), so the only empty state left is a filtered-out
+                // register.
+                emptyMessage="No matching transactions"
+                // No columnsVisibility flag: it would only arm the header
+                // dropdown's own hide submenu (and even then each header must
+                // opt in), which toggles columns behind ColumnsMenu's back —
+                // bypassing its filter-clearing, so a hidden column could keep
+                // filtering invisibly. The toolbar's Columns menu is the one
+                // visibility control.
+                tableLayout={{
+                  dense: true,
+                  columnsResizable: true,
+                  columnsResizeMode: "onChange",
+                  headerSticky: true,
+                  width: "fixed",
+                }}
+              >
+                {/* One virtualized list for the whole register — no pagination.
                 The page body scrolls it; rows are measured, so multi-leg
                 and expanded rows keep exact offsets. A table wider than the
                 page still scrolls horizontally inside the grid. */}
-            {/* overflow-visible + the scroll-area-viewport marker present
+                {/* overflow-visible + the scroll-area-viewport marker present
                 the page body as this grid's external scroll area: the table
                 viewport then adds no overflow of its own, so the sticky
                 column header sticks against the page scroll. */}
-            <DataGridContainer className="overflow-visible">
-              <div data-slot="scroll-area-viewport">
-                {data === null ? (
-                  // The virtual list has no skeleton mode; the plain renderer
-                  // shows the shaped per-column skeletons and swaps out with
-                  // the first real rows.
-                  <DataGridTable />
-                ) : (
-                  <DataGridTableVirtual estimateSize={37} virtualizerOptions={virtualizerOptions} />
-                )}
-              </div>
-            </DataGridContainer>
-          </DataGrid>
-        </div>
+                <DataGridContainer className="overflow-visible">
+                  <div data-slot="scroll-area-viewport">
+                    {data === null ? (
+                      // The virtual list has no skeleton mode; the plain renderer
+                      // shows the shaped per-column skeletons and swaps out with
+                      // the first real rows.
+                      <DataGridTable />
+                    ) : (
+                      <DataGridTableVirtual estimateSize={37} virtualizerOptions={virtualizerOptions} />
+                    )}
+                  </div>
+                </DataGridContainer>
+              </DataGrid>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
- Replace the empty Transactions table with a dedicated empty view: icon, title, and hint, vertically centered on the page
- Hide the search field, `Columns` menu, filter chips, and count badge while the register is empty
- Show the unreadable-journal case as the same view with its own icon and wording
- Center the Net Worth empty state the same way and retitle it to "No transactions yet"
- Add a shared `PageEmpty` component used by both pages
- Cover the empty views with component, integration, and e2e tests