### PR TITLE
feat: consistent data tables on the Net Worth and Transactions pages

### DIFF
--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -4,10 +4,19 @@
 
 import { ChatLayout } from "./components/accountant24/chat-layout";
 import { Onboarding } from "./components/accountant24/onboarding";
+import { TooltipProvider } from "./components/shadcn/tooltip";
 import { useHasModels } from "./hooks/use-provider-status";
 
 export default function App() {
   const hasModels = useHasModels();
   if (hasModels === null) return null;
-  return hasModels ? <ChatLayout /> : <Onboarding />;
+  return (
+    // The app's one tooltip provider: every tooltip opens on dwell (400ms —
+    // enough to filter cursor transit, snappier than the 600-700ms library
+    // defaults), and once one is open, moving to a neighboring trigger opens
+    // instantly (the provider shares the warm-up timer) — so scanning a row
+    // of markers or pills never waits per item. Individual tooltips must NOT
+    // wrap their own provider, or they leave the shared warm-up group.
+    <TooltipProvider delay={400}>{hasModels ? <ChatLayout /> : <Onboarding />}</TooltipProvider>
+  );
 }

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/chat-layout.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/chat-layout.test.tsx
@@ -334,7 +334,8 @@ describe("ChatLayout Net Worth view", () => {
     fireEvent.click(sheetButton());
     fireEvent.click(screen.getByRole("button", { name: "Select thread stub" }));
 
-    expect(screen.queryByTestId("net-worth-view")).toBeNull();
+    // Hidden, not unmounted — the page's state survives the round trip.
+    expect((screen.getByTestId("net-worth-view").parentElement as HTMLElement).className).toContain("invisible");
     expect(threadWrapper().className).not.toContain("hidden");
   });
 
@@ -343,7 +344,7 @@ describe("ChatLayout Net Worth view", () => {
     fireEvent.click(sheetButton());
     fireEvent.click(screen.getByRole("button", { name: "New chat stub" }));
 
-    expect(screen.queryByTestId("net-worth-view")).toBeNull();
+    expect((screen.getByTestId("net-worth-view").parentElement as HTMLElement).className).toContain("invisible");
     expect(threadWrapper().className).not.toContain("hidden");
   });
 
@@ -352,7 +353,7 @@ describe("ChatLayout Net Worth view", () => {
     fireEvent.click(sheetButton());
     fireEvent.keyDown(document.body, { key: "n", metaKey: true });
 
-    expect(screen.queryByTestId("net-worth-view")).toBeNull();
+    expect((screen.getByTestId("net-worth-view").parentElement as HTMLElement).className).toContain("invisible");
     expect(threadWrapper().className).not.toContain("hidden");
     expect(h.switchToNewThread).toHaveBeenCalledTimes(1);
   });

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-columns.test.ts
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-columns.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+// Spec for the Net Worth table config: its storage key and defaults over
+// the shared core, and the page-width math the view sizes its body with
+// (the visible columns' widths summed, resizes and hidden columns
+// respected — mirroring TanStack's getTotalSize()).
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { installJsdomPolyfills } from "@/test/jsdomPolyfills";
+import { loadTableConfig, NET_WORTH_TABLE_KEY, saveTableConfig, tableWidth } from "../net-worth-columns";
+
+beforeAll(() => installJsdomPolyfills());
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("loadTableConfig()", () => {
+  it("should hide both assertion columns by default with no custom widths", () => {
+    expect(loadTableConfig()).toEqual({ visibility: { asserted: false, assertedAmount: false }, sizing: {} });
+  });
+
+  it("should round-trip the config under the net-worth key", () => {
+    const config = { visibility: { asserted: true, assertedAmount: false }, sizing: { account: 320 } };
+    saveTableConfig(config);
+    expect(JSON.parse(window.localStorage.getItem(NET_WORTH_TABLE_KEY) ?? "")).toEqual(config);
+    expect(loadTableConfig()).toEqual(config);
+  });
+});
+
+describe("tableWidth()", () => {
+  it("should sum only the spine columns while the assertion pair is hidden", () => {
+    // account 400 + holding 180 + value 160.
+    expect(tableWidth(loadTableConfig())).toBe(740);
+  });
+
+  it("should include the assertion pair when visible", () => {
+    // 740 + asserted 130 + assertedAmount 170.
+    expect(tableWidth({ visibility: { asserted: true, assertedAmount: true }, sizing: {} })).toBe(1040);
+  });
+
+  it("should prefer a resized width over the default", () => {
+    expect(tableWidth({ visibility: { asserted: false, assertedAmount: false }, sizing: { account: 500 } })).toBe(840);
+  });
+});

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-columns.test.ts
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-columns.test.ts
@@ -34,6 +34,16 @@ describe("loadTableConfig()", () => {
     expect(JSON.parse(window.localStorage.getItem(NET_WORTH_TABLE_KEY) ?? "")).toEqual(config);
     expect(loadTableConfig()).toEqual(config);
   });
