### PR TITLE
refactor: say "price" instead of "rate", matching hledger

### DIFF
--- a/packages/desktop/src/main/__tests__/ledger-json.test.ts
+++ b/packages/desktop/src/main/__tests__/ledger-json.test.ts
@@ -529,7 +529,7 @@ describe("parseTransactionsJson()", () => {
   });
 });
 
-// parseLatestPriceTarget reads the journal's de-facto base currency off
+// parseLatestPriceTarget reads the journal's de-facto base commodity off
 // plain `hledger prices` output: the target commodity of the last (latest)
 // declared price, whatever display style the journal gives the amount.
 

--- a/packages/desktop/src/main/ledger-json.ts
+++ b/packages/desktop/src/main/ledger-json.ts
@@ -117,8 +117,8 @@ export function parseBalanceSheetJson(json: string): RawBalanceSheet | null {
 
 /** The target commodity of the journal's latest declared market price — the
  *  last line of `hledger prices` output. This is the journal's de-facto base
- *  currency: the agent records prices toward the user's currency, and it is
- *  the same "latest P directive" rule hledger's own `-V` valuation applies
+ *  commodity: the agent records prices toward the user's main currency, and
+ *  it is the same "latest P directive" rule hledger's own `-V` valuation applies
  *  per commodity, read once for the whole report. The amount's display style
  *  is journal-defined ("0.01 EUR", "EUR0.01", "€0.01"), so the symbol is
  *  whatever remains once the number is stripped away. Null when the journal

--- a/packages/desktop/src/main/ledger.ts
+++ b/packages/desktop/src/main/ledger.ts
@@ -65,9 +65,9 @@ async function ledgerMentions(): Promise<LedgerMentions> {
 }
 
 /** The report's base commodity — the target of the journal's latest
- *  declared market price. The agent records prices toward the user's
- *  currency, so the journal itself answers "which currency is home" and no
- *  currency is hardcoded. When the journal declares no prices, the latest
+ *  declared market price. The agent records prices toward the user's main
+ *  currency, so the journal itself answers which commodity is the base and
+ *  nothing is hardcoded. When the journal declares no prices, the latest
  *  cost-inferred price (`--infer-market-prices`, e.g. `2 WRLD @ 210.00 EUR`)
  *  answers instead. The probes stay sequential so a later-dated cost can
  *  never out-rank a declared price. Seam for the future default-currency
@@ -84,12 +84,12 @@ async function resolveBaseCommodity(): Promise<string | null> {
  *  hledger), each with hledger's own total, plus the hledger-computed net.
  *  Run twice — native holdings and the market valuation — and paired. With a
  *  base commodity the valued run is `-X <base> --infer-market-prices`, which
- *  collapses multi-commodity holdings to one base-currency figure wherever
+ *  collapses multi-commodity holdings to one base-commodity figure wherever
  *  hledger finds any price path (direct, reverse, chained, or cost-
  *  inferred); with no prices at all there is nothing to aim at, and `-V`
  *  lets hledger value what it can. The payload carries the base commodity
  *  (the `-X` target; null on the `-V` path) so the renderer can lead a
- *  multi-commodity figure with the home-currency leg. Each row also carries
+ *  multi-commodity figure with the base-commodity leg. Each row also carries
  *  the date and amount of the account's latest balance assertion (from
  *  `print -O json`) — when the balance was last reconciled and what it was
  *  confirmed to be. Empty when there's no journal yet or hledger fails. */

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-view.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-view.test.tsx
@@ -271,7 +271,7 @@ describe("<NetWorthView />", () => {
   });
 
   it("should show an unconverted multi-commodity net comma-joined, without ~", async () => {
-    // No rates in the journal: the valued run returns the same figures.
+    // No prices in the journal: the valued run returns the same figures.
     vi.mocked(ledgerApi.netWorth).mockResolvedValue({
       ...DATA,
       net: { amounts: [A("EUR", 7796.25), A("UAH", 1000)], value: [A("EUR", 7796.25), A("UAH", 1000)] },
@@ -329,10 +329,10 @@ describe("<NetWorthView />", () => {
     renderView();
     await screen.findByText("2,050.00 UAH");
     await userEvent.hover(screen.getByRole("button", { name: "About other currencies" }));
-    expect(await screen.findByText("No rate recorded yet to value these in your main currency.")).toBeInTheDocument();
+    expect(await screen.findByText("No price recorded yet to value these in your main currency.")).toBeInTheDocument();
     // The same how-to line as the Value column help: the fix, not just the fact.
     expect(
-      screen.getByText(/To update a rate, tell the agent what one unit of the holding is worth/),
+      screen.getByText(/To update a price, tell the agent what one unit of the holding is worth/),
     ).toBeInTheDocument();
   });
 
@@ -552,11 +552,11 @@ describe("<NetWorthView />", () => {
       await hoverInfo("Value");
       expect(
         await screen.findByText(
-          /What the holding is worth in your main currency, at the latest rate recorded in the ledger/,
+          /What the holding is worth in your main currency, at the latest price recorded in the ledger/,
         ),
       ).toBeInTheDocument();
       expect(screen.getByText(/~ means the value was converted and is an estimate/)).toBeInTheDocument();
-      // The tooltip also teaches how to refresh a rate.
+      // The tooltip also teaches how to refresh a price.
       expect(screen.getByText(/1 USD is 0.92 EUR/)).toBeInTheDocument();
     });
 

--- a/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
@@ -12,7 +12,7 @@
 // every section by account path, and a Columns menu toggling the two
 // assertion columns across every section at once. Complete account paths
 // in one color, every native holding in the Holding column, the market
-// value (hledger's `-X` valuation in the base currency) in the Value
+// value (hledger's `-X` valuation in the base commodity) in the Value
 // column; every column sorts, A-Z on the account path by default,
 // independently per section. All figures are hledger-computed; only the
 // presentation happens here. Data refreshes when the agent finishes a turn.
@@ -53,12 +53,12 @@ type OptionalColumnId = "asserted" | "assertedAmount";
 const ASSERTED_ON_LABEL = "Asserted On";
 const ASSERTED_AMOUNT_LABEL = "Asserted Amount";
 
-/** The how-to line for anything valued at a recorded rate — shared by the
+/** The how-to line for anything valued at a recorded price — shared by the
  *  Value column help and the bands' unpriced-legs tooltip so the copy stays
  *  identical in both. */
-const RATE_HELP = (
+const PRICE_HELP = (
   <p className="mt-1.5">
-    To update a rate, tell the agent what one unit of the holding is worth now in your main currency, for example: "1
+    To update a price, tell the agent what one unit of the holding is worth now in your main currency, for example: "1
     USD is 0.92 EUR."
   </p>
 );
@@ -93,10 +93,10 @@ const COLUMN_HELP: Record<string, ReactNode> = {
   Value: (
     <div>
       <p>
-        What the holding is worth in your main currency, at the latest rate recorded in the ledger. A ~ means the value
+        What the holding is worth in your main currency, at the latest price recorded in the ledger. A ~ means the value
         was converted and is an estimate.
       </p>
-      {RATE_HELP}
+      {PRICE_HELP}
     </div>
   ),
 };
@@ -321,7 +321,7 @@ const AccountsGrid: FC<{
 const BAND_CLASS = "flex items-center justify-between gap-8 rounded-xl bg-muted/50 px-5 py-4";
 
 /** A summary band's figure. When the valuation could not fold every leg
- *  into the base currency, the base leg leads at the band's weight and the
+ *  into the base commodity, the base leg leads at the band's weight and the
  *  leftover legs sit smaller and muted on their own line under it, marked
  *  with the same info icon as the column help. A figure with no split
  *  renders exactly as before. */
@@ -338,8 +338,8 @@ const BandValue: FC<{ figure: NetWorthTotal; baseCommodity: string | null }> = (
           {/* One wrapper like every COLUMN_HELP entry: the tooltip content
               lays its direct children out in a row. */}
           <div>
-            <p>No rate recorded yet to value these in your main currency.</p>
-            {RATE_HELP}
+            <p>No price recorded yet to value these in your main currency.</p>
+            {PRICE_HELP}
           </div>
         </InfoTip>
         <span className="text-sm font-medium text-muted-foreground">{tail}</span>

--- a/packages/desktop/src/renderer/lib/__tests__/amountFormat.test.ts
+++ b/packages/desktop/src/renderer/lib/__tests__/amountFormat.test.ts
@@ -135,7 +135,7 @@ describe("isConverted()", () => {
 });
 
 describe("formatValue()", () => {
-  it("should prefix a converted figure with ~ (an estimate at the last recorded rate)", () => {
+  it("should prefix a converted figure with ~ (an estimate at the last recorded price)", () => {
     expect(formatValue({ amounts: [a("UAH", 1408.26), a("USD", 100)], value: [a("EUR", 115.573, 3)] }, "en-US")).toBe(
       "~115.57 EUR",
     );

--- a/packages/desktop/src/renderer/lib/amountFormat.ts
+++ b/packages/desktop/src/renderer/lib/amountFormat.ts
@@ -58,7 +58,7 @@ export function isConverted({ amounts, value }: ValuedFigure): boolean {
 }
 
 /** Format a figure's market-value line. Converted figures get a leading "~":
- *  they are estimates at the last rate recorded in the ledger, not exact
+ *  they are estimates at the last price recorded in the ledger, not exact
  *  balances. A figure the valuation left untouched renders without it. */
 export function formatValue(figure: ValuedFigure, locale?: string): string {
   return `${isConverted(figure) ? "~" : ""}${formatAmounts(figure.value, "value", locale)}`;

--- a/packages/desktop/src/shared/types.ts
+++ b/packages/desktop/src/shared/types.ts
@@ -34,7 +34,7 @@ export interface AccountBalance {
   /** The balance in its original commodities, one entry per commodity. */
   amounts: LedgerAmount[];
   /** The same balance at market value (`-X` valuation) — a single
-   *  base-currency figure when hledger finds a price path, otherwise equal
+   *  base-commodity figure when hledger finds a price path, otherwise equal
    *  to `amounts`. This is the primary number the report views show. */
   value: LedgerAmount[];
   /** ISO date of the account's most recent balance assertion in the journal
@@ -73,7 +73,7 @@ export interface NetWorth {
   /** The valuation's base commodity: the `-X` target resolved from the
    *  journal's declared or cost-inferred prices. Null when valuation fell
    *  back to `-V`. Lets the renderer lead a multi-commodity figure with the
-   *  home-currency leg. */
+   *  base-commodity leg. */
   baseCommodity: string | null;
 }
 

--- a/packages/pi-extension/src/ledger/__tests__/transactions.test.ts
+++ b/packages/pi-extension/src/ledger/__tests__/transactions.test.ts
@@ -196,94 +196,100 @@ describe("addBalanceAssertions()", () => {
 // ── Market prices (standalone P directives) ─────────────────────────
 
 describe("addPrices()", () => {
-  const rate = {
+  const usdPrice = {
     date: "2026-03-15",
     commodity: "USD",
-    price: { amount: 0.87, currency: "EUR" },
+    price: { amount: 0.87, commodity: "EUR" },
   };
 
   test("should format the P directive verbatim", async () => {
     writeFileSync(join(LEDGER, "main.journal"), "");
-    const result = await addPrices([rate]);
+    const result = await addPrices([usdPrice]);
     expect(result.ledgerIsValid).toBe(true);
     expect(result.transactions[0].transactionText).toBe("P 2026-03-15 USD 0.87 EUR");
   });
 
   test("should double-quote a commodity containing digits, as hledger requires", async () => {
     writeFileSync(join(LEDGER, "main.journal"), "");
-    const result = await addPrices([{ ...rate, commodity: "SOL2" }]);
+    const result = await addPrices([{ ...usdPrice, commodity: "SOL2" }]);
     expect(result.transactions[0].transactionText).toBe('P 2026-03-15 "SOL2" 0.87 EUR');
   });
 
-  test("should double-quote a target currency containing digits", async () => {
+  test("should double-quote a target commodity containing digits", async () => {
     writeFileSync(join(LEDGER, "main.journal"), "");
-    const result = await addPrices([{ ...rate, price: { amount: 0.87, currency: "SOL2" } }]);
+    const result = await addPrices([{ ...usdPrice, price: { amount: 0.87, commodity: "SOL2" } }]);
     expect(result.transactions[0].transactionText).toBe('P 2026-03-15 USD 0.87 "SOL2"');
   });
 
-  test("should preserve the rate's full precision instead of rounding to 2 decimals", async () => {
+  test("should preserve the price's full precision instead of rounding to 2 decimals", async () => {
     writeFileSync(join(LEDGER, "main.journal"), "");
-    const result = await addPrices([{ ...rate, commodity: "UAH", price: { amount: 0.0205, currency: "EUR" } }]);
+    const result = await addPrices([{ ...usdPrice, commodity: "UAH", price: { amount: 0.0205, commodity: "EUR" } }]);
     expect(result.transactions[0].transactionText).toBe("P 2026-03-15 UAH 0.0205 EUR");
   });
 
-  test("should render a tiny rate in plain decimal, never exponential notation", async () => {
+  test("should render a tiny price in plain decimal, never exponential notation", async () => {
     writeFileSync(join(LEDGER, "main.journal"), "");
-    const result = await addPrices([{ ...rate, commodity: "SAT", price: { amount: 0.0000005, currency: "EUR" } }]);
+    const result = await addPrices([{ ...usdPrice, commodity: "SAT", price: { amount: 0.0000005, commodity: "EUR" } }]);
     expect(result.transactions[0].transactionText).toBe("P 2026-03-15 SAT 0.0000005 EUR");
   });
 
   test("should route each price of a batch to the monthly file of its date", async () => {
     writeFileSync(join(LEDGER, "main.journal"), "");
-    await addPrices([rate, { date: "2026-04-02", commodity: "BTC", price: { amount: 55000, currency: "EUR" } }]);
+    await addPrices([usdPrice, { date: "2026-04-02", commodity: "BTC", price: { amount: 55000, commodity: "EUR" } }]);
     expect(readFileSync(join(LEDGER, "2026", "03.journal"), "utf-8")).toContain("P 2026-03-15 USD 0.87 EUR");
     expect(readFileSync(join(LEDGER, "2026", "04.journal"), "utf-8")).toContain("P 2026-04-02 BTC 55000 EUR");
   });
 
   test("should declare both sides of the price as commodities when missing", async () => {
     writeFileSync(join(LEDGER, "main.journal"), "");
-    await addPrices([{ ...rate, commodity: "BTC" }]);
+    await addPrices([{ ...usdPrice, commodity: "BTC" }]);
     const commodities = readFileSync(join(LEDGER, "commodities.journal"), "utf-8");
     expect(commodities).toContain("commodity BTC");
     expect(commodities).toContain("commodity EUR");
   });
 
   test("should reject a date not in YYYY-MM-DD format", async () => {
-    await expect(addPrices([{ ...rate, date: "March 15" }])).rejects.toThrow("Invalid date format");
+    await expect(addPrices([{ ...usdPrice, date: "March 15" }])).rejects.toThrow("Invalid date format");
   });
 
   test("should reject a missing commodity", async () => {
-    await expect(addPrices([{ ...rate, commodity: "" }])).rejects.toThrow("missing a commodity");
+    await expect(addPrices([{ ...usdPrice, commodity: "" }])).rejects.toThrow("missing `commodity`");
   });
 
   test("should reject a price without an amount", async () => {
-    await expect(addPrices([{ ...rate, price: { currency: "EUR" } }] as any)).rejects.toThrow("missing the amount");
+    await expect(addPrices([{ ...usdPrice, price: { commodity: "EUR" } }] as any)).rejects.toThrow(
+      "missing `price.amount`",
+    );
   });
 
   test("should reject a zero price", async () => {
-    await expect(addPrices([{ ...rate, price: { amount: 0, currency: "EUR" } }])).rejects.toThrow("must be positive");
-  });
-
-  test("should reject a negative price", async () => {
-    await expect(addPrices([{ ...rate, price: { amount: -0.87, currency: "EUR" } }])).rejects.toThrow(
+    await expect(addPrices([{ ...usdPrice, price: { amount: 0, commodity: "EUR" } }])).rejects.toThrow(
       "must be positive",
     );
   });
 
-  test("should reject a price without a currency", async () => {
-    await expect(addPrices([{ ...rate, price: { amount: 0.87 } }] as any)).rejects.toThrow("missing the currency");
+  test("should reject a negative price", async () => {
+    await expect(addPrices([{ ...usdPrice, price: { amount: -0.87, commodity: "EUR" } }])).rejects.toThrow(
+      "must be positive",
+    );
+  });
+
+  test("should reject a price without a quote commodity", async () => {
+    await expect(addPrices([{ ...usdPrice, price: { amount: 0.87 } }] as any)).rejects.toThrow(
+      "missing `price.commodity`",
+    );
   });
 
   test("should point at the offending price when a batch fails validation", async () => {
-    await expect(addPrices([rate, { ...rate, commodity: "" }])).rejects.toThrow(
-      "Price 2: Price is missing a commodity.",
+    await expect(addPrices([usdPrice, { ...usdPrice, commodity: "" }])).rejects.toThrow(
+      "Price 2: Price is missing `commodity`.",
     );
   });
 
   test("should surface hledger's error when the write does not validate", async () => {
     writeFileSync(join(LEDGER, "main.journal"), "");
     vi.mocked(spawnText).mockResolvedValue(makeMockProc(1, "", "commodity check failed"));
-    await expect(addPrices([rate])).rejects.toThrow("commodity check failed");
+    await expect(addPrices([usdPrice])).rejects.toThrow("commodity check failed");
   });
 });
 

--- a/packages/pi-extension/src/ledger/transactions.ts
+++ b/packages/pi-extension/src/ledger/transactions.ts
@@ -28,11 +28,12 @@ export interface AddBalanceAssertionParams {
 }
 
 /** A market price: hledger's P directive, stating what one unit of a
- *  commodity was worth on a date. */
+ *  commodity was worth on a date. Both sides are commodities — the one
+ *  being priced, and the one the price is quoted in. */
 export interface AddPriceParams {
   date: string;
   commodity: string;
-  price: { amount: number; currency: string };
+  price: { amount: number; commodity: string };
 }
 
 export interface AddTransactionsResult {
@@ -84,8 +85,8 @@ export async function addBalanceAssertions(
 export async function addPrices(paramsList: AddPriceParams[], signal?: AbortSignal): Promise<AddTransactionsResult> {
   validateEach(paramsList, validatePriceInputs, "Price");
   const formatted = paramsList.map((params) => routeByMonth(params.date, formatPrice(params)));
-  const currencies = paramsList.flatMap((params) => [params.commodity, params.price.currency]);
-  return persistFormatted(formatted, currencies, signal);
+  const commodities = paramsList.flatMap((params) => [params.commodity, params.price.commodity]);
+  return persistFormatted(formatted, commodities, signal);
 }
 
 async function persistFormatted(
@@ -285,16 +286,16 @@ function validatePriceInputs(params: AddPriceParams): void {
     throw new Error(`Invalid date format: ${params.date}. Expected YYYY-MM-DD.`);
   }
   if (!params.commodity) {
-    throw new Error("Price is missing a commodity.");
+    throw new Error("Price is missing `commodity`.");
   }
   if (params.price?.amount == null) {
-    throw new Error(`Price for ${params.commodity} is missing the amount.`);
+    throw new Error(`Price for ${params.commodity} is missing \`price.amount\`.`);
   }
   if (!(params.price.amount > 0)) {
     throw new Error(`Price for ${params.commodity} must be positive.`);
   }
-  if (!params.price.currency) {
-    throw new Error(`Price for ${params.commodity} is missing the currency.`);
+  if (!params.price.commodity) {
+    throw new Error(`Price for ${params.commodity} is missing \`price.commodity\`.`);
   }
 }
 
@@ -355,9 +356,9 @@ function quoteCommodity(commodity: string): string {
   return /^[\p{L}\p{Sc}]+$/u.test(commodity) ? commodity : `"${commodity}"`;
 }
 
-/** Plain decimal rendering preserving the given precision — market rates
+/** Plain decimal rendering preserving the given precision — market prices
  *  carry meaning in their decimals (0.0205), so no fixed rounding; tiny
- *  rates must never fall into exponential notation. */
+ *  prices must never fall into exponential notation. */
 function formatPriceAmount(amount: number): string {
   const plain = String(amount);
   if (!plain.toLowerCase().includes("e")) return plain;
@@ -365,6 +366,6 @@ function formatPriceAmount(amount: number): string {
 }
 
 function formatPrice(params: AddPriceParams): string {
-  const amount = `${formatPriceAmount(params.price.amount)} ${quoteCommodity(params.price.currency)}`;
+  const amount = `${formatPriceAmount(params.price.amount)} ${quoteCommodity(params.price.commodity)}`;
   return `P ${params.date} ${quoteCommodity(params.commodity)} ${amount}`;
 }

--- a/packages/pi-extension/src/system-prompt/system.md
+++ b/packages/pi-extension/src/system-prompt/system.md
@@ -65,7 +65,7 @@ Your workspace is `~/Accountant24`. All file operations stay within this directo
 
 # Market prices
 
-- When the user states a market rate or asset price (for example "1 USD is 0.92 EUR" or "BTC is 60,000 EUR"), record it with `add_prices`; the latest prices drive the Net Worth valuation.
+- When the user states a commodity's price (for example "1 USD is 0.92 EUR" or "BTC is 60,000 EUR"), record it with `add_prices`; the latest prices drive the Net Worth valuation.
 
 # Memory
 

--- a/packages/pi-extension/src/tools/__tests__/add-prices.test.ts
+++ b/packages/pi-extension/src/tools/__tests__/add-prices.test.ts
@@ -38,15 +38,15 @@ beforeEach(() => {
 const run = (params: any) =>
   addPricesTool.execute("test", params, undefined, undefined, undefined as any) as Promise<any>;
 
-const rate = {
+const usdPrice = {
   date: "2026-03-15",
   commodity: "USD",
-  price: { amount: 0.87, currency: "EUR" },
+  price: { amount: 0.87, commodity: "EUR" },
 };
 
 test("saves a P directive and reports its text", async () => {
   writeFileSync(join(LEDGER, "main.journal"), "");
-  const result = await run({ prices: [rate] });
+  const result = await run({ prices: [usdPrice] });
   const text = result.content[0].text;
   expect(text).toContain("Price saved to");
   expect(text).toContain("P 2026-03-15 USD 0.87 EUR");
@@ -54,7 +54,7 @@ test("saves a P directive and reports its text", async () => {
 
 test("routes the directive to ledger/YYYY/MM.journal and returns diffs in details", async () => {
   writeFileSync(join(LEDGER, "main.journal"), "");
-  const result = await run({ prices: [rate] });
+  const result = await run({ prices: [usdPrice] });
   const filePath = join(LEDGER, "2026", "03.journal");
   expect(existsSync(filePath)).toBe(true);
   expect(readFileSync(filePath, "utf-8")).toContain("P 2026-03-15 USD 0.87 EUR");
@@ -65,7 +65,7 @@ test("routes the directive to ledger/YYYY/MM.journal and returns diffs in detail
 test("reports a numbered list when several prices are saved at once", async () => {
   writeFileSync(join(LEDGER, "main.journal"), "");
   const result = await run({
-    prices: [rate, { date: "2026-03-15", commodity: "BTC", price: { amount: 55000, currency: "EUR" } }],
+    prices: [usdPrice, { date: "2026-03-15", commodity: "BTC", price: { amount: 55000, commodity: "EUR" } }],
   });
   const text = result.content[0].text;
   expect(text).toContain("2 prices saved");

--- a/packages/pi-extension/src/tools/add-prices.ts
+++ b/packages/pi-extension/src/tools/add-prices.ts
@@ -4,12 +4,14 @@ import { type AddTransactionsResult, addPrices } from "../ledger";
 import { TOOL_LABELS } from "../tool-labels";
 
 const Price = Type.Object({
-  date: Type.String({ description: "Date the rate was observed, in YYYY-MM-DD format, usually today" }),
+  date: Type.String({ description: "Date the price was observed, in YYYY-MM-DD format, usually today" }),
   commodity: Type.String({ description: "Commodity being priced, e.g. USD, BTC, AAPL" }),
   price: Type.Object(
     {
       amount: Type.Number({ description: "Price of one unit of the commodity" }),
-      currency: Type.String({ description: "Currency the price is quoted in, e.g. EUR" }),
+      commodity: Type.String({
+        description: "Commodity the price is quoted in, usually the user's main currency, e.g. EUR",
+      }),
     },
     { description: "The market price of one unit of the commodity" },
   ),
@@ -25,10 +27,10 @@ export const addPricesTool: ToolDefinition<typeof Params, AddTransactionsResult>
   description:
     "Record market prices (hledger P directives): what one unit of a commodity was worth on a date. " +
     "Auto-routes to the correct monthly files and validates.",
-  promptSnippet: "Record market prices when the user states a current rate or asset price",
+  promptSnippet: "Record market prices when the user states a commodity's current price",
   promptGuidelines: [
     "Record prices toward the user's main currency; the Net Worth report values every holding at its latest recorded price.",
-    "A price is a standalone P directive, not a transaction. Record one when the user states a rate; purchases already imply prices through their cost.",
+    "A price is a standalone P directive, not a transaction. Record one when the user states a price; purchases already imply prices through their cost.",
   ],
   parameters: Params,
 


### PR DESCRIPTION
- Rename the Net Worth help copy from "rate" to "price" in the Value column tooltip and the
  unpriced-legs tooltip
- Rename `RATE_HELP` to `PRICE_HELP`
- Drop "rate" from the `add_prices` tool schema, prompt snippet, guidelines, and the system prompt,
  using hledger's "commodity" for both sides of a price
- Rename the `add_prices` quote-side field from `price.currency` to `price.commodity`
- Report missing price fields by name: `commodity`, `price.amount`, `price.commodity`
- Settle on "base commodity" in code comments and "main currency" in UI copy, dropping
  "home currency" and "base currency"