+
+  it("should clamp stored sub-minimum widths up to each column's minimum", () => {
+    // Raw drag values below the minimums (the grid clamps only at render)
+    // must not survive a reload into the width model.
+    saveTableConfig({ visibility: { asserted: false, assertedAmount: false }, sizing: { account: 90, value: 30 } });
+    expect(loadTableConfig().sizing).toEqual({
+      account: COLUMN_MIN_SIZES.account,
+      value: COLUMN_MIN_SIZES.value,
+    });
+  });
 });
 
 describe("column sizes", () => {
@@ -58,5 +68,14 @@ describe("tableWidth()", () => {
 
   it("should prefer a resized width over the default", () => {
     expect(tableWidth({ visibility: { asserted: false, assertedAmount: false }, sizing: { account: 300 } })).toBe(640);
+  });
+
+  it("should clamp live sub-minimum drag values like the grid does", () => {
+    // A drag past the minimum stores the raw value (45) while the grid
+    // renders the clamp (140); the wrapper must match the grid, or it ends
+    // up narrower than the table and the container clips the last column.
+    expect(tableWidth({ visibility: { asserted: false, assertedAmount: false }, sizing: { value: 45 } })).toBe(
+      492 + 170 + COLUMN_MIN_SIZES.value,
+    );
   });
 });

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-columns.test.ts
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-columns.test.ts
@@ -1,13 +1,22 @@
 // @vitest-environment jsdom
 
 // Spec for the Net Worth table config: its storage key and defaults over
-// the shared core, and the page-width math the view sizes its body with
-// (the visible columns' widths summed, resizes and hidden columns
-// respected — mirroring TanStack's getTotalSize()).
+// the shared core, and the static width model — the same as the
+// Transactions register: fixed defaults whose default-visible set fills
+// the 52rem page floor exactly, optional columns growing the table past
+// the floor, and minimums that keep every header pill sitting with equal
+// breathing room to both column separators.
 
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { installJsdomPolyfills } from "@/test/jsdomPolyfills";
-import { loadTableConfig, NET_WORTH_TABLE_KEY, saveTableConfig, tableWidth } from "../net-worth-columns";
+import {
+  COLUMN_MIN_SIZES,
+  COLUMN_SIZES,
+  loadTableConfig,
+  NET_WORTH_TABLE_KEY,
+  saveTableConfig,
+  tableWidth,
+} from "../net-worth-columns";
 
 beforeAll(() => installJsdomPolyfills());
 beforeEach(() => {
@@ -27,18 +36,27 @@ describe("loadTableConfig()", () => {
   });
 });
 
+describe("column sizes", () => {
+  it("should keep every default at or above its column's minimum", () => {
+    for (const [id, min] of Object.entries(COLUMN_MIN_SIZES)) {
+      expect(COLUMN_SIZES[id]).toBeGreaterThanOrEqual(min);
+    }
+  });
+});
+
 describe("tableWidth()", () => {
-  it("should sum only the spine columns while the assertion pair is hidden", () => {
-    // account 400 + holding 180 + value 160.
-    expect(tableWidth(loadTableConfig())).toBe(740);
+  it("should fill exactly the 52rem page floor while the assertion pair is hidden", () => {
+    // account 492 + holding 170 + value 170.
+    expect(tableWidth(loadTableConfig())).toBe(832);
   });
 
-  it("should include the assertion pair when visible", () => {
-    // 740 + asserted 130 + assertedAmount 170.
-    expect(tableWidth({ visibility: { asserted: true, assertedAmount: true }, sizing: {} })).toBe(1040);
+  it("should grow past the floor when the assertion pair is on", () => {
+    // 832 + asserted 170 + assertedAmount 200 — the page scrolls, like the
+    // Transactions register with its optional columns on.
+    expect(tableWidth({ visibility: { asserted: true, assertedAmount: true }, sizing: {} })).toBe(1202);
   });
 
   it("should prefer a resized width over the default", () => {
-    expect(tableWidth({ visibility: { asserted: false, assertedAmount: false }, sizing: { account: 500 } })).toBe(840);
+    expect(tableWidth({ visibility: { asserted: false, assertedAmount: false }, sizing: { account: 300 } })).toBe(640);
   });
 });

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-view.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-view.test.tsx
@@ -1,16 +1,17 @@
 // @vitest-environment jsdom
 
 // Spec for the Net Worth view: skeleton while the first load is in
-// flight, a pinned title and search box, one data table per `hledger bs`
-// section (Assets, Liabilities — the latter already sign-flipped positive by
-// hledger) with the section's own total, the hledger-computed Net as the
-// closing line, sorting on every column (A-Z on the account path by default,
-// independent per section), search filtering every section by path, the
-// two assertion columns hidden by default behind the header's Columns menu
-// (the choice persisted in localStorage), the empty state (no journal yet
-// or hledger failed), and the refetch on the agent's running → idle edge.
-// jsdom pins navigator.language to en-US, so formatted expectations are
-// deterministic.
+// flight, a pinned title and search box, one stock data grid per `hledger
+// bs` section (Assets, Liabilities — the latter already sign-flipped
+// positive by hledger, each a labeled region) with the section's own
+// total, the hledger-computed Net as the closing line, sorting on every
+// column (A-Z on the account path by default, independent per section),
+// search filtering every section by path, the two assertion columns hidden
+// by default behind the header's Columns menu (the choice persisted in
+// localStorage with the shared table-config shape), the empty state (no
+// journal yet or hledger failed), and the refetch on the agent's running →
+// idle edge. jsdom pins navigator.language to en-US, so formatted
+// expectations are deterministic.
 
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -100,13 +101,17 @@ const renderView = (isRunning = false) =>
     </Chrome>,
   );
 
-/** The rendered account order of one section's table: each body row's
- *  account-cell title. */
-const accountOrder = (tableName: string) =>
-  within(screen.getByRole("table", { name: tableName }))
+/** One section's rendered scope: the labeled region around its band and
+ *  grid (the vendored grid's own <table> carries no accessible name). */
+const section = (name: string) => within(screen.getByRole("region", { name }));
+
+/** The rendered account order of one section's grid: each body row's
+ *  account-cell title (the full path, also the truncation tooltip). */
+const accountOrder = (sectionName: string) =>
+  section(sectionName)
     .getAllByRole("row")
     .slice(1) // the column-header row
-    .map((row) => row.querySelector("td")?.getAttribute("title"));
+    .map((row) => row.querySelector("[title]")?.getAttribute("title"));
 
 /** Turn both assertion columns on through the header's Columns menu, then
  *  close it so the tables are clickable again. */
@@ -151,8 +156,8 @@ describe("<NetWorthView />", () => {
     expect(screen.getByText("~2,085.72 EUR")).toBeInTheDocument();
     // The liabilities total is exact EUR: no marker.
     expect(screen.getByText("346.75 EUR", { selector: "div" })).toBeInTheDocument();
-    expect(screen.getByRole("table", { name: "Assets" })).toBeInTheDocument();
-    expect(screen.getByRole("table", { name: "Liabilities" })).toBeInTheDocument();
+    expect(section("Assets").getByRole("table")).toBeInTheDocument();
+    expect(section("Liabilities").getByRole("table")).toBeInTheDocument();
   });
 
   it("should show liabilities with hledger's positive sign", async () => {
@@ -376,8 +381,7 @@ describe("<NetWorthView />", () => {
   });
 
   describe("sorting", () => {
-    const assetsButton = (name: string) =>
-      within(screen.getByRole("table", { name: "Assets" })).getByRole("button", { name });
+    const assetsButton = (name: string) => section("Assets").getByRole("button", { name });
 
     it("should sort Z-A when the Account header is clicked", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
@@ -456,9 +460,7 @@ describe("<NetWorthView />", () => {
       });
       renderView();
       await screen.findByTitle("assets:cash");
-      const liabilitiesValue = within(screen.getByRole("table", { name: "Liabilities" })).getByRole("button", {
-        name: "Value",
-      });
+      const liabilitiesValue = section("Liabilities").getByRole("button", { name: "Value" });
       await userEvent.click(liabilitiesValue);
       // Liabilities re-sorted by value, biggest first...
       expect(accountOrder("Liabilities")).toEqual(["liabilities:loan", "liabilities:card"]);
@@ -497,10 +499,7 @@ describe("<NetWorthView />", () => {
 
   describe("column explanations", () => {
     const hoverInfo = async (label: string) => {
-      const marker = within(screen.getByRole("table", { name: "Assets" })).getByRole("button", {
-        name: `About ${label}`,
-      });
-      await userEvent.hover(marker);
+      await userEvent.hover(section("Assets").getByRole("button", { name: `About ${label}` }));
     };
 
     it("should explain the Holding column behind its info marker", async () => {
@@ -572,9 +571,7 @@ describe("<NetWorthView />", () => {
       await userEvent.type(screen.getByRole("searchbox", { name: "Search accounts" }), "CASH");
       expect(accountOrder("Assets")).toEqual(["assets:cash"]);
       // The liabilities table has no matching account.
-      expect(
-        within(screen.getByRole("table", { name: "Liabilities" })).getByText("No matching accounts"),
-      ).toBeInTheDocument();
+      expect(section("Liabilities").getByText("No matching accounts")).toBeInTheDocument();
     });
 
     it("should show empty messages when nothing matches, and restore rows when cleared", async () => {
@@ -618,10 +615,9 @@ describe("<NetWorthView />", () => {
       renderView();
       await screen.findByTitle("assets:cash");
       await showAssertionColumns();
-      for (const table of ["Assets", "Liabilities"]) {
-        const scope = within(screen.getByRole("table", { name: table }));
-        expect(scope.getByRole("button", { name: "Asserted On" })).toBeInTheDocument();
-        expect(scope.getByRole("button", { name: "Asserted Amount" })).toBeInTheDocument();
+      for (const name of ["Assets", "Liabilities"]) {
+        expect(section(name).getByRole("button", { name: "Asserted On" })).toBeInTheDocument();
+        expect(section(name).getByRole("button", { name: "Asserted Amount" })).toBeInTheDocument();
       }
     });
 
@@ -630,8 +626,12 @@ describe("<NetWorthView />", () => {
       const { unmount } = renderView();
       await screen.findByTitle("assets:cash");
       await showAssertionColumns();
-      expect(window.localStorage.getItem("accountant24.net-worth.columns")).toBe(
-        JSON.stringify({ asserted: true, assertedAmount: true }),
+      // The write is debounced (a resize drag never writes per pointer move).
+      await waitFor(() =>
+        expect(JSON.parse(window.localStorage.getItem("accountant24.net-worth-table") ?? "{}").visibility).toEqual({
+          asserted: true,
+          assertedAmount: true,
+        }),
       );
       unmount();
 
@@ -644,8 +644,8 @@ describe("<NetWorthView />", () => {
 
     it("should reflect the persisted columns in the loading skeleton, hidden by default", async () => {
       window.localStorage.setItem(
-        "accountant24.net-worth.columns",
-        JSON.stringify({ asserted: true, assertedAmount: true }),
+        "accountant24.net-worth-table",
+        JSON.stringify({ visibility: { asserted: true, assertedAmount: true } }),
       );
       vi.mocked(ledgerApi.netWorth).mockReturnValue(new Promise(() => {}));
       const { unmount } = renderView();
@@ -663,8 +663,8 @@ describe("<NetWorthView />", () => {
 
     it("should show only the toggled column when just one is enabled", async () => {
       window.localStorage.setItem(
-        "accountant24.net-worth.columns",
-        JSON.stringify({ asserted: true, assertedAmount: false }),
+        "accountant24.net-worth-table",
+        JSON.stringify({ visibility: { asserted: true, assertedAmount: false } }),
       );
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
@@ -677,8 +677,8 @@ describe("<NetWorthView />", () => {
 
     it("should fall back to hidden columns when the stored value is garbage", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
-      for (const stored of ["not json", JSON.stringify({ asserted: "yes" }), JSON.stringify(null)]) {
-        window.localStorage.setItem("accountant24.net-worth.columns", stored);
+      for (const stored of ["not json", JSON.stringify({ visibility: { asserted: "yes" } }), JSON.stringify(null)]) {
+        window.localStorage.setItem("accountant24.net-worth-table", stored);
         const { unmount } = renderView();
         await screen.findByTitle("assets:cash");
         expect(screen.queryByRole("button", { name: "Asserted On" })).not.toBeInTheDocument();
@@ -692,11 +692,12 @@ describe("<NetWorthView />", () => {
       renderView();
       await screen.findByTitle("assets:cash");
       await userEvent.type(screen.getByRole("searchbox", { name: "Search accounts" }), "zzz");
+      // The three spine columns plus the grid's trailing resize-fill column.
       const emptyCell = () => screen.getAllByText("No matching accounts")[0]?.closest("td");
-      expect(emptyCell()?.colSpan).toBe(3);
+      expect(emptyCell()?.colSpan).toBe(4);
       // With the assertion pair on, the row widens to match.
       await showAssertionColumns();
-      expect(emptyCell()?.colSpan).toBe(5);
+      expect(emptyCell()?.colSpan).toBe(6);
     });
   });
 

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-view.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-view.test.tsx
@@ -106,12 +106,12 @@ const renderView = (isRunning = false) =>
 const section = (name: string) => within(screen.getByRole("region", { name }));
 
 /** The rendered account order of one section's grid: each body row's
- *  account-cell title (the full path, also the truncation tooltip). */
+ *  account pill text (the full path). */
 const accountOrder = (sectionName: string) =>
   section(sectionName)
     .getAllByRole("row")
     .slice(1) // the column-header row
-    .map((row) => row.querySelector("[title]")?.getAttribute("title"));
+    .map((row) => row.querySelector("[data-directive-type=account]")?.textContent);
 
 /** Turn both assertion columns on through the header's Columns menu, then
  *  close it so the tables are clickable again. */
@@ -149,7 +149,7 @@ describe("<NetWorthView />", () => {
     vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
     renderView();
     // Settle on loaded data first — the skeleton also carries an Assets band.
-    await screen.findByTitle("assets:cash");
+    await screen.findByText("assets:cash");
     expect(screen.getByRole("heading", { level: 2, name: "Assets" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 2, name: "Liabilities" })).toBeInTheDocument();
     // The assets total includes converted holdings: an estimate, so ~.
@@ -163,7 +163,7 @@ describe("<NetWorthView />", () => {
   it("should show liabilities with hledger's positive sign", async () => {
     vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
     renderView();
-    expect(await screen.findByTitle("liabilities:creditcard")).toBeInTheDocument();
+    expect(await screen.findByText("liabilities:creditcard")).toBeInTheDocument();
     // The account row (holding + value) and the section total all read
     // €346.75 — never a minus.
     expect(screen.getAllByText("346.75 EUR")).toHaveLength(3);
@@ -194,10 +194,11 @@ describe("<NetWorthView />", () => {
     expect(screen.queryByRole("heading", { level: 2, name: "Liabilities" })).not.toBeInTheDocument();
   });
 
-  it("should list complete account paths sorted A-Z by default", async () => {
+  it("should list complete account paths as account pills, sorted A-Z by default", async () => {
     vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
     renderView();
-    expect(await screen.findByTitle("assets:cash")).toHaveTextContent("assets:cash");
+    // The chat's account pill, same as the register.
+    expect((await screen.findByText("assets:cash")).closest("[data-directive-type=account]")).toBeInTheDocument();
     // The fixture arrives in hledger's order (cash, darka, bank); the table
     // re-sorts it alphabetically.
     expect(accountOrder("Assets")).toEqual(["assets:bank", "assets:cash", "assets:darka:etf:sxr8"]);
@@ -217,7 +218,7 @@ describe("<NetWorthView />", () => {
   it("should show each account's last asserted date, and an em dash when it was never asserted, when toggled on", async () => {
     vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
     renderView();
-    await screen.findByTitle("assets:cash");
+    await screen.findByText("assets:cash");
     await showAssertionColumns();
     // One sortable header per section table.
     expect(screen.getAllByRole("button", { name: "Asserted On" })).toHaveLength(2);
@@ -232,7 +233,7 @@ describe("<NetWorthView />", () => {
   it("should show the last asserted amount in the account's own commodity when toggled on", async () => {
     vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
     renderView();
-    await screen.findByTitle("assets:cash");
+    await screen.findByText("assets:cash");
     await showAssertionColumns();
     expect(screen.getAllByRole("button", { name: "Asserted Amount" })).toHaveLength(2);
     // Formatted like Holding: locale digits, commodity suffix, the amount's
@@ -255,7 +256,7 @@ describe("<NetWorthView />", () => {
       baseCommodity: null,
     });
     renderView();
-    await screen.findByTitle("assets:legacy");
+    await screen.findByText("assets:legacy");
     await showAssertionColumns();
     expect(screen.getByText("2026-05-01")).toBeInTheDocument();
     // Only the amount cell falls back to the dash.
@@ -352,7 +353,7 @@ describe("<NetWorthView />", () => {
       baseCommodity: null,
     });
     renderView();
-    await screen.findByTitle("assets:bank:mono");
+    await screen.findByText("assets:bank:mono");
     expect(screen.queryByText(/~/)).not.toBeInTheDocument();
   });
 
@@ -386,7 +387,7 @@ describe("<NetWorthView />", () => {
     it("should sort Z-A when the Account header is clicked", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       await userEvent.click(assetsButton("Account"));
       expect(accountOrder("Assets")).toEqual(["assets:darka:etf:sxr8", "assets:cash", "assets:bank"]);
     });
@@ -394,7 +395,7 @@ describe("<NetWorthView />", () => {
     it("should sort by market value, biggest first, when the Value header is clicked", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       // €1,920.15 (darka) > €115.57 (cash) > €50.00 (bank).
       await userEvent.click(assetsButton("Value"));
       expect(accountOrder("Assets")).toEqual(["assets:darka:etf:sxr8", "assets:cash", "assets:bank"]);
@@ -406,7 +407,7 @@ describe("<NetWorthView />", () => {
     it("should sort by the native quantity, biggest first, when the Holding header is clicked", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       // Primary native quantities: cash=1,408.26, bank=50, darka=22.45 — a
       // plain number sort so the column reads monotonic.
       await userEvent.click(assetsButton("Holding"));
@@ -419,7 +420,7 @@ describe("<NetWorthView />", () => {
     it("should sort by asserted date, most recent first, with never-asserted rows last", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       await showAssertionColumns();
       await userEvent.click(assetsButton("Asserted On"));
       // bank (07-12) > cash (06-15) > darka (never asserted).
@@ -432,7 +433,7 @@ describe("<NetWorthView />", () => {
     it("should sort by the asserted amount, biggest first, with never-asserted rows counting as zero", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       await showAssertionColumns();
       // Asserted quantities: cash=1,400, bank=45, darka=0 (never asserted) —
       // a plain number sort, like Holding.
@@ -459,7 +460,7 @@ describe("<NetWorthView />", () => {
         ],
       });
       renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       const liabilitiesValue = section("Liabilities").getByRole("button", { name: "Value" });
       await userEvent.click(liabilitiesValue);
       // Liabilities re-sorted by value, biggest first...
@@ -487,7 +488,7 @@ describe("<NetWorthView />", () => {
         baseCommodity: null,
       });
       renderView();
-      await screen.findByTitle("assets:closed");
+      await screen.findByText("assets:closed");
       // The amount-less row counts as zero and sinks below real holdings.
       await userEvent.click(assetsButton("Holding"));
       expect(accountOrder("Assets")).toEqual(["assets:wallet:big", "assets:wallet:small", "assets:closed"]);
@@ -498,14 +499,18 @@ describe("<NetWorthView />", () => {
   });
 
   describe("column explanations", () => {
+    /** The inline marker inside a sort pill is a decorative hover-only span
+     *  (a nested labeled widget would pollute the pill's accessible name),
+     *  so it is addressed by its slot, scoped to its header pill. */
     const hoverInfo = async (label: string) => {
-      await userEvent.hover(section("Assets").getByRole("button", { name: `About ${label}` }));
+      const pill = section("Assets").getByRole("button", { name: label });
+      await userEvent.hover(pill.querySelector("[data-slot=column-help]") as Element);
     };
 
     it("should explain the Holding column behind its info marker", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       await hoverInfo("Holding");
       expect(
         await screen.findByText(/What the account actually holds: cash in its own currency, shares, or crypto/),
@@ -515,7 +520,7 @@ describe("<NetWorthView />", () => {
     it("should explain the Asserted On column, including the dash", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       await showAssertionColumns();
       await hoverInfo("Asserted On");
       expect(
@@ -529,7 +534,7 @@ describe("<NetWorthView />", () => {
     it("should explain the Asserted Amount column, including the dash", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       await showAssertionColumns();
       await hoverInfo("Asserted Amount");
       expect(
@@ -543,7 +548,7 @@ describe("<NetWorthView />", () => {
     it("should explain the Value column, including the ~ marker", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       await hoverInfo("Value");
       expect(
         await screen.findByText(
@@ -558,8 +563,9 @@ describe("<NetWorthView />", () => {
     it("should give the Account column no info marker", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
-      await screen.findByTitle("assets:cash");
-      expect(screen.queryByRole("button", { name: "About Account" })).not.toBeInTheDocument();
+      await screen.findByText("assets:cash");
+      const accountPill = section("Assets").getByRole("button", { name: "Account" });
+      expect(accountPill.querySelector("[data-slot=column-help]")).toBeNull();
     });
   });
 
@@ -567,7 +573,7 @@ describe("<NetWorthView />", () => {
     it("should filter every section by account path, case-insensitively", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       await userEvent.type(screen.getByRole("searchbox", { name: "Search accounts" }), "CASH");
       expect(accountOrder("Assets")).toEqual(["assets:cash"]);
       // The liabilities table has no matching account.
@@ -577,7 +583,7 @@ describe("<NetWorthView />", () => {
     it("should show empty messages when nothing matches, and restore rows when cleared", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       const box = screen.getByRole("searchbox", { name: "Search accounts" });
       await userEvent.type(box, "zzz");
       expect(screen.getAllByText("No matching accounts")).toHaveLength(2);
@@ -590,7 +596,7 @@ describe("<NetWorthView />", () => {
     it("should hide both assertion columns by default", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       expect(screen.queryByRole("button", { name: "Asserted On" })).not.toBeInTheDocument();
       expect(screen.queryByRole("button", { name: "Asserted Amount" })).not.toBeInTheDocument();
       expect(screen.queryByText("2026-07-12")).not.toBeInTheDocument();
@@ -600,7 +606,7 @@ describe("<NetWorthView />", () => {
     it("should list only the two assertion columns in the Columns menu, unchecked by default", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       await userEvent.click(screen.getByRole("button", { name: "Columns" }));
       const items = await screen.findAllByRole("menuitemcheckbox");
       // Account, Holding, and Value are the page's spine: never listed.
@@ -613,7 +619,7 @@ describe("<NetWorthView />", () => {
     it("should show the assertion columns in both section tables when toggled on", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       await showAssertionColumns();
       for (const name of ["Assets", "Liabilities"]) {
         expect(section(name).getByRole("button", { name: "Asserted On" })).toBeInTheDocument();
@@ -624,7 +630,7 @@ describe("<NetWorthView />", () => {
     it("should persist the column choice and restore it on remount", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       const { unmount } = renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       await showAssertionColumns();
       // The write is debounced (a resize drag never writes per pointer move).
       await waitFor(() =>
@@ -637,7 +643,7 @@ describe("<NetWorthView />", () => {
 
       // A fresh mount reads the stored choice: no menu interaction needed.
       renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       expect(screen.getAllByRole("button", { name: "Asserted On" })).toHaveLength(2);
       expect(screen.getByText("1,400.00 UAH")).toBeInTheDocument();
     });
@@ -668,7 +674,7 @@ describe("<NetWorthView />", () => {
       );
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       expect(screen.getAllByRole("button", { name: "Asserted On" })).toHaveLength(2);
       expect(screen.queryByRole("button", { name: "Asserted Amount" })).not.toBeInTheDocument();
       expect(screen.getByText("2026-07-12")).toBeInTheDocument();
@@ -680,7 +686,7 @@ describe("<NetWorthView />", () => {
       for (const stored of ["not json", JSON.stringify({ visibility: { asserted: "yes" } }), JSON.stringify(null)]) {
         window.localStorage.setItem("accountant24.net-worth-table", stored);
         const { unmount } = renderView();
-        await screen.findByTitle("assets:cash");
+        await screen.findByText("assets:cash");
         expect(screen.queryByRole("button", { name: "Asserted On" })).not.toBeInTheDocument();
         expect(screen.queryByRole("button", { name: "Asserted Amount" })).not.toBeInTheDocument();
         unmount();
@@ -690,7 +696,7 @@ describe("<NetWorthView />", () => {
     it("should span the empty-search row across only the visible columns", async () => {
       vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
       renderView();
-      await screen.findByTitle("assets:cash");
+      await screen.findByText("assets:cash");
       await userEvent.type(screen.getByRole("searchbox", { name: "Search accounts" }), "zzz");
       // The three spine columns plus the grid's trailing resize-fill column.
       const emptyCell = () => screen.getAllByText("No matching accounts")[0]?.closest("td");
@@ -743,6 +749,58 @@ describe("<NetWorthView />", () => {
       </Chrome>,
     );
     await waitFor(() => expect(ledgerApi.netWorth).toHaveBeenCalledTimes(2));
+  });
+
+  it("should defer the idle-edge refetch while hidden and refresh once on the next show", async () => {
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
+    const { rerender } = render(
+      <Chrome isRunning={false}>
+        <NetWorthView active={false} />
+      </Chrome>,
+    );
+    await screen.findByText("~115.57 EUR");
+    expect(ledgerApi.netWorth).toHaveBeenCalledTimes(1);
+
+    // A whole turn passes behind the hidden page: no report query runs.
+    rerender(
+      <Chrome isRunning={true}>
+        <NetWorthView active={false} />
+      </Chrome>,
+    );
+    await act(async () => {});
+    rerender(
+      <Chrome isRunning={false}>
+        <NetWorthView active={false} />
+      </Chrome>,
+    );
+    await act(async () => {});
+    expect(ledgerApi.netWorth).toHaveBeenCalledTimes(1);
+
+    // The show pays the deferred refresh, once.
+    rerender(
+      <Chrome isRunning={false}>
+        <NetWorthView active={true} />
+      </Chrome>,
+    );
+    await waitFor(() => expect(ledgerApi.netWorth).toHaveBeenCalledTimes(2));
+  });
+
+  it("should not refetch on show when no turn finished while hidden", async () => {
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(DATA);
+    const { rerender } = render(
+      <Chrome isRunning={false}>
+        <NetWorthView active={false} />
+      </Chrome>,
+    );
+    await screen.findByText("~115.57 EUR");
+
+    rerender(
+      <Chrome isRunning={false}>
+        <NetWorthView active={true} />
+      </Chrome>,
+    );
+    await act(async () => {});
+    expect(ledgerApi.netWorth).toHaveBeenCalledTimes(1);
   });
 
   it("should keep the current rows visible while a refetch is in flight", async () => {

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth.integration.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth.integration.test.tsx
@@ -140,10 +140,10 @@ describe("Net Worth view flow", () => {
 
     openSheet();
 
-    expect(await screen.findByTitle("assets:cash")).toBeInTheDocument();
-    expect(screen.getByTitle("assets:checking")).toBeInTheDocument();
+    expect(await screen.findByText("assets:cash")).toBeInTheDocument();
+    expect(screen.getByText("assets:checking")).toBeInTheDocument();
     expect(screen.getByText("~86.00 EUR")).toBeInTheDocument();
-    expect(screen.getByTitle("liabilities:card")).toBeInTheDocument();
+    expect(screen.getByText("liabilities:card")).toBeInTheDocument();
     // The assertion columns stay hidden until toggled on.
     expect(screen.queryByText("2026-07-01")).toBeNull();
     expect(bridge.callsFor("ledger_net_worth")).toHaveLength(2);
@@ -152,7 +152,7 @@ describe("Net Worth view flow", () => {
   it("should reveal the assertion columns via the Columns menu and keep them when the page is reopened", async () => {
     render(<ChatLayout />);
     openSheet();
-    await screen.findByTitle("assets:cash");
+    await screen.findByText("assets:cash");
 
     await userEvent.click(screen.getByRole("button", { name: "Columns" }));
     await userEvent.click(await screen.findByRole("menuitemcheckbox", { name: "Asserted On" }));
@@ -161,21 +161,21 @@ describe("Net Worth view flow", () => {
     expect(screen.getByText("2026-07-01")).toBeInTheDocument();
     expect(screen.getByText("95.00 USD")).toBeInTheDocument();
 
-    // Leave and reopen: the choice comes back from localStorage, with the
-    // usual per-open fetch and no menu interaction.
+    // Leave and reopen: the page stays mounted behind the chat, so the
+    // columns are simply still there — no refetch, no menu interaction.
     fireEvent.keyDown(document.body, { key: "n", metaKey: true });
-    expect(screen.queryByTitle("assets:cash")).toBeNull();
+    // Hidden, not unmounted: the rows are still in the tree.
+    expect(screen.getByText("assets:cash")).toBeInTheDocument();
     openSheet();
-    await screen.findByTitle("assets:cash");
     expect(screen.getByText("2026-07-01")).toBeInTheDocument();
     expect(screen.getByText("95.00 USD")).toBeInTheDocument();
-    expect(bridge.callsFor("ledger_net_worth")).toHaveLength(3);
+    expect(bridge.callsFor("ledger_net_worth")).toHaveLength(2);
   });
 
   it("should mark the sidebar entry active and keep the chat mounted but hidden while open", async () => {
     render(<ChatLayout />);
     openSheet();
-    await screen.findByTitle("assets:cash");
+    await screen.findByText("assets:cash");
 
     expect(screen.getByRole("button", { name: "Net Worth" })).toHaveAttribute("data-active");
     const thread = screen.getByTestId("thread");
@@ -186,26 +186,30 @@ describe("Net Worth view flow", () => {
   it("should ignore a second click on the active entry: the page stays, with no extra IPC", async () => {
     render(<ChatLayout />);
     openSheet();
-    await screen.findByTitle("assets:cash");
+    await screen.findByText("assets:cash");
 
     openSheet();
 
-    expect(screen.getByTitle("assets:cash")).toBeInTheDocument();
+    expect(screen.getByText("assets:cash")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Net Worth" })).toHaveAttribute("data-active");
     expect(bridge.callsFor("ledger_net_worth")).toHaveLength(2);
   });
 
-  it("should fetch a fresh report on every open", async () => {
+  it("should keep the report across a round trip to the chat, with no extra fetch", async () => {
     render(<ChatLayout />);
     openSheet();
-    await screen.findByTitle("assets:cash");
+    await screen.findByText("assets:cash");
     // Returning to the chat goes through new chat (Cmd/Ctrl+N), not the entry.
     fireEvent.keyDown(document.body, { key: "n", metaKey: true });
-    expect(screen.queryByTitle("assets:cash")).toBeNull();
+    // Hidden, not unmounted: the rows are still in the tree.
+    expect(screen.getByText("assets:cash")).toBeInTheDocument();
 
     openSheet();
-    await screen.findByTitle("assets:cash");
-    expect(bridge.callsFor("ledger_net_worth")).toHaveLength(3);
+    await screen.findByText("assets:cash");
+    // The badge's fetch plus the page's one open — the report survives the
+    // round trip (a turn that finishes while the page is hidden defers its
+    // refresh to the next show).
+    expect(bridge.callsFor("ledger_net_worth")).toHaveLength(2);
   });
 
   it("should show the empty state when the report has no balances", async () => {

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/table-config.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/table-config.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+// Spec for the shared table-config core: stored configs are validated
+// field by field over the page's defaults (garbage can never hide or break
+// a table), saves never throw, and the hook persists changes debounced —
+// including a flush on unmount, so a page that unmounts on view switch
+// (Net Worth) never loses a change made within the debounce window.
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { installJsdomPolyfills } from "@/test/jsdomPolyfills";
+import { loadStoredTableConfig, saveStoredTableConfig, type TableConfig, useTableConfig } from "../table-config";
+
+const KEY = "accountant24.test-table";
+const DEFAULT_VISIBILITY = { alpha: true, beta: false };
+const SIZABLE = ["chrome", "alpha", "beta"];
+
+const load = () => loadStoredTableConfig(KEY, DEFAULT_VISIBILITY, SIZABLE);
+
+beforeAll(() => installJsdomPolyfills());
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("loadStoredTableConfig()", () => {
+  it("should return the defaults when nothing is stored", () => {
+    expect(load()).toEqual({ visibility: { alpha: true, beta: false }, sizing: {} });
+  });
+
+  it("should return the defaults when the stored value is not JSON, null, or an array", () => {
+    for (const stored of ["not json", "null", "[1,2]"]) {
+      window.localStorage.setItem(KEY, stored);
+      expect(load()).toEqual({ visibility: { alpha: true, beta: false }, sizing: {} });
+    }
+  });
+
+  it("should apply stored visibility only for known columns with boolean values", () => {
+    window.localStorage.setItem(KEY, JSON.stringify({ visibility: { alpha: false, beta: "yes", stale: true } }));
+    expect(load().visibility).toEqual({ alpha: false, beta: false });
+  });
+
+  it("should apply stored widths only for sizable columns with positive finite values", () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({ sizing: { chrome: 44, alpha: 120.5, beta: -10, stale: 200, alsoBad: "wide" } }),
+    );
+    expect(load().sizing).toEqual({ chrome: 44, alpha: 120.5 });
+  });
+
+  it("should round-trip a config through save and load", () => {
+    const config: TableConfig = { visibility: { alpha: false, beta: true }, sizing: { alpha: 240 } };
+    saveStoredTableConfig(KEY, config);
+    expect(load()).toEqual(config);
+  });
+});
+
+describe("useTableConfig()", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should never write back the just-loaded config", () => {
+    const save = vi.fn();
+    renderHook(() => useTableConfig(load, save));
+    act(() => vi.runAllTimers());
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("should save a change once, debounced, with the latest value", () => {
+    const save = vi.fn();
+    const { result } = renderHook(() => useTableConfig(load, save));
+    act(() => result.current.applyConfig("sizing", { alpha: 200 }));
+    act(() => result.current.applyConfig("sizing", { alpha: 220 }));
+    expect(save).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(300));
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith({ visibility: { alpha: true, beta: false }, sizing: { alpha: 220 } });
+  });
+
+  it("should flush a pending change when the component unmounts before the debounce fires", () => {
+    const save = vi.fn();
+    const { result, unmount } = renderHook(() => useTableConfig(load, save));
+    act(() => result.current.applyConfig("visibility", (prev) => ({ ...prev, beta: true })));
+    unmount();
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith({ visibility: { alpha: true, beta: true }, sizing: {} });
+  });
+
+  it("should not write on unmount when everything was already saved", () => {
+    const save = vi.fn();
+    const { result, unmount } = renderHook(() => useTableConfig(load, save));
+    act(() => result.current.applyConfig("sizing", { alpha: 200 }));
+    act(() => vi.advanceTimersByTime(300));
+    expect(save).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/table-config.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/table-config.test.tsx
@@ -47,6 +47,14 @@ describe("loadStoredTableConfig()", () => {
     expect(load().sizing).toEqual({ chrome: 44, alpha: 120.5 });
   });
 
+  it("should clamp stored widths below a column's minimum up to it", () => {
+    // A resize drag past the minimum persists the raw sub-minimum value
+    // (the grid clamps only at render); loading must not let it back in.
+    window.localStorage.setItem(KEY, JSON.stringify({ sizing: { alpha: 30, beta: 500 } }));
+    const clamped = loadStoredTableConfig(KEY, DEFAULT_VISIBILITY, SIZABLE, { alpha: 120, beta: 90 });
+    expect(clamped.sizing).toEqual({ alpha: 120, beta: 500 });
+  });
+
   it("should round-trip a config through save and load", () => {
     const config: TableConfig = { visibility: { alpha: false, beta: true }, sizing: { alpha: 240 } };
     saveStoredTableConfig(KEY, config);

--- a/packages/desktop/src/renderer/components/accountant24/app-column-header.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/app-column-header.tsx
@@ -6,6 +6,7 @@
 // Merged over the vendored classes via cn.
 
 import type { Column } from "@tanstack/react-table";
+import type { ReactNode } from "react";
 import type { DataGridFeatures } from "@/components/reui/data-grid/data-grid";
 import { DataGridColumnHeader } from "@/components/reui/data-grid/data-grid-column-header";
 import { cn } from "@/lib/utils";
@@ -15,11 +16,14 @@ const HEADER_CLASS = "rounded-4xl hover:bg-muted data-[state=open]:bg-muted";
 export function AppColumnHeader<TData extends object, TValue>({
   column,
   title,
+  icon,
   className,
 }: {
   column: Column<DataGridFeatures, TData, TValue>;
   title: string;
+  /** Rendered inside the pill, before the title (the vendored icon slot). */
+  icon?: ReactNode;
   className?: string;
 }) {
-  return <DataGridColumnHeader column={column} title={title} className={cn(HEADER_CLASS, className)} />;
+  return <DataGridColumnHeader column={column} title={title} icon={icon} className={cn(HEADER_CLASS, className)} />;
 }

--- a/packages/desktop/src/renderer/components/accountant24/app-column-header.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/app-column-header.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+// The app-styled data-grid sort header, shared by the data pages: the
+// vendored default hovers a small rounded-lg secondary box; ours is the
+// ghost-button recipe (muted pill) every other hoverable control uses.
+// Merged over the vendored classes via cn.
+
+import type { Column } from "@tanstack/react-table";
+import type { DataGridFeatures } from "@/components/reui/data-grid/data-grid";
+import { DataGridColumnHeader } from "@/components/reui/data-grid/data-grid-column-header";
+import { cn } from "@/lib/utils";
+
+const HEADER_CLASS = "rounded-4xl hover:bg-muted data-[state=open]:bg-muted";
+
+export function AppColumnHeader<TData extends object, TValue>({
+  column,
+  title,
+  className,
+}: {
+  column: Column<DataGridFeatures, TData, TValue>;
+  title: string;
+  className?: string;
+}) {
+  return <DataGridColumnHeader column={column} title={title} className={cn(HEADER_CLASS, className)} />;
+}

--- a/packages/desktop/src/renderer/components/accountant24/chat-layout.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/chat-layout.tsx
@@ -71,13 +71,21 @@ export function ChatLayout() {
   const runtime = usePiRuntime({ client, adapters: { attachments } });
   const [settingsOpen, setSettingsOpen] = useState(false);
   // Which view fills the inset. The chat is never unmounted (see below); the
-  // report pages mount fresh on each open so they always show current data.
+  // report pages latch on first open and stay mounted after, so their state
+  // survives view switches (a hidden page defers its refresh to the next
+  // show — see useAgentIdleRefresh).
   const [view, setView] = useState<"chat" | "transactions" | "net-worth">("chat");
-  // Latches once Transactions is first opened; the view then stays mounted.
+  // Latch per report page once it is first opened; the view then stays
+  // mounted.
   const [transactionsMounted, setTransactionsMounted] = useState(false);
   const showTransactions = useCallback(() => {
     setView("transactions");
     setTransactionsMounted(true);
+  }, []);
+  const [netWorthMounted, setNetWorthMounted] = useState(false);
+  const showNetWorth = useCallback(() => {
+    setView("net-worth");
+    setNetWorthMounted(true);
   }, []);
   const showChat = useCallback(() => setView("chat"), []);
   // Non-null once an update is downloaded and staged; drives the footer banner.
@@ -168,7 +176,7 @@ export function ChatLayout() {
                   </SidebarMenuButton>
                 </SidebarMenuItem>
                 <SidebarMenuItem>
-                  <SidebarMenuButton isActive={view === "net-worth"} onClick={() => setView("net-worth")}>
+                  <SidebarMenuButton isActive={view === "net-worth"} onClick={showNetWorth}>
                     <WalletIcon className="size-4" />
                     <span className="whitespace-nowrap">Net Worth</span>
                     <NetWorthBadge />
@@ -216,7 +224,19 @@ export function ChatLayout() {
                 <TransactionsView active={view === "transactions"} />
               </div>
             )}
-            {view === "net-worth" && <NetWorthView />}
+            {/* Same treatment as Transactions: sort, search, resized
+                columns, and scroll survive view switches, and a turn that
+                finishes behind the hidden page only marks it dirty. */}
+            {netWorthMounted && (
+              <div
+                className={cn(
+                  "absolute inset-0 flex flex-col",
+                  view !== "net-worth" && "pointer-events-none invisible opacity-0",
+                )}
+              >
+                <NetWorthView active={view === "net-worth"} />
+              </div>
+            )}
           </SidebarInset>
           <Settings open={settingsOpen} onOpenChange={setSettingsOpen} />
         </SidebarProvider>

--- a/packages/desktop/src/renderer/components/accountant24/mentions.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/mentions.tsx
@@ -14,7 +14,7 @@ import { unstable_useMentionAdapter } from "@assistant-ui/react";
 import { AtSignIcon, LandmarkIcon, StoreIcon, TagIcon } from "lucide-react";
 import { type FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Badge } from "@/components/shadcn/badge";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/shadcn/tooltip";
 import { useAgentIdleRefresh } from "@/hooks/use-agent-idle-refresh";
 import { cn } from "@/lib/utils";
 import { ledgerApi } from "@/rpc/api";
@@ -85,20 +85,20 @@ export const MentionPill: FC<{
   );
   if (!truncate) return badge;
   return (
-    <TooltipProvider delay={500}>
-      <Tooltip
-        open={tooltipOpen}
-        onOpenChange={(open) => {
-          const el = pillRef.current;
-          setTooltipOpen(open && !!el && el.scrollWidth > el.clientWidth);
-        }}
-      >
-        <TooltipTrigger ref={pillRef} render={badge} />
-        <TooltipContent side="top" className="max-w-80 break-words">
-          {label}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    // No local TooltipProvider: the app-level provider (App.tsx) owns the
+    // dwell delay and the shared warm-up across neighboring tooltips.
+    <Tooltip
+      open={tooltipOpen}
+      onOpenChange={(open) => {
+        const el = pillRef.current;
+        setTooltipOpen(open && !!el && el.scrollWidth > el.clientWidth);
+      }}
+    >
+      <TooltipTrigger ref={pillRef} render={badge} />
+      <TooltipContent side="top" className="max-w-80 break-words">
+        {label}
+      </TooltipContent>
+    </Tooltip>
   );
 };
 

--- a/packages/desktop/src/renderer/components/accountant24/net-worth-columns.ts
+++ b/packages/desktop/src/renderer/components/accountant24/net-worth-columns.ts
@@ -1,5 +1,8 @@
 // Persisted table configuration for the Net Worth view: its storage key
-// and column set over the shared load/save core (table-config.ts).
+// and column set over the shared load/save core (table-config.ts), plus
+// the static column widths — the same model as the Transactions register:
+// fixed defaults, resizing moves only the dragged column, and extra
+// columns grow the table past the page floor.
 
 import { loadStoredTableConfig, saveStoredTableConfig, type TableConfig } from "./table-config";
 
@@ -14,14 +17,29 @@ export const DEFAULT_COLUMN_VISIBILITY: Record<string, boolean> = {
   assertedAmount: false,
 };
 
-/** Every column's default width, in display order — also the ids the
- *  sizing validation accepts and what the page-width math sums. */
+/** Every column's default width, in display order. The default-visible set
+ *  fills the 52rem page floor exactly (492 + 170 + 170 — the toolbar's
+ *  content span, title edge to Columns edge); toggling the assertion pair
+ *  grows the table past the floor and the page scrolls, the same way the
+ *  Transactions register grows when its optional columns come on. */
 export const COLUMN_SIZES: Record<string, number> = {
-  account: 400,
-  asserted: 130,
-  assertedAmount: 170,
-  holding: 180,
-  value: 160,
+  account: 492,
+  asserted: 170,
+  assertedAmount: 200,
+  holding: 170,
+  value: 170,
+};
+
+/** Every column's minimum: its header pill (measured rendered widths:
+ *  Account 93, Asserted On 146, Asserted Amount 178, Holding 115, Value
+ *  100) plus the cell's 8px padding on each side — at the minimum the pill
+ *  sits with the same breathing room to both column separators. */
+export const COLUMN_MIN_SIZES: Record<string, number> = {
+  account: 110,
+  asserted: 162,
+  assertedAmount: 194,
+  holding: 132,
+  value: 116,
 };
 
 export type NetWorthTableConfig = TableConfig;
@@ -34,11 +52,9 @@ export function saveTableConfig(config: NetWorthTableConfig): void {
   saveStoredTableConfig(NET_WORTH_TABLE_KEY, config);
 }
 
-/** The width the section tables render at: the visible columns' widths
- *  (resized or default) summed — computed from the config alone, so the
- *  page can size the shared width wrapper (section bands, the Net band)
- *  without reaching into a table instance. Mirrors TanStack's
- *  getTotalSize() for the same columns. */
+/** The width the section tables render at (the visible columns, resized or
+ *  default) — what the page sizes the shared width wrapper (section bands,
+ *  the Net band) with. Mirrors TanStack's getTotalSize(). */
 export function tableWidth(config: NetWorthTableConfig): number {
   return Object.entries(COLUMN_SIZES).reduce(
     (total, [id, size]) => (config.visibility[id] === false ? total : total + (config.sizing[id] ?? size)),

--- a/packages/desktop/src/renderer/components/accountant24/net-worth-columns.ts
+++ b/packages/desktop/src/renderer/components/accountant24/net-worth-columns.ts
@@ -30,22 +30,31 @@ export const COLUMN_SIZES: Record<string, number> = {
   value: 170,
 };
 
-/** Every column's minimum: its header pill (measured rendered widths:
- *  Account 93, Asserted On 146, Asserted Amount 178, Holding 115, Value
- *  100) plus the cell's 8px padding on each side — at the minimum the pill
- *  sits with the same breathing room to both column separators. */
+/** Every column's minimum: whichever is larger of
+ *  - its header pill (measured rendered widths: Account 93, Asserted On
+ *    146, Asserted Amount 178, Holding 115, Value 100) plus the cell's 8px
+ *    padding per side, so at the minimum the pill sits with the same
+ *    breathing room to both column separators, and
+ *  - its content: a typical formatted amount ("~1,187.50 EUR") for the
+ *    money columns, a readable account pill for Account — cranking a
+ *    column to the stop must never make its data unreadable. */
 export const COLUMN_MIN_SIZES: Record<string, number> = {
-  account: 110,
+  account: 220,
   asserted: 162,
   assertedAmount: 194,
-  holding: 132,
-  value: 116,
+  holding: 140,
+  value: 140,
 };
 
 export type NetWorthTableConfig = TableConfig;
 
 export function loadTableConfig(): NetWorthTableConfig {
-  return loadStoredTableConfig(NET_WORTH_TABLE_KEY, DEFAULT_COLUMN_VISIBILITY, Object.keys(COLUMN_SIZES));
+  return loadStoredTableConfig(
+    NET_WORTH_TABLE_KEY,
+    DEFAULT_COLUMN_VISIBILITY,
+    Object.keys(COLUMN_SIZES),
+    COLUMN_MIN_SIZES,
+  );
 }
 
 export function saveTableConfig(config: NetWorthTableConfig): void {
@@ -54,10 +63,15 @@ export function saveTableConfig(config: NetWorthTableConfig): void {
 
 /** The width the section tables render at (the visible columns, resized or
  *  default) — what the page sizes the shared width wrapper (section bands,
- *  the Net band) with. Mirrors TanStack's getTotalSize(). */
+ *  the Net band) with. Mirrors TanStack's getTotalSize() INCLUDING its
+ *  minimum clamp: a live drag past a column's minimum stores the raw
+ *  sub-minimum value while the grid renders the clamp, and summing the raw
+ *  values would make the wrapper narrower than the table — whose container
+ *  then clips the last column. */
 export function tableWidth(config: NetWorthTableConfig): number {
   return Object.entries(COLUMN_SIZES).reduce(
-    (total, [id, size]) => (config.visibility[id] === false ? total : total + (config.sizing[id] ?? size)),
+    (total, [id, size]) =>
+      config.visibility[id] === false ? total : total + Math.max(config.sizing[id] ?? size, COLUMN_MIN_SIZES[id] ?? 0),
     0,
   );
 }

--- a/packages/desktop/src/renderer/components/accountant24/net-worth-columns.ts
+++ b/packages/desktop/src/renderer/components/accountant24/net-worth-columns.ts
@@ -1,0 +1,47 @@
+// Persisted table configuration for the Net Worth view: its storage key
+// and column set over the shared load/save core (table-config.ts).
+
+import { loadStoredTableConfig, saveStoredTableConfig, type TableConfig } from "./table-config";
+
+export const NET_WORTH_TABLE_KEY = "accountant24.net-worth-table";
+
+/** Only the assertion pair toggles, hidden by default: the tables stay
+ *  narrow and lead with what you have now; the reconciliation trail is
+ *  opt-in via the Columns menu. Account, Holding, and Value are the page's
+ *  spine and never leave, so they have no entry here. */
+export const DEFAULT_COLUMN_VISIBILITY: Record<string, boolean> = {
+  asserted: false,
+  assertedAmount: false,
+};
+
+/** Every column's default width, in display order — also the ids the
+ *  sizing validation accepts and what the page-width math sums. */
+export const COLUMN_SIZES: Record<string, number> = {
+  account: 400,
+  asserted: 130,
+  assertedAmount: 170,
+  holding: 180,
+  value: 160,
+};
+
+export type NetWorthTableConfig = TableConfig;
+
+export function loadTableConfig(): NetWorthTableConfig {
+  return loadStoredTableConfig(NET_WORTH_TABLE_KEY, DEFAULT_COLUMN_VISIBILITY, Object.keys(COLUMN_SIZES));
+}
+
+export function saveTableConfig(config: NetWorthTableConfig): void {
+  saveStoredTableConfig(NET_WORTH_TABLE_KEY, config);
+}
+
+/** The width the section tables render at: the visible columns' widths
+ *  (resized or default) summed — computed from the config alone, so the
+ *  page can size the shared width wrapper (section bands, the Net band)
+ *  without reaching into a table instance. Mirrors TanStack's
+ *  getTotalSize() for the same columns. */
+export function tableWidth(config: NetWorthTableConfig): number {
+  return Object.entries(COLUMN_SIZES).reduce(
+    (total, [id, size]) => (config.visibility[id] === false ? total : total + (config.sizing[id] ?? size)),
+    0,
+  );
+}

--- a/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
@@ -17,10 +17,11 @@
 // independently per section. All figures are hledger-computed; only the
 // presentation happens here. Data refreshes when the agent finishes a turn.
 
-import type { ColumnDef, SortingState, Updater } from "@tanstack/react-table";
+import type { Column, ColumnDef, SortingState, Updater } from "@tanstack/react-table";
 import { InfoIcon, WalletIcon } from "lucide-react";
 import { type FC, type ReactNode, useState } from "react";
 import { AppColumnHeader } from "@/components/accountant24/app-column-header";
+import { MentionPill } from "@/components/accountant24/mentions";
 import { PageEmpty } from "@/components/accountant24/page-empty";
 import { useTableConfig } from "@/components/accountant24/table-config";
 import { twoStateSortingChange, useAppTable } from "@/components/accountant24/use-app-table";
@@ -28,11 +29,12 @@ import { DataGrid, DataGridContainer, type DataGridFeatures } from "@/components
 import { DataGridTable } from "@/components/reui/data-grid/data-grid-table";
 import { Button } from "@/components/shadcn/button";
 import { Skeleton } from "@/components/shadcn/skeleton";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/shadcn/tooltip";
 import { formatAmount, formatAmounts, formatValue, splitValueLead } from "@/lib/amountFormat";
 import type { AccountBalance, NetWorthSection, NetWorthTotal } from "@/rpc/types";
 import { ColumnsMenu } from "./columns-menu";
 import {
+  COLUMN_MIN_SIZES,
   COLUMN_SIZES,
   loadTableConfig,
   type NetWorthTableConfig,
@@ -100,35 +102,63 @@ const COLUMN_HELP: Record<string, ReactNode> = {
 };
 
 /** A visible little info marker; hovering it explains the spot it marks —
- *  the column help for its label by default, or the given children. A
- *  separate target from the text it explains, so the help is discoverable
- *  and the text stays inert. */
-const InfoTip: FC<{ label: string; children?: ReactNode }> = ({ label, children }) => (
-  <TooltipProvider>
-    <Tooltip>
-      <TooltipTrigger
-        render={
+ *  the column help for its label by default, or the given children.
+ *  `inline` renders it for use INSIDE a sort pill: a nested <button> would
+ *  be invalid DOM, and a labeled widget would pollute the pill's
+ *  accessible name, so the inline marker is a decorative hover-only span
+ *  (data-slot="column-help"), hidden from the a11y tree. The standalone
+ *  Button variant keeps full keyboard access where it is used (the bands). */
+const InfoTip: FC<{ label: string; inline?: boolean; children?: ReactNode }> = ({
+  label,
+  inline = false,
+  children,
+}) => (
+  // No local TooltipProvider: the app-level provider (App.tsx) owns the
+  // dwell delay and the shared warm-up across neighboring tooltips.
+  <Tooltip>
+    <TooltipTrigger
+      render={
+        inline ? (
+          <span
+            aria-hidden
+            data-slot="column-help"
+            className="flex size-5 items-center justify-center text-muted-foreground/70 hover:text-foreground"
+          />
+        ) : (
           <Button
             variant="ghost"
             size="icon"
             aria-label={`About ${label}`}
             className="size-5 text-muted-foreground/70 hover:text-foreground"
           />
-        }
-      >
-        <InfoIcon className="size-3.5" />
-      </TooltipTrigger>
-      <TooltipContent side="top" className="max-w-60">
-        {children ?? COLUMN_HELP[label]}
-      </TooltipContent>
-    </Tooltip>
-  </TooltipProvider>
+        )
+      }
+    >
+      <InfoIcon className="size-3.5" />
+    </TooltipTrigger>
+    <TooltipContent side="top" className="max-w-60">
+      {children ?? COLUMN_HELP[label]}
+    </TooltipContent>
+  </Tooltip>
 );
 
 /** The money/meta columns put the biggest figures first on the first click
  *  (the vendored header ignores `sortDescFirst`, so the sorting handler
  *  applies the policy). */
 const DESC_FIRST: ReadonlySet<string> = new Set(["asserted", "assertedAmount", "holding", "value"]);
+
+/** A money/meta column header: the info marker rides inside the sort pill
+ *  (the vendored header's icon slot), so marker and label right-align over
+ *  the figures as one unit and the marker can never detach from its label,
+ *  however narrow the column is resized. */
+const InfoColumnHeader: FC<{
+  column: Column<DataGridFeatures, AccountBalance, unknown>;
+  title: string;
+}> = ({ column, title }) => (
+  <div className="flex items-center justify-end">
+    <AppColumnHeader column={column} title={title} icon={<InfoTip inline label={title} />} />
+  </div>
+);
 
 /** The accounts data grid columns. Sorting semantics:
  *  - Account: A-Z on the full path (the table's default sort);
@@ -150,29 +180,24 @@ const columns: ColumnDef<DataGridFeatures, AccountBalance>[] = [
     enableHiding: false,
     sortFn: "text",
     size: COLUMN_SIZES.account,
-    minSize: 104,
+    minSize: COLUMN_MIN_SIZES.account,
     header: ({ column }) => <AppColumnHeader column={column} title="Account" />,
-    // The full path, truncating inside the fixed column (complete path in
-    // the tooltip).
+    // The chat's account pill, like the register: the full path, truncating
+    // inside the pill on a fixed column (complete path in the tooltip).
     cell: ({ row }) => (
-      <div className="truncate" title={row.original.name}>
-        {row.original.name}
+      <div className="flex h-6 items-center">
+        <MentionPill truncate type="account" label={row.original.name} />
       </div>
     ),
-    meta: { headerTitle: "Account", skeleton: <Skeleton className="h-4 w-56" /> },
+    meta: { headerTitle: "Account", skeleton: <Skeleton className="h-6 w-52 rounded-3xl" /> },
   },
   {
     id: "asserted",
     accessorFn: (row) => row.assertedOn ?? "",
     sortFn: "text",
     size: COLUMN_SIZES.asserted,
-    minSize: 120,
-    header: ({ column }) => (
-      <div className="flex items-center justify-end">
-        <InfoTip label={ASSERTED_ON_LABEL} />
-        <AppColumnHeader column={column} title={ASSERTED_ON_LABEL} />
-      </div>
-    ),
+    minSize: COLUMN_MIN_SIZES.asserted,
+    header: ({ column }) => <InfoColumnHeader column={column} title={ASSERTED_ON_LABEL} />,
     // The journal's own ISO date, verbatim — unambiguous, and what you see
     // is literally what the column sorts by. An em dash marks accounts whose
     // balance was never asserted.
@@ -188,13 +213,8 @@ const columns: ColumnDef<DataGridFeatures, AccountBalance>[] = [
     accessorFn: (row) => row.assertedAmount?.quantity ?? 0,
     sortFn: "basic",
     size: COLUMN_SIZES.assertedAmount,
-    minSize: 160,
-    header: ({ column }) => (
-      <div className="flex items-center justify-end">
-        <InfoTip label={ASSERTED_AMOUNT_LABEL} />
-        <AppColumnHeader column={column} title={ASSERTED_AMOUNT_LABEL} />
-      </div>
-    ),
+    minSize: COLUMN_MIN_SIZES.assertedAmount,
+    header: ({ column }) => <InfoColumnHeader column={column} title={ASSERTED_AMOUNT_LABEL} />,
     // The asserted native amount, formatted like Holding; an em dash marks
     // accounts never asserted (or an assertion whose amount the journal
     // export didn't carry), the same placeholder as the date column.
@@ -212,13 +232,8 @@ const columns: ColumnDef<DataGridFeatures, AccountBalance>[] = [
     sortFn: "basic",
     enableHiding: false,
     size: COLUMN_SIZES.holding,
-    minSize: 104,
-    header: ({ column }) => (
-      <div className="flex items-center justify-end">
-        <InfoTip label="Holding" />
-        <AppColumnHeader column={column} title="Holding" />
-      </div>
-    ),
+    minSize: COLUMN_MIN_SIZES.holding,
+    header: ({ column }) => <InfoColumnHeader column={column} title="Holding" />,
     cell: ({ row }) => formatAmounts(row.original.amounts, "native", navigator.language),
     meta: {
       headerTitle: "Holding",
@@ -232,13 +247,8 @@ const columns: ColumnDef<DataGridFeatures, AccountBalance>[] = [
     sortFn: "basic",
     enableHiding: false,
     size: COLUMN_SIZES.value,
-    minSize: 100,
-    header: ({ column }) => (
-      <div className="flex items-center justify-end">
-        <InfoTip label="Value" />
-        <AppColumnHeader column={column} title="Value" />
-      </div>
-    ),
+    minSize: COLUMN_MIN_SIZES.value,
+    header: ({ column }) => <InfoColumnHeader column={column} title="Value" />,
     cell: ({ row }) => formatValue(row.original, navigator.language),
     meta: {
       headerTitle: "Value",
@@ -305,14 +315,10 @@ const AccountsGrid: FC<{
 /** The soft summary-band surface shared by the section headers and the Net
  *  line: label left, hledger's figure right, on the app's muted panel. The
  *  label centers on the figure block, so it stays mid-band when the figure
- *  grows a second (muted) line. px-5 inside mx-3 keeps the text on the px-8
- *  line of the page title. */
-const BAND_CLASS = "mx-3 flex items-center justify-between gap-8 rounded-xl bg-muted/50 px-5 py-4";
-
-/** The grids' side gutter: with the dense cells' own px-2, the table text
- *  lines up with the bands' text (mx-3 + px-5 = 32px). */
-const GRID_GUTTER_CLASS = "px-6";
-const GRID_GUTTER_PX = 48;
+ *  grows a second (muted) line. No side margins: the band's edges sit on
+ *  the page's content edges, flush with the grid — one left line under the
+ *  pinned title, one right line under the Columns button. */
+const BAND_CLASS = "flex items-center justify-between gap-8 rounded-xl bg-muted/50 px-5 py-4";
 
 /** A summary band's figure. When the valuation could not fold every leg
  *  into the base currency, the base leg leads at the band's weight and the
@@ -353,12 +359,10 @@ const SheetSection: FC<{
 }> = ({ section, baseCommodity, search, config, onSizingChange }) => (
   <section aria-label={section.name}>
     <div className={`mt-8 mb-2 ${BAND_CLASS}`}>
-      <h2 className="text-xl font-semibold">{section.name}</h2>
+      <h2 className="text-lg font-semibold">{section.name}</h2>
       <BandValue figure={section.total} baseCommodity={baseCommodity} />
     </div>
-    <div className={GRID_GUTTER_CLASS}>
-      <AccountsGrid rows={section.rows} search={search} config={config} onSizingChange={onSizingChange} />
-    </div>
+    <AccountsGrid rows={section.rows} search={search} config={config} onSizingChange={onSizingChange} />
   </section>
 );
 
@@ -375,14 +379,12 @@ const SheetSkeleton: FC<{
 }> = ({ config, onSizingChange }) => (
   <div role="status" aria-label="Loading accounts">
     <div className={`mt-8 mb-2 ${BAND_CLASS}`}>
-      <h2 className="text-xl font-semibold">Assets</h2>
+      <h2 className="text-lg font-semibold">Assets</h2>
       <Skeleton className="h-5 w-36 self-center" />
     </div>
-    <div className={GRID_GUTTER_CLASS}>
-      <AccountsGrid rows={NO_ROWS} search="" config={config} onSizingChange={onSizingChange} loading />
-    </div>
+    <AccountsGrid rows={NO_ROWS} search="" config={config} onSizingChange={onSizingChange} loading />
     <div className={`mt-8 ${BAND_CLASS}`}>
-      <div className="text-xl font-semibold">Net Worth</div>
+      <div className="text-lg font-semibold">Net Worth</div>
       <Skeleton className="h-5 w-32" />
     </div>
   </div>
@@ -450,10 +452,11 @@ export const NetWorthView: FC<{ active?: boolean }> = ({ active = true }) => {
         {sheet !== null && sections.length === 0 ? (
           <SheetEmpty />
         ) : (
-          // The body is as wide as the tables' columns plus the grid
-          // gutters (never below the 52rem page floor); past the window
-          // width the page scrolls horizontally, like Transactions.
-          <div className="mx-auto pb-12" style={{ width: `max(52rem, ${tableWidth(config) + GRID_GUTTER_PX}px)` }}>
+          // The body is exactly as wide as the tables' columns (never below
+          // the 52rem page floor — the same span as the toolbar's content
+          // box, title edge to Columns edge); past the window width the
+          // page scrolls horizontally, like Transactions.
+          <div className="mx-auto pb-12" style={{ width: `max(52rem, ${tableWidth(config)}px)` }}>
             {sheet === null ? (
               <SheetSkeleton config={config} onSizingChange={onSizingChange} />
             ) : (
@@ -470,7 +473,7 @@ export const NetWorthView: FC<{ active?: boolean }> = ({ active = true }) => {
                 ))}
                 {/* The closing Net band, straight from hledger's own net. */}
                 <div className={`mt-8 ${BAND_CLASS}`}>
-                  <div className="text-xl font-semibold">Net Worth</div>
+                  <div className="text-lg font-semibold">Net Worth</div>
                   <BandValue figure={sheet.net} baseCommodity={sheet.baseCommodity} />
                 </div>
               </>

--- a/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
@@ -3,65 +3,54 @@
 // Full-page Net Worth view: `hledger bs` rendered as data — an Assets
 // and a Liabilities section (liabilities already sign-flipped positive by
 // hledger), each with hledger's own total, and the hledger-computed Net as
-// the classic bottom line. A pinned header carries the page title, a
-// search box filtering every section by account path, and a Columns menu
-// toggling the two assertion columns (hidden by default, remembered in
-// localStorage) across every section at once. Each section is a
-// shadcn-style data table (TanStack Table): complete account paths in one
-// color, every native holding in a muted Holding column, the market value
-// (hledger's `-X` valuation in the base currency) in the Value column;
-// every column sorts, A-Z on the account path by default, independently per
-// section. All figures are hledger-computed; only the presentation happens
-// here. Data refreshes when the agent finishes a turn.
+// the classic bottom line. Each section is the same stock ReUI data grid
+// (TanStack v9) as the Transactions register: the app-styled two-state
+// sort headers, resizable columns (widths persisted with the column
+// visibility in localStorage, shared across the sections so they stay
+// aligned), per-column loading skeletons, and the filtered-out empty
+// state. A pinned header carries the page title, a search box filtering
+// every section by account path, and a Columns menu toggling the two
+// assertion columns across every section at once. Complete account paths
+// in one color, every native holding in the Holding column, the market
+// value (hledger's `-X` valuation in the base currency) in the Value
+// column; every column sorts, A-Z on the account path by default,
+// independently per section. All figures are hledger-computed; only the
+// presentation happens here. Data refreshes when the agent finishes a turn.
 
-import { type Column, type ColumnDef, flexRender, type SortingState } from "@tanstack/react-table";
-import { ArrowDownIcon, ArrowUpIcon, ChevronsUpDownIcon, InfoIcon, WalletIcon } from "lucide-react";
+import type { ColumnDef, SortingState, Updater } from "@tanstack/react-table";
+import { InfoIcon, WalletIcon } from "lucide-react";
 import { type FC, type ReactNode, useState } from "react";
+import { AppColumnHeader } from "@/components/accountant24/app-column-header";
 import { PageEmpty } from "@/components/accountant24/page-empty";
-import { useAppTable } from "@/components/accountant24/use-app-table";
-import type { DataGridFeatures } from "@/components/reui/data-grid/data-grid";
+import { useTableConfig } from "@/components/accountant24/table-config";
+import { twoStateSortingChange, useAppTable } from "@/components/accountant24/use-app-table";
+import { DataGrid, DataGridContainer, type DataGridFeatures } from "@/components/reui/data-grid/data-grid";
+import { DataGridTable } from "@/components/reui/data-grid/data-grid-table";
 import { Button } from "@/components/shadcn/button";
 import { Skeleton } from "@/components/shadcn/skeleton";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/shadcn/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/tooltip";
 import { formatAmount, formatAmounts, formatValue, splitValueLead } from "@/lib/amountFormat";
 import type { AccountBalance, NetWorthSection, NetWorthTotal } from "@/rpc/types";
 import { ColumnsMenu } from "./columns-menu";
+import {
+  COLUMN_SIZES,
+  loadTableConfig,
+  type NetWorthTableConfig,
+  saveTableConfig,
+  tableWidth,
+} from "./net-worth-columns";
 import { SearchField } from "./search-field";
 import { useNetWorth } from "./use-net-worth";
-
-/** Column visibility map (id -> shown); TanStack v9 no longer exports a
- *  dedicated state type for it. */
-type ColumnVisibility = Record<string, boolean>;
 
 /** The two columns the Columns menu can toggle; the other three are the
  *  page's spine and never leave. */
 type OptionalColumnId = "asserted" | "assertedAmount";
 
-/** Clickable column header driving the table's sorting; the icon mirrors
- *  the current direction, neutral chevrons while the column is unsorted. */
-const SortHeader: FC<{ column: Column<DataGridFeatures, AccountBalance>; label: string; className?: string }> = ({
-  column,
-  label,
-  className,
-}) => {
-  const sorted = column.getIsSorted();
-  const Icon = sorted === "asc" ? ArrowUpIcon : sorted === "desc" ? ArrowDownIcon : ChevronsUpDownIcon;
-  return (
-    <Button variant="ghost" size="sm" className={className} onClick={() => column.toggleSorting()}>
-      {label}
-      <Icon className={sorted ? undefined : "text-muted-foreground/60"} />
-    </Button>
-  );
-};
-
-/** Assertion-column labels, defined once: the headers, the help keys, the
- *  Columns menu, and the loading skeleton all read these. */
+/** Assertion-column labels, defined once: the headers, the help keys, and
+ *  the Columns menu all read these. */
 const ASSERTED_ON_LABEL = "Asserted On";
 const ASSERTED_AMOUNT_LABEL = "Asserted Amount";
 
-/** What each money/meta column means, keyed by its label; shown behind the
- *  little info marker next to the header (the Account column needs none). */
 /** The how-to line for anything valued at a recorded rate — shared by the
  *  Value column help and the bands' unpriced-legs tooltip so the copy stays
  *  identical in both. */
@@ -72,6 +61,8 @@ const RATE_HELP = (
   </p>
 );
 
+/** What each money/meta column means, keyed by its label; shown behind the
+ *  little info marker next to the header (the Account column needs none). */
 const COLUMN_HELP: Record<string, ReactNode> = {
   Holding:
     "What the account actually holds: cash in its own currency, shares, or crypto. Exactly as recorded in the ledger, before any conversion.",
@@ -134,7 +125,12 @@ const InfoTip: FC<{ label: string; children?: ReactNode }> = ({ label, children 
   </TooltipProvider>
 );
 
-/** The accounts data table columns. Sorting semantics:
+/** The money/meta columns put the biggest figures first on the first click
+ *  (the vendored header ignores `sortDescFirst`, so the sorting handler
+ *  applies the policy). */
+const DESC_FIRST: ReadonlySet<string> = new Set(["asserted", "assertedAmount", "holding", "value"]);
+
+/** The accounts data grid columns. Sorting semantics:
  *  - Account: A-Z on the full path (the table's default sort);
  *  - Holding: by the primary native quantity — a plain number sort, so the
  *    column reads monotonic (commodity grouping was tried and read as
@@ -144,180 +140,165 @@ const InfoTip: FC<{ label: string; children?: ReactNode }> = ({ label, children 
  *  - Asserted Amount: by quantity, like Holding; never-asserted rows
  *    count as zero;
  *  - Value: by market value.
- *  Money columns put the biggest figures first on the first click. The two
- *  assertion columns hide by default (the tables stay narrow) and toggle on
- *  via the header's Columns menu; the other three are the page's spine and
- *  cannot be hidden. */
+ *  The two assertion columns hide by default (the tables stay narrow) and
+ *  toggle on via the header's Columns menu; the other three are the page's
+ *  spine and cannot be hidden. */
 const columns: ColumnDef<DataGridFeatures, AccountBalance>[] = [
   {
     id: "account",
     accessorFn: (row) => row.name,
     enableHiding: false,
     sortFn: "text",
-    header: ({ column }) => <SortHeader column={column} label="Account" className="-ml-3" />,
-    cell: ({ row }) => row.original.name,
+    size: COLUMN_SIZES.account,
+    minSize: 104,
+    header: ({ column }) => <AppColumnHeader column={column} title="Account" />,
+    // The full path, truncating inside the fixed column (complete path in
+    // the tooltip).
+    cell: ({ row }) => (
+      <div className="truncate" title={row.original.name}>
+        {row.original.name}
+      </div>
+    ),
+    meta: { headerTitle: "Account", skeleton: <Skeleton className="h-4 w-56" /> },
   },
   {
     id: "asserted",
     accessorFn: (row) => row.assertedOn ?? "",
     sortFn: "text",
-    sortDescFirst: true,
+    size: COLUMN_SIZES.asserted,
+    minSize: 120,
     header: ({ column }) => (
       <div className="flex items-center justify-end">
         <InfoTip label={ASSERTED_ON_LABEL} />
-        <SortHeader column={column} label={ASSERTED_ON_LABEL} className="-mr-3" />
+        <AppColumnHeader column={column} title={ASSERTED_ON_LABEL} />
       </div>
     ),
     // The journal's own ISO date, verbatim — unambiguous, and what you see
     // is literally what the column sorts by. An em dash marks accounts whose
     // balance was never asserted.
-    cell: ({ row }) => row.original.assertedOn ?? "\u2014",
+    cell: ({ row }) => row.original.assertedOn ?? "—",
+    meta: {
+      headerTitle: ASSERTED_ON_LABEL,
+      cellClassName: "text-right tabular-nums",
+      skeleton: <Skeleton className="ms-auto h-4 w-20" />,
+    },
   },
   {
     id: "assertedAmount",
     accessorFn: (row) => row.assertedAmount?.quantity ?? 0,
     sortFn: "basic",
-    sortDescFirst: true,
+    size: COLUMN_SIZES.assertedAmount,
+    minSize: 160,
     header: ({ column }) => (
       <div className="flex items-center justify-end">
         <InfoTip label={ASSERTED_AMOUNT_LABEL} />
-        <SortHeader column={column} label={ASSERTED_AMOUNT_LABEL} className="-mr-3" />
+        <AppColumnHeader column={column} title={ASSERTED_AMOUNT_LABEL} />
       </div>
     ),
     // The asserted native amount, formatted like Holding; an em dash marks
     // accounts never asserted (or an assertion whose amount the journal
     // export didn't carry), the same placeholder as the date column.
     cell: ({ row }) =>
-      row.original.assertedAmount ? formatAmount(row.original.assertedAmount, "native", navigator.language) : "\u2014",
+      row.original.assertedAmount ? formatAmount(row.original.assertedAmount, "native", navigator.language) : "—",
+    meta: {
+      headerTitle: ASSERTED_AMOUNT_LABEL,
+      cellClassName: "text-right tabular-nums",
+      skeleton: <Skeleton className="ms-auto h-4 w-24" />,
+    },
   },
   {
     id: "holding",
     accessorFn: (row) => row.amounts[0]?.quantity ?? 0,
     sortFn: "basic",
-    sortDescFirst: true,
     enableHiding: false,
+    size: COLUMN_SIZES.holding,
+    minSize: 104,
     header: ({ column }) => (
       <div className="flex items-center justify-end">
         <InfoTip label="Holding" />
-        <SortHeader column={column} label="Holding" className="-mr-3" />
+        <AppColumnHeader column={column} title="Holding" />
       </div>
     ),
     cell: ({ row }) => formatAmounts(row.original.amounts, "native", navigator.language),
+    meta: {
+      headerTitle: "Holding",
+      cellClassName: "text-right tabular-nums",
+      skeleton: <Skeleton className="ms-auto h-4 w-24" />,
+    },
   },
   {
     id: "value",
     accessorFn: (row) => row.value[0]?.quantity ?? 0,
     sortFn: "basic",
-    sortDescFirst: true,
     enableHiding: false,
+    size: COLUMN_SIZES.value,
+    minSize: 100,
     header: ({ column }) => (
       <div className="flex items-center justify-end">
         <InfoTip label="Value" />
-        <SortHeader column={column} label="Value" className="-mr-3" />
+        <AppColumnHeader column={column} title="Value" />
       </div>
     ),
     cell: ({ row }) => formatValue(row.original, navigator.language),
+    meta: {
+      headerTitle: "Value",
+      cellClassName: "text-right tabular-nums",
+      skeleton: <Skeleton className="ms-auto h-4 w-24" />,
+    },
   },
 ];
 
-// py-2.5 keeps the pre-table row density; the stock p-3 cells read too airy
-// for this dense money list.
-const CELL_CLASS: Record<string, string> = {
-  account: "w-full py-2.5",
-  holding: "py-2.5 text-right tabular-nums",
-  asserted: "py-2.5 text-right tabular-nums",
-  assertedAmount: "py-2.5 text-right tabular-nums",
-  value: "py-2.5 text-right tabular-nums",
-};
+/** Stable empty row list for the loading grid. */
+const NO_ROWS: AccountBalance[] = [];
 
-/** The assertion pair starts hidden: the tables stay narrow and lead with
- *  what you have now; the reconciliation trail is opt-in via the Columns
- *  menu. The choice is remembered per user in localStorage and validated
- *  key-by-key on load, so garbage or stale entries fall back to hidden. */
-const COLUMNS_STORAGE_KEY = "accountant24.net-worth.columns";
-const DEFAULT_COLUMN_VISIBILITY: ColumnVisibility = { asserted: false, assertedAmount: false };
-
-export function loadColumnVisibility(): ColumnVisibility {
-  try {
-    const parsed: unknown = JSON.parse(window.localStorage.getItem(COLUMNS_STORAGE_KEY) ?? "");
-    const pick = (key: string) => (parsed as Record<string, unknown>)[key] === true;
-    return { asserted: pick("asserted"), assertedAmount: pick("assertedAmount") };
-  } catch {
-    return { ...DEFAULT_COLUMN_VISIBILITY };
-  }
-}
-
-function saveColumnVisibility(visibility: ColumnVisibility): void {
-  try {
-    window.localStorage.setItem(COLUMNS_STORAGE_KEY, JSON.stringify(visibility));
-  } catch {
-    // Best-effort: without storage the toggle still works for the session.
-  }
-}
-
-const AccountsTable: FC<{
+/** One section's accounts on the stock data grid. Sorting is local (each
+ *  section sorts independently); visibility and sizing come in from the
+ *  page config, and resizes bubble back up so every section stays aligned
+ *  on the same column widths. */
+const AccountsGrid: FC<{
   rows: AccountBalance[];
   search: string;
-  label: string;
-  columnVisibility: ColumnVisibility;
-}> = ({ rows, search, label, columnVisibility }) => {
+  config: NetWorthTableConfig;
+  onSizingChange: (updater: Updater<Record<string, number>>) => void;
+  loading?: boolean;
+}> = ({ rows, search, config, onSizingChange, loading = false }) => {
   // A-Z on the account path until the user picks another column; a click
   // always leaves some direction active (no unsorted third state).
   const [sorting, setSorting] = useState<SortingState>([{ id: "account", desc: false }]);
-  // Visibility is owned by the page (one Columns menu drives every section
-  // table) and fully controlled: nothing in here mutates it.
   const table = useAppTable({
     data: rows,
     columns,
-    state: { sorting, globalFilter: search, columnVisibility },
-    onSortingChange: setSorting,
-    enableSortingRemoval: false,
-    // The account path is the only searchable field; substring match,
-    // case-insensitive.
+    getRowId: (row) => row.name,
+    state: {
+      sorting,
+      globalFilter: search,
+      columnVisibility: config.visibility,
+      columnSizing: config.sizing,
+    },
+    onSortingChange: twoStateSortingChange(setSorting, DESC_FIRST),
+    onColumnSizingChange: onSizingChange,
+    // The account path is the only searchable field (and the only column
+    // the global filter needs to visit); substring match, case-insensitive.
+    getColumnCanGlobalFilter: (column) => column.id === "account",
     globalFilterFn: (row, _columnId, value) => row.original.name.toLowerCase().includes(String(value).toLowerCase()),
   });
-
   return (
-    <Table aria-label={label}>
-      {/* The header row is labels, not data — no hover highlight. */}
-      <TableHeader>
-        {table.getHeaderGroups().map((headerGroup) => (
-          <TableRow key={headerGroup.id} className="hover:bg-transparent">
-            {headerGroup.headers.map((header) => (
-              <TableHead key={header.id} className={header.column.id === "account" ? "w-full" : undefined}>
-                {flexRender(header.column.columnDef.header, header.getContext())}
-              </TableHead>
-            ))}
-          </TableRow>
-        ))}
-      </TableHeader>
-      <TableBody>
-        {table.getRowModel().rows.length === 0 ? (
-          <TableRow>
-            <TableCell
-              colSpan={table.getVisibleLeafColumns().length}
-              className="h-24 text-center text-muted-foreground"
-            >
-              No matching accounts
-            </TableCell>
-          </TableRow>
-        ) : (
-          table.getRowModel().rows.map((row) => (
-            <TableRow key={row.id}>
-              {row.getVisibleCells().map((cell) => (
-                <TableCell
-                  key={cell.id}
-                  className={CELL_CLASS[cell.column.id]}
-                  title={cell.column.id === "account" ? row.original.name : undefined}
-                >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </TableCell>
-              ))}
-            </TableRow>
-          ))
-        )}
-      </TableBody>
-    </Table>
+    <DataGrid
+      table={table}
+      recordCount={table.getFilteredRowModel().rows.length}
+      isLoading={loading}
+      emptyMessage="No matching accounts"
+      tableLayout={{
+        dense: true,
+        columnsResizable: true,
+        columnsResizeMode: "onChange",
+        width: "fixed",
+      }}
+    >
+      <DataGridContainer>
+        <DataGridTable />
+      </DataGridContainer>
+    </DataGrid>
   );
 };
 
@@ -327,6 +308,11 @@ const AccountsTable: FC<{
  *  grows a second (muted) line. px-5 inside mx-3 keeps the text on the px-8
  *  line of the page title. */
 const BAND_CLASS = "mx-3 flex items-center justify-between gap-8 rounded-xl bg-muted/50 px-5 py-4";
+
+/** The grids' side gutter: with the dense cells' own px-2, the table text
+ *  lines up with the bands' text (mx-3 + px-5 = 32px). */
+const GRID_GUTTER_CLASS = "px-6";
+const GRID_GUTTER_PX = 48;
 
 /** A summary band's figure. When the valuation could not fold every leg
  *  into the base currency, the base leg leads at the band's weight and the
@@ -356,94 +342,51 @@ const BandValue: FC<{ figure: NetWorthTotal; baseCommodity: string | null }> = (
   );
 };
 
-/** One `bs` section: its hledger name and total over its accounts table. */
+/** One `bs` section: its hledger name and total over its accounts grid,
+ *  wrapped in a labeled region so each section's table stays addressable. */
 const SheetSection: FC<{
   section: NetWorthSection;
   baseCommodity: string | null;
   search: string;
-  columnVisibility: ColumnVisibility;
-}> = ({ section, baseCommodity, search, columnVisibility }) => (
-  <section>
+  config: NetWorthTableConfig;
+  onSizingChange: (updater: Updater<Record<string, number>>) => void;
+}> = ({ section, baseCommodity, search, config, onSizingChange }) => (
+  <section aria-label={section.name}>
     <div className={`mt-8 mb-2 ${BAND_CLASS}`}>
       <h2 className="text-xl font-semibold">{section.name}</h2>
       <BandValue figure={section.total} baseCommodity={baseCommodity} />
     </div>
-    {/* px-5: with the cells' own px-3, the table text lines up with the px-8
-        headings. */}
-    <div className="px-5">
-      <AccountsTable rows={section.rows} search={search} label={section.name} columnVisibility={columnVisibility} />
+    <div className={GRID_GUTTER_CLASS}>
+      <AccountsGrid rows={section.rows} search={search} config={config} onSizingChange={onSizingChange} />
     </div>
   </section>
 );
 
-const SKELETON_ROWS = ["s1", "s2", "s3", "s4", "s5", "s6"];
-
 /** The loading state mirrors the loaded page: everything that needs no data
  *  (the Assets band, the column labels, the Net band) is up immediately, and
  *  skeletons stand in only for the figures and rows hledger is still
- *  computing. The column set follows the page's visibility state (known
- *  before any data arrives), so the header doesn't jump when rows land.
- *  Assets and Net always exist on a balance sheet; Liabilities may not, so
- *  no placeholder for it. */
-const SheetSkeleton: FC<{ columnVisibility: ColumnVisibility }> = ({ columnVisibility }) => {
-  const metaLabels = [
-    ...(columnVisibility.asserted ? [ASSERTED_ON_LABEL] : []),
-    ...(columnVisibility.assertedAmount ? [ASSERTED_AMOUNT_LABEL] : []),
-    "Holding",
-    "Value",
-  ];
-  return (
-    <div role="status" aria-label="Loading accounts">
-      <div className={`mt-8 mb-2 ${BAND_CLASS}`}>
-        <h2 className="text-xl font-semibold">Assets</h2>
-        <Skeleton className="h-5 w-36 self-center" />
-      </div>
-      <div className="px-5">
-        <Table>
-          <TableHeader>
-            <TableRow className="hover:bg-transparent">
-              <TableHead className="w-full">
-                <Button variant="ghost" size="sm" className="-ml-3" disabled>
-                  Account
-                  <ChevronsUpDownIcon className="text-muted-foreground/60" />
-                </Button>
-              </TableHead>
-              {metaLabels.map((label) => (
-                <TableHead key={label}>
-                  <div className="flex items-center justify-end">
-                    <InfoTip label={label} />
-                    <Button variant="ghost" size="sm" className="-mr-3" disabled>
-                      {label}
-                      <ChevronsUpDownIcon className="text-muted-foreground/60" />
-                    </Button>
-                  </div>
-                </TableHead>
-              ))}
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {SKELETON_ROWS.map((row) => (
-              <TableRow key={row} className="hover:bg-transparent">
-                <TableCell className="w-full py-2.5">
-                  <Skeleton className="h-4 w-56" />
-                </TableCell>
-                {metaLabels.map((label) => (
-                  <TableCell key={label} className="py-2.5">
-                    <Skeleton className="ml-auto h-4 w-24" />
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
-      <div className={`mt-8 ${BAND_CLASS}`}>
-        <div className="text-xl font-semibold">Net Worth</div>
-        <Skeleton className="h-5 w-32" />
-      </div>
+ *  computing — the grid's own per-column skeletons, under the real headers,
+ *  following the page's visibility state (known before any data arrives) so
+ *  the header doesn't jump when rows land. Assets and Net always exist on a
+ *  balance sheet; Liabilities may not, so no placeholder for it. */
+const SheetSkeleton: FC<{
+  config: NetWorthTableConfig;
+  onSizingChange: (updater: Updater<Record<string, number>>) => void;
+}> = ({ config, onSizingChange }) => (
+  <div role="status" aria-label="Loading accounts">
+    <div className={`mt-8 mb-2 ${BAND_CLASS}`}>
+      <h2 className="text-xl font-semibold">Assets</h2>
+      <Skeleton className="h-5 w-36 self-center" />
     </div>
-  );
-};
+    <div className={GRID_GUTTER_CLASS}>
+      <AccountsGrid rows={NO_ROWS} search="" config={config} onSizingChange={onSizingChange} loading />
+    </div>
+    <div className={`mt-8 ${BAND_CLASS}`}>
+      <div className="text-xl font-semibold">Net Worth</div>
+      <Skeleton className="h-5 w-32" />
+    </div>
+  </div>
+);
 
 // "No transactions yet", not "no accounts": the default workspace already
 // declares accounts on first start — what an empty report is missing is
@@ -457,37 +400,29 @@ const SheetEmpty: FC = () => (
 );
 
 /** The Net Worth page, shown in place of the chat thread. Laid out like
- *  a Claude-app content page: a centered column of capped width, a large
- *  title sitting well below the window chrome (clear of the drag region and
- *  the sidebar toggle), and the search box under it. Title and search are
- *  pinned; the sections and the Net line scroll. */
-export const NetWorthView: FC = () => {
-  const sheet = useNetWorth();
+ *  a Claude-app content page: a large title sitting well below the window
+ *  chrome (clear of the drag region and the sidebar toggle), the search box
+ *  and Columns menu beside it, pinned; the sections and the Net line
+ *  scroll. The body is exactly as wide as the tables' columns (never below
+ *  the default page cap), so showing the assertion pair or resizing a
+ *  column widens the page — past the window width the page scrolls
+ *  horizontally, like the Transactions register. `active` = the page is the
+ *  visible view; the layout keeps it mounted while hidden, and a hidden
+ *  page defers its idle-edge refetches to the next show. */
+export const NetWorthView: FC<{ active?: boolean }> = ({ active = true }) => {
+  const sheet = useNetWorth(active);
   const [search, setSearch] = useState("");
-  // The Columns choice, shared by every section table and the loading
-  // skeleton; owned here so one menu drives the whole page, saved on every
-  // toggle and restored on the next visit.
-  const [columnVisibility, setColumnVisibility] = useState<ColumnVisibility>(loadColumnVisibility);
-  const setColumnShown = (id: OptionalColumnId, shown: boolean) =>
-    setColumnVisibility((prev) => {
-      const next = { ...prev, [id]: shown };
-      saveColumnVisibility(next);
-      return next;
-    });
+  // One config (visibility + sizing) drives every section grid and the
+  // loading skeleton, saved debounced and restored on the next visit.
+  const { config, applyConfig } = useTableConfig(loadTableConfig, saveTableConfig);
+  const onSizingChange = (updater: Updater<Record<string, number>>) => applyConfig("sizing", updater);
   // hledger emits a section even when it has no accounts; an empty side
   // renders nothing rather than a fabricated zero.
   const sections = sheet?.sections.filter((s) => s.rows.length > 0) ?? [];
-  // The assertion columns push the table past the default page cap; widen
-  // the page one step per extra column so nothing gets clipped where the
-  // window has the room, without leaving a four-column table adrift on a
-  // six-column-wide page. Narrow windows still fall back to the table's own
-  // horizontal scroll.
-  const extraColumns = (columnVisibility.asserted ? 1 : 0) + (columnVisibility.assertedAmount ? 1 : 0);
-  const pageWidth = extraColumns === 2 ? "max-w-6xl" : extraColumns === 1 ? "max-w-5xl" : "max-w-4xl";
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className={`mx-auto flex w-full ${pageWidth} shrink-0 items-center justify-between gap-8 px-8 pt-16 pb-4`}>
+      <div className="mx-auto flex w-full max-w-4xl shrink-0 items-center justify-between gap-8 px-8 pt-16 pb-4">
         <h1 className="whitespace-nowrap text-3xl font-semibold">Net Worth</h1>
         {(sheet === null || sections.length > 0) && (
           // min-w-0 (not shrink-0): when the window narrows, the search
@@ -501,23 +436,26 @@ export const NetWorthView: FC = () => {
                 { id: "asserted", label: ASSERTED_ON_LABEL },
                 { id: "assertedAmount", label: ASSERTED_AMOUNT_LABEL },
               ]}
-              visibility={columnVisibility}
-              onToggle={setColumnShown}
+              visibility={config.visibility}
+              onToggle={(id, shown) => applyConfig("visibility", (prev) => ({ ...prev, [id]: shown }))}
             />
           </div>
         )}
       </div>
       {/* scroll-fade-t-6: content dissolves over 24px as it slides under the
           pinned search field, same as the chat viewport's top fade. */}
-      <div className="scroll-fade-t scroll-fade-t-6 min-h-0 flex-1 overflow-y-auto">
+      <div className="scroll-fade-t scroll-fade-t-6 min-h-0 flex-1 overflow-auto">
         {/* The empty view sits directly in the scroll container (not the
             width column) so it can center itself in the body's height. */}
         {sheet !== null && sections.length === 0 ? (
           <SheetEmpty />
         ) : (
-          <div className={`mx-auto w-full ${pageWidth} pb-12`}>
+          // The body is as wide as the tables' columns plus the grid
+          // gutters (never below the 52rem page floor); past the window
+          // width the page scrolls horizontally, like Transactions.
+          <div className="mx-auto pb-12" style={{ width: `max(52rem, ${tableWidth(config) + GRID_GUTTER_PX}px)` }}>
             {sheet === null ? (
-              <SheetSkeleton columnVisibility={columnVisibility} />
+              <SheetSkeleton config={config} onSizingChange={onSizingChange} />
             ) : (
               <>
                 {sections.map((section) => (
@@ -526,7 +464,8 @@ export const NetWorthView: FC = () => {
                     section={section}
                     baseCommodity={sheet.baseCommodity}
                     search={search}
-                    columnVisibility={columnVisibility}
+                    config={config}
+                    onSizingChange={onSizingChange}
                   />
                 ))}
                 {/* The closing Net band, straight from hledger's own net. */}

--- a/packages/desktop/src/renderer/components/accountant24/table-config.ts
+++ b/packages/desktop/src/renderer/components/accountant24/table-config.ts
@@ -22,11 +22,15 @@ export interface TableConfig {
  *  visibility, and non-positive widths are dropped, so a stale or garbled
  *  entry can never hide or break a table. `sizableColumns` lists every leaf
  *  column id the sizing validation accepts — it can exceed the visibility
- *  keys (chrome columns resize but never hide). */
+ *  keys (chrome columns resize but never hide). Stored widths clamp to
+ *  `minSizes`: a resize drag past a column's minimum persists the raw
+ *  sub-minimum value (the grid clamps only at render), and letting it back
+ *  into the model would make every later width computation lie. */
 export function loadStoredTableConfig(
   key: string,
   defaultVisibility: Record<string, boolean>,
   sizableColumns: readonly string[],
+  minSizes: Record<string, number> = {},
 ): TableConfig {
   const config: TableConfig = { visibility: { ...defaultVisibility }, sizing: {} };
   let stored: unknown;
@@ -45,7 +49,7 @@ export function loadStoredTableConfig(
   if (typeof s.sizing === "object" && s.sizing !== null) {
     for (const [id, width] of Object.entries(s.sizing)) {
       if (sizableColumns.includes(id) && typeof width === "number" && Number.isFinite(width) && width > 0) {
-        config.sizing[id] = width;
+        config.sizing[id] = Math.max(width, minSizes[id] ?? 0);
       }
     }
   }

--- a/packages/desktop/src/renderer/components/accountant24/table-config.ts
+++ b/packages/desktop/src/renderer/components/accountant24/table-config.ts
@@ -1,0 +1,108 @@
+"use client";
+
+// Persisted table configuration shared by the data pages (Transactions,
+// Net Worth) — the same best-effort localStorage idiom as the sidebar
+// width: load validates the stored value field by field and falls back to
+// the page's defaults, save never throws. Each page brings its own storage
+// key, default visibility, and known-column list (see
+// transactions-columns.ts / net-worth-columns.ts).
+
+import { functionalUpdate, type Updater } from "@tanstack/react-table";
+import { useEffect, useRef, useState } from "react";
+
+/** Everything the grid lets the user shape: column visibility and resized
+ *  widths. Column order is fixed by the column definitions on every page;
+ *  it is neither user-changeable nor persisted. */
+export interface TableConfig {
+  visibility: Record<string, boolean>;
+  sizing: Record<string, number>;
+}
+
+/** The persisted config over the defaults; unknown columns, non-bool
+ *  visibility, and non-positive widths are dropped, so a stale or garbled
+ *  entry can never hide or break a table. `sizableColumns` lists every leaf
+ *  column id the sizing validation accepts — it can exceed the visibility
+ *  keys (chrome columns resize but never hide). */
+export function loadStoredTableConfig(
+  key: string,
+  defaultVisibility: Record<string, boolean>,
+  sizableColumns: readonly string[],
+): TableConfig {
+  const config: TableConfig = { visibility: { ...defaultVisibility }, sizing: {} };
+  let stored: unknown;
+  try {
+    stored = JSON.parse(window.localStorage.getItem(key) ?? "");
+  } catch {
+    return config;
+  }
+  if (typeof stored !== "object" || stored === null || Array.isArray(stored)) return config;
+  const s = stored as { visibility?: unknown; sizing?: unknown };
+  if (typeof s.visibility === "object" && s.visibility !== null) {
+    for (const [id, visible] of Object.entries(s.visibility)) {
+      if (id in defaultVisibility && typeof visible === "boolean") config.visibility[id] = visible;
+    }
+  }
+  if (typeof s.sizing === "object" && s.sizing !== null) {
+    for (const [id, width] of Object.entries(s.sizing)) {
+      if (sizableColumns.includes(id) && typeof width === "number" && Number.isFinite(width) && width > 0) {
+        config.sizing[id] = width;
+      }
+    }
+  }
+  return config;
+}
+
+export function saveStoredTableConfig(key: string, config: TableConfig): void {
+  try {
+    window.localStorage.setItem(key, JSON.stringify(config));
+  } catch {
+    // Persistence is best-effort; the session keeps its in-memory state.
+  }
+}
+
+/** How long after the last config change (a resize drag emits one per
+ *  pointer move) the table config is written to localStorage. */
+const SAVE_CONFIG_DELAY_MS = 250;
+
+/** The pages' table-config state: loaded once on mount, updated field by
+ *  field, persisted debounced — an onChange column resize updates state on
+ *  every pointer move, and a synchronous localStorage write per move would
+ *  put disk I/O on the drag frame path. One write lands shortly after the
+ *  last change; the just-loaded initial config never writes back. */
+export function useTableConfig(
+  load: () => TableConfig,
+  save: (config: TableConfig) => void,
+): {
+  config: TableConfig;
+  applyConfig: <K extends keyof TableConfig>(field: K, updater: Updater<TableConfig[K]>) => void;
+} {
+  const [config, setConfig] = useState<TableConfig>(load);
+
+  const applyConfig = <K extends keyof TableConfig>(field: K, updater: Updater<TableConfig[K]>) =>
+    setConfig((prev) => ({ ...prev, [field]: functionalUpdate(updater, prev[field]) }));
+
+  const savedConfig = useRef(config);
+  const configRef = useRef(config);
+  configRef.current = config;
+  const saveRef = useRef(save);
+  saveRef.current = save;
+  useEffect(() => {
+    if (savedConfig.current === config) return;
+    const timer = setTimeout(() => {
+      savedConfig.current = config;
+      saveRef.current(config);
+    }, SAVE_CONFIG_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [config]);
+  // Flush a pending write on unmount: a page that unmounts on view switch
+  // (Net Worth) would otherwise lose a change made within the debounce
+  // window — the timer above is cleaned up with the component.
+  useEffect(
+    () => () => {
+      if (savedConfig.current !== configRef.current) saveRef.current(configRef.current);
+    },
+    [],
+  );
+
+  return { config, applyConfig };
+}

--- a/packages/desktop/src/renderer/components/accountant24/tooltip-icon-button.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/tooltip-icon-button.tsx
@@ -2,7 +2,7 @@
 
 import { type ComponentPropsWithRef, forwardRef } from "react";
 import { Button } from "@/components/shadcn/button";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/shadcn/tooltip";
 import { cn } from "@/lib/utils";
 
 export type TooltipIconButtonProps = ComponentPropsWithRef<typeof Button> & {
@@ -13,25 +13,25 @@ export type TooltipIconButtonProps = ComponentPropsWithRef<typeof Button> & {
 export const TooltipIconButton = forwardRef<HTMLButtonElement, TooltipIconButtonProps>(
   ({ children, tooltip, side = "bottom", className, ...rest }, ref) => {
     return (
-      <TooltipProvider delay={0}>
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                variant="ghost"
-                size="icon"
-                {...rest}
-                className={cn("aui-button-icon size-6 p-1 active:scale-90", className)}
-                ref={ref}
-              />
-            }
-          >
-            {children}
-            <span className="aui-sr-only sr-only">{tooltip}</span>
-          </TooltipTrigger>
-          <TooltipContent side={side}>{tooltip}</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      // No local TooltipProvider: the app-level provider (App.tsx) owns the
+      // dwell delay and the shared warm-up across neighboring tooltips.
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon"
+              {...rest}
+              className={cn("aui-button-icon size-6 p-1 active:scale-90", className)}
+              ref={ref}
+            />
+          }
+        >
+          {children}
+          <span className="aui-sr-only sr-only">{tooltip}</span>
+        </TooltipTrigger>
+        <TooltipContent side={side}>{tooltip}</TooltipContent>
+      </Tooltip>
     );
   },
 );

--- a/packages/desktop/src/renderer/components/accountant24/transactions-columns.ts
+++ b/packages/desktop/src/renderer/components/accountant24/transactions-columns.ts
@@ -1,8 +1,7 @@
-// Persisted table configuration for the Transactions view — the same
-// best-effort localStorage idiom as the sidebar width: load validates the
-// stored value field by field and falls back to the defaults, save never
-// throws. Covers everything the grid lets the user shape: column
-// visibility, drag order, and resized widths.
+// Persisted table configuration for the Transactions view: its storage key
+// and column set over the shared load/save core (table-config.ts).
+
+import { loadStoredTableConfig, saveStoredTableConfig, type TableConfig } from "./table-config";
 
 export const TRANSACTIONS_TABLE_KEY = "accountant24.transactions-table";
 
@@ -21,54 +20,15 @@ export const DEFAULT_COLUMN_VISIBILITY: Record<string, boolean> = {
 
 /** Every leaf column id the sizing validation accepts: the hideable ones
  *  plus the expander gutter, which is chrome (resizable, never hidden) and
- *  so has no visibility entry. Derived, so a new column is declared once.
- *  Column order itself is fixed by the column definitions; it is neither
- *  user-changeable nor persisted. */
+ *  so has no visibility entry. Derived, so a new column is declared once. */
 const KNOWN_COLUMNS = ["expand", ...Object.keys(DEFAULT_COLUMN_VISIBILITY)];
 
-export interface TransactionsTableConfig {
-  visibility: Record<string, boolean>;
-  sizing: Record<string, number>;
-}
+export type TransactionsTableConfig = TableConfig;
 
-const defaults = (): TransactionsTableConfig => ({
-  visibility: { ...DEFAULT_COLUMN_VISIBILITY },
-  sizing: {},
-});
-
-/** The persisted config over the defaults; unknown columns, non-bool
- *  visibility, and non-positive widths are dropped, so a stale or garbled
- *  entry (an older build also stored a column order, now ignored) can never
- *  hide or break the table. */
 export function loadTableConfig(): TransactionsTableConfig {
-  let stored: unknown;
-  try {
-    stored = JSON.parse(window.localStorage.getItem(TRANSACTIONS_TABLE_KEY) ?? "");
-  } catch {
-    return defaults();
-  }
-  const config = defaults();
-  if (typeof stored !== "object" || stored === null || Array.isArray(stored)) return config;
-  const s = stored as { visibility?: unknown; sizing?: unknown };
-  if (typeof s.visibility === "object" && s.visibility !== null) {
-    for (const [id, visible] of Object.entries(s.visibility)) {
-      if (id in DEFAULT_COLUMN_VISIBILITY && typeof visible === "boolean") config.visibility[id] = visible;
-    }
-  }
-  if (typeof s.sizing === "object" && s.sizing !== null) {
-    for (const [id, width] of Object.entries(s.sizing)) {
-      if (KNOWN_COLUMNS.includes(id) && typeof width === "number" && Number.isFinite(width) && width > 0) {
-        config.sizing[id] = width;
-      }
-    }
-  }
-  return config;
+  return loadStoredTableConfig(TRANSACTIONS_TABLE_KEY, DEFAULT_COLUMN_VISIBILITY, KNOWN_COLUMNS);
 }
 
 export function saveTableConfig(config: TransactionsTableConfig): void {
-  try {
-    window.localStorage.setItem(TRANSACTIONS_TABLE_KEY, JSON.stringify(config));
-  } catch {
-    // Persistence is best-effort; the session keeps its in-memory state.
-  }
+  saveStoredTableConfig(TRANSACTIONS_TABLE_KEY, config);
 }

--- a/packages/desktop/src/renderer/components/accountant24/transactions-columns.ts
+++ b/packages/desktop/src/renderer/components/accountant24/transactions-columns.ts
@@ -23,10 +23,24 @@ export const DEFAULT_COLUMN_VISIBILITY: Record<string, boolean> = {
  *  so has no visibility entry. Derived, so a new column is declared once. */
 const KNOWN_COLUMNS = ["expand", ...Object.keys(DEFAULT_COLUMN_VISIBILITY)];
 
+/** Every column's minimum (the register's column defs read these): header
+ *  fit for the text columns, content fit where the data is the wider
+ *  constraint (a typical formatted amount for Amount, a readable account
+ *  pill for Account, the full ISO date for Date). */
+export const COLUMN_MIN_SIZES: Record<string, number> = {
+  date: 104,
+  payee: 90,
+  account: 220,
+  amount: 140,
+  status: 94,
+  note: 108,
+  tags: 80,
+};
+
 export type TransactionsTableConfig = TableConfig;
 
 export function loadTableConfig(): TransactionsTableConfig {
-  return loadStoredTableConfig(TRANSACTIONS_TABLE_KEY, DEFAULT_COLUMN_VISIBILITY, KNOWN_COLUMNS);
+  return loadStoredTableConfig(TRANSACTIONS_TABLE_KEY, DEFAULT_COLUMN_VISIBILITY, KNOWN_COLUMNS, COLUMN_MIN_SIZES);
 }
 
 export function saveTableConfig(config: TransactionsTableConfig): void {

--- a/packages/desktop/src/renderer/components/accountant24/transactions-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/transactions-view.tsx
@@ -57,7 +57,7 @@ import { cn } from "@/lib/utils";
 import type { LedgerPosting, LedgerTransaction, LedgerTransactionStatus } from "@/rpc/types";
 import { POPOVER_WIDTH } from "./popover";
 import { SearchField } from "./search-field";
-import { loadTableConfig, saveTableConfig } from "./transactions-columns";
+import { COLUMN_MIN_SIZES, loadTableConfig, saveTableConfig } from "./transactions-columns";
 import { useTransactions } from "./use-transactions";
 
 /** The tag pill's text, also what search and the Tags sort key see. */
@@ -135,9 +135,7 @@ const columns: ColumnDef<DataGridFeatures, LedgerTransaction>[] = [
       return !range || inRange(row.original.date, range);
     },
     size: 120,
-    // Unlike the other minimums (header-fit), dates are fixed-width data:
-    // the minimum keeps the full ISO date readable.
-    minSize: 104,
+    minSize: COLUMN_MIN_SIZES.date,
     header: ({ column }) => <AppColumnHeader column={column} title="Date" />,
     // The journal's own ISO date, verbatim — unambiguous, and what you see
     // is literally what the column sorts by.
@@ -153,7 +151,7 @@ const columns: ColumnDef<DataGridFeatures, LedgerTransaction>[] = [
       return payees.length === 0 || payees.includes(row.original.payee);
     },
     size: 200,
-    minSize: 90,
+    minSize: COLUMN_MIN_SIZES.payee,
     header: ({ column }) => <AppColumnHeader column={column} title="Payee" />,
     cell: ({ row }) =>
       row.original.payee ? (
@@ -178,9 +176,7 @@ const columns: ColumnDef<DataGridFeatures, LedgerTransaction>[] = [
     // + 200 + 326 + 150) so the Amount column ends on the toolbar's right
     // edge instead of leaving slack in the grid's trailing fill column.
     size: 326,
-    // Readability floor: below this the account pills crush into a
-    // meaningless "assets…".
-    minSize: 220,
+    minSize: COLUMN_MIN_SIZES.account,
     header: ({ column }) => <AppColumnHeader column={column} title="Account" />,
     // The leading legs only (splitPostings) — one pill per line; expanding
     // the row appends the folded legs to the same stack, so the unfolded
@@ -226,9 +222,7 @@ const columns: ColumnDef<DataGridFeatures, LedgerTransaction>[] = [
       );
     },
     size: 150,
-    // Data-fit floor: a typical formatted amount ("5,414.60 EUR") stays
-    // readable at the minimum (the other minimums are header-fit).
-    minSize: 140,
+    minSize: COLUMN_MIN_SIZES.amount,
     header: ({ column }) => <AppColumnHeader column={column} title="Amount" className="justify-end" />,
     cell: ({ row }) => {
       const { shown, hidden } = splitPostings(row.original.postings);
@@ -278,7 +272,7 @@ const columns: ColumnDef<DataGridFeatures, LedgerTransaction>[] = [
       return statuses.length === 0 || statuses.includes(row.original.status);
     },
     size: 100,
-    minSize: 94,
+    minSize: COLUMN_MIN_SIZES.status,
     header: ({ column }) => <AppColumnHeader column={column} title="Status" />,
     cell: ({ row }) => <div className={LINE}>{row.original.status}</div>,
     meta: {
@@ -292,7 +286,7 @@ const columns: ColumnDef<DataGridFeatures, LedgerTransaction>[] = [
     accessorFn: (row) => row.note,
     sortFn: "text",
     size: 300,
-    minSize: 108,
+    minSize: COLUMN_MIN_SIZES.note,
     header: ({ column }) => <AppColumnHeader column={column} title="Comment" />,
     // Collapsed: one line, ellipsized (full text in the tooltip). Expanded:
     // the whole comment, wrapping at the h-6 line rhythm.
@@ -325,7 +319,7 @@ const columns: ColumnDef<DataGridFeatures, LedgerTransaction>[] = [
     // Facet counts per tag name, one per row (the accessor is sort text).
     getUniqueValues: (row) => [...new Set(row.tags.map((tag) => tag.name))],
     size: 300,
-    minSize: 80,
+    minSize: COLUMN_MIN_SIZES.tags,
     header: ({ column }) => <AppColumnHeader column={column} title="Tags" />,
     // Collapsed: every tag on one line, sharing the width (each pill
     // ellipsizes on its own). Expanded: one tag per line, on the same

--- a/packages/desktop/src/renderer/components/accountant24/transactions-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/transactions-view.tsx
@@ -14,8 +14,7 @@
 // while the register has nothing to show.
 // Data refreshes when the agent finishes a turn while the page is visible.
 
-import type { Column, ColumnDef, ExpandedState, SortingState, Updater } from "@tanstack/react-table";
-import { functionalUpdate } from "@tanstack/react-table";
+import type { Column, ColumnDef, ExpandedState, SortingState } from "@tanstack/react-table";
 import {
   CalendarIcon,
   CircleCheckIcon,
@@ -25,7 +24,8 @@ import {
   ReceiptTextIcon,
   XIcon,
 } from "lucide-react";
-import { type ComponentProps, type FC, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { type ComponentProps, type FC, type ReactNode, useMemo, useRef, useState } from "react";
+import { AppColumnHeader } from "@/components/accountant24/app-column-header";
 import { ColumnsMenu } from "@/components/accountant24/columns-menu";
 import {
   FilterChip,
@@ -37,9 +37,9 @@ import {
 } from "@/components/accountant24/filter-chip";
 import { MentionPill } from "@/components/accountant24/mentions";
 import { PageEmpty } from "@/components/accountant24/page-empty";
-import { useAppTable } from "@/components/accountant24/use-app-table";
+import { useTableConfig } from "@/components/accountant24/table-config";
+import { twoStateSortingChange, useAppTable } from "@/components/accountant24/use-app-table";
 import { DataGrid, DataGridContainer, type DataGridFeatures } from "@/components/reui/data-grid/data-grid";
-import { DataGridColumnHeader } from "@/components/reui/data-grid/data-grid-column-header";
 import { DataGridTable, DataGridTableRowExpand } from "@/components/reui/data-grid/data-grid-table";
 import {
   DataGridTableVirtual,
@@ -57,18 +57,13 @@ import { cn } from "@/lib/utils";
 import type { LedgerPosting, LedgerTransaction, LedgerTransactionStatus } from "@/rpc/types";
 import { POPOVER_WIDTH } from "./popover";
 import { SearchField } from "./search-field";
-import { loadTableConfig, saveTableConfig, type TransactionsTableConfig } from "./transactions-columns";
+import { loadTableConfig, saveTableConfig } from "./transactions-columns";
 import { useTransactions } from "./use-transactions";
 
 /** The tag pill's text, also what search and the Tags sort key see. */
 const tagText = (tag: { name: string; value: string }): string => (tag.value ? `${tag.name}: ${tag.value}` : tag.name);
 
 const compareText = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
-
-/** App-styled sort header: the vendored default hovers a small rounded-lg
- *  secondary box; ours is the ghost-button recipe (muted pill) every other
- *  hoverable control uses. Merged over the vendored classes via cn. */
-const HEADER_CLASS = "rounded-4xl hover:bg-muted data-[state=open]:bg-muted";
 
 /** One posting line inside a cell: a fixed-height line box so the Account
  *  pills and the Amount figures line up row by row across the two columns. */
@@ -143,7 +138,7 @@ const columns: ColumnDef<DataGridFeatures, LedgerTransaction>[] = [
     // Unlike the other minimums (header-fit), dates are fixed-width data:
     // the minimum keeps the full ISO date readable.
     minSize: 104,
-    header: ({ column }) => <DataGridColumnHeader column={column} title="Date" className={HEADER_CLASS} />,
+    header: ({ column }) => <AppColumnHeader column={column} title="Date" />,
     // The journal's own ISO date, verbatim — unambiguous, and what you see
     // is literally what the column sorts by.
     cell: ({ row }) => <div className={LINE}>{row.original.date}</div>,
@@ -159,7 +154,7 @@ const columns: ColumnDef<DataGridFeatures, LedgerTransaction>[] = [
     },
     size: 200,
     minSize: 90,
-    header: ({ column }) => <DataGridColumnHeader column={column} title="Payee" className={HEADER_CLASS} />,
+    header: ({ column }) => <AppColumnHeader column={column} title="Payee" />,
     cell: ({ row }) =>
       row.original.payee ? (
         <div className={LINE}>
@@ -181,7 +176,7 @@ const columns: ColumnDef<DataGridFeatures, LedgerTransaction>[] = [
     getUniqueValues: (row) => row.postings.map((p) => p.account),
     size: 250,
     minSize: 104,
-    header: ({ column }) => <DataGridColumnHeader column={column} title="Account" className={HEADER_CLASS} />,
+    header: ({ column }) => <AppColumnHeader column={column} title="Account" />,
     // The leading legs only (splitPostings) — one pill per line; expanding
     // the row appends the folded legs to the same stack, so the unfolded
     // lines read as part of the row (the virtual table measures the growth).
@@ -229,9 +224,7 @@ const columns: ColumnDef<DataGridFeatures, LedgerTransaction>[] = [
     },
     size: 150,
     minSize: 100,
-    header: ({ column }) => (
-      <DataGridColumnHeader column={column} title="Amount" className={cn(HEADER_CLASS, "justify-end")} />
-    ),
+    header: ({ column }) => <AppColumnHeader column={column} title="Amount" className="justify-end" />,
     cell: ({ row }) => {
       const { shown, hidden } = splitPostings(row.original.postings);
       return (
@@ -281,7 +274,7 @@ const columns: ColumnDef<DataGridFeatures, LedgerTransaction>[] = [
     },
     size: 100,
     minSize: 94,
-    header: ({ column }) => <DataGridColumnHeader column={column} title="Status" className={HEADER_CLASS} />,
+    header: ({ column }) => <AppColumnHeader column={column} title="Status" />,
     cell: ({ row }) => <div className={LINE}>{row.original.status}</div>,
     meta: {
       headerTitle: "Status",
@@ -295,7 +288,7 @@ const columns: ColumnDef<DataGridFeatures, LedgerTransaction>[] = [
     sortFn: "text",
     size: 300,
     minSize: 108,
-    header: ({ column }) => <DataGridColumnHeader column={column} title="Comment" className={HEADER_CLASS} />,
+    header: ({ column }) => <AppColumnHeader column={column} title="Comment" />,
     // Collapsed: one line, ellipsized (full text in the tooltip). Expanded:
     // the whole comment, wrapping at the h-6 line rhythm.
     cell: ({ row }) =>
@@ -328,7 +321,7 @@ const columns: ColumnDef<DataGridFeatures, LedgerTransaction>[] = [
     getUniqueValues: (row) => [...new Set(row.tags.map((tag) => tag.name))],
     size: 300,
     minSize: 80,
-    header: ({ column }) => <DataGridColumnHeader column={column} title="Tags" className={HEADER_CLASS} />,
+    header: ({ column }) => <AppColumnHeader column={column} title="Tags" />,
     // Collapsed: every tag on one line, sharing the width (each pill
     // ellipsizes on its own). Expanded: one tag per line, on the same
     // rhythm as the unfolded account legs.
@@ -372,10 +365,6 @@ const NO_ROWS: LedgerTransaction[] = [];
 /** Registers up to this many rows render directly; the virtualizer's
  *  spacer-and-measure machinery only pays off past it. */
 const VIRTUALIZE_AFTER = 100;
-
-/** How long after the last column change (a resize drag emits one per
- *  pointer move) the table config is written to localStorage. */
-const SAVE_CONFIG_DELAY_MS = 250;
 
 /** A faceted chip wired to its column: reads the picked values and the facet
  *  counts off the column, and writes the filter back. Holds the
@@ -568,7 +557,7 @@ export const TransactionsView: FC<{ now?: Date; active?: boolean }> = ({ now, ac
   // Newest first by default (the payee tiebreak lives in the date column's
   // comparator); the column headers drive every other order.
   const [sorting, setSorting] = useState<SortingState>([{ id: "date", desc: true }]);
-  const [config, setConfig] = useState<TransactionsTableConfig>(loadTableConfig);
+  const { config, applyConfig } = useTableConfig(loadTableConfig, saveTableConfig);
   const [expanded, setExpanded] = useState<ExpandedState>({});
 
   // One lowercased haystack per transaction (payee, comment, every leg's
@@ -584,24 +573,6 @@ export const TransactionsView: FC<{ now?: Date; active?: boolean }> = ({ now, ac
     }
     return texts;
   }, [data]);
-
-  /** Update one config field; persistence follows debounced (below). */
-  const applyConfig = <K extends keyof TransactionsTableConfig>(key: K, updater: Updater<TransactionsTableConfig[K]>) =>
-    setConfig((prev) => ({ ...prev, [key]: functionalUpdate(updater, prev[key]) }));
-
-  // Persist the config debounced: an onChange column resize updates state on
-  // every pointer move, and a synchronous localStorage write per move would
-  // put disk I/O on the drag frame path. One write lands shortly after the
-  // last change; the just-loaded initial config never writes back.
-  const savedConfig = useRef(config);
-  useEffect(() => {
-    if (savedConfig.current === config) return;
-    const timer = setTimeout(() => {
-      savedConfig.current = config;
-      saveTableConfig(config);
-    }, SAVE_CONFIG_DELAY_MS);
-    return () => clearTimeout(timer);
-  }, [config]);
 
   const rows = data ?? NO_ROWS;
 
@@ -629,18 +600,7 @@ export const TransactionsView: FC<{ now?: Date; active?: boolean }> = ({ now, ac
       globalFilter: search,
       expanded,
     },
-    // Two-state sort headers (asc <-> desc), matching Net Worth. The
-    // vendored header's third click clears the sort (journal order — near
-    // enough to the date default to read as a dead click); map that clear
-    // to ascending so a header always just flips direction.
-    onSortingChange: (updater) => {
-      setSorting((prev) => {
-        const next = typeof updater === "function" ? updater(prev) : updater;
-        const cleared = prev[0];
-        if (next.length === 0 && cleared) return [{ id: cleared.id, desc: false }];
-        return next;
-      });
-    },
+    onSortingChange: twoStateSortingChange(setSorting),
     onColumnVisibilityChange: (updater) => applyConfig("visibility", updater),
     onColumnSizingChange: (updater) => applyConfig("sizing", updater),
     onExpandedChange: setExpanded,

--- a/packages/desktop/src/renderer/components/accountant24/transactions-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/transactions-view.tsx
@@ -174,8 +174,13 @@ const columns: ColumnDef<DataGridFeatures, LedgerTransaction>[] = [
     // Facet counts for the filter chip count EVERY leg, matching the
     // filter's any-leg semantics (the accessor covers only the shown leg).
     getUniqueValues: (row) => row.postings.map((p) => p.account),
-    size: 250,
-    minSize: 104,
+    // With the other defaults, fills the 52rem page floor exactly (36 + 120
+    // + 200 + 326 + 150) so the Amount column ends on the toolbar's right
+    // edge instead of leaving slack in the grid's trailing fill column.
+    size: 326,
+    // Readability floor: below this the account pills crush into a
+    // meaningless "assets…".
+    minSize: 220,
     header: ({ column }) => <AppColumnHeader column={column} title="Account" />,
     // The leading legs only (splitPostings) — one pill per line; expanding
     // the row appends the folded legs to the same stack, so the unfolded
@@ -197,8 +202,6 @@ const columns: ColumnDef<DataGridFeatures, LedgerTransaction>[] = [
         </div>
       );
     },
-    // The widest default: account paths are the page's longest text, and the
-    // table sizes itself from the column widths (see getTotalSize below).
     meta: {
       headerTitle: "Account",
       cellClassName: "align-top",
@@ -223,7 +226,9 @@ const columns: ColumnDef<DataGridFeatures, LedgerTransaction>[] = [
       );
     },
     size: 150,
-    minSize: 100,
+    // Data-fit floor: a typical formatted amount ("5,414.60 EUR") stays
+    // readable at the minimum (the other minimums are header-fit).
+    minSize: 140,
     header: ({ column }) => <AppColumnHeader column={column} title="Amount" className="justify-end" />,
     cell: ({ row }) => {
       const { shown, hidden } = splitPostings(row.original.postings);

--- a/packages/desktop/src/renderer/components/accountant24/use-app-table.ts
+++ b/packages/desktop/src/renderer/components/accountant24/use-app-table.ts
@@ -4,7 +4,14 @@
 // Transactions register) build their tables through here so the two
 // vendored-grid facts every page must know are stated once.
 
-import { type TableOptions, useTable } from "@tanstack/react-table";
+import {
+  functionalUpdate,
+  type OnChangeFn,
+  type SortingState,
+  type TableOptions,
+  useTable,
+} from "@tanstack/react-table";
+import type { Dispatch, SetStateAction } from "react";
 import { type DataGridFeatures, dataGridFeatures } from "@/components/reui/data-grid/data-grid";
 
 /** A table on the shared grid feature bundle. Two presets, both about the
@@ -20,4 +27,30 @@ export function useAppTable<TData extends object>(
   options: Omit<TableOptions<DataGridFeatures, TData>, "features">,
 ): ReturnType<typeof useTable<DataGridFeatures, TData>> {
   return useTable({ features: dataGridFeatures, manualPagination: true, ...options });
+}
+
+/** Two-state sort headers (asc <-> desc) over the vendored header's fixed
+ *  asc -> desc -> clear click cycle, shared by the data pages:
+ *  - The clearing third click (journal/report order — near enough to the
+ *    default sort to read as a dead click) maps to ascending, so a header
+ *    always just flips direction.
+ *  - The vendored cycle also ignores `sortDescFirst`; columns listed in
+ *    `descFirst` get their first click (the column newly becoming the sort
+ *    key) rewritten to descending — money columns put the biggest figures
+ *    first. */
+export function twoStateSortingChange(
+  setSorting: Dispatch<SetStateAction<SortingState>>,
+  descFirst: ReadonlySet<string> = new Set(),
+): OnChangeFn<SortingState> {
+  return (updater) =>
+    setSorting((prev) => {
+      const next = functionalUpdate(updater, prev);
+      const cleared = prev[0];
+      if (next.length === 0 && cleared) return [{ id: cleared.id, desc: false }];
+      const first = next[0];
+      if (first && first.id !== cleared?.id && !first.desc && descFirst.has(first.id)) {
+        return [{ id: first.id, desc: true }];
+      }
+      return next;
+    });
 }

--- a/packages/desktop/src/renderer/components/accountant24/use-net-worth.ts
+++ b/packages/desktop/src/renderer/components/accountant24/use-net-worth.ts
@@ -9,8 +9,10 @@ import type { NetWorth } from "@/rpc/types";
 
 /** null = first load in flight; no section rows = loaded but empty (no
  *  journal yet or hledger failed — both render the empty state pointing at
- *  the agent). */
-export function useNetWorth(): NetWorth | null {
+ *  the agent). `active` = the host is visible; while false, the idle-edge
+ *  refresh defers to the next show (see useAgentIdleRefresh). The
+ *  always-visible sidebar badge omits it. */
+export function useNetWorth(active = true): NetWorth | null {
   const [data, setData] = useState<NetWorth | null>(null);
 
   const refresh = useCallback(() => {
@@ -29,10 +31,11 @@ export function useNetWorth(): NetWorth | null {
   }, []);
 
   useEffect(() => refresh(), [refresh]);
-  // Refetch when a turn finishes (it may have posted transactions). Existing
-  // rows stay up while the refresh is in flight, so the list never flickers
-  // back to the skeleton.
-  useAgentIdleRefresh(refresh);
+  // Refetch when a turn finishes (it may have posted transactions) — while
+  // the host is visible; hidden, the refetch waits for the next show.
+  // Existing rows stay up while the refresh is in flight, so the list never
+  // flickers back to the skeleton.
+  useAgentIdleRefresh(refresh, active);
 
   return data;
 }


### PR DESCRIPTION
- Rebuild the Net Worth sections on the same data grid as the Transactions register: sortable pill headers, resizable columns persisted with the column visibility, per-column loading skeletons
- Keep the Net Worth page mounted across view switches and defer its refresh while hidden, like Transactions
- Render Net Worth account cells as the chat's account pills
- Move the column info markers inside the sort header pills
- Serve every tooltip from one app-level provider: 400ms dwell delay, instant open on neighboring tooltips
- Align both pages' tables and summary bands with the toolbar's content edges; fill the default page width exactly
- Clamp stored column widths to each column's minimum; minimums fit the header pill and typical data
- Extract shared `table-config`, `AppColumnHeader`, and `twoStateSortingChange` helpers