### PR TITLE
feat: steer the agent by sending messages while it works

### DIFF
--- a/packages/desktop/src/main/agent/__tests__/agent.integration.test.ts
+++ b/packages/desktop/src/main/agent/__tests__/agent.integration.test.ts
@@ -52,6 +52,9 @@ function makeSession() {
       opts?.preflightResult?.(true);
     }),
     abort: vi.fn(async () => {}),
+    clearQueue: vi.fn((): { steering: string[]; followUp: string[] } => ({ steering: [], followUp: [] })),
+    getSteeringMessages: vi.fn((): readonly string[] => []),
+    getFollowUpMessages: vi.fn((): readonly string[] => []),
     setModel: vi.fn(async () => {}),
     setThinkingLevel: vi.fn(),
     setSessionName: vi.fn(),
@@ -179,6 +182,24 @@ describe("renderer IPC → host → renderer events", () => {
         }),
       },
     ]);
+  });
+
+  it("should round-trip a clear_queue request into a correlated response line", async () => {
+    await setup();
+    invoke("agent_send", { sessionPath: A, command: { type: "get_state", id: "warmup" } });
+    await flush();
+    fixtures[0].sessions.get(A)?.session.clearQueue.mockReturnValueOnce({ steering: ["use 50 EUR"], followUp: [] });
+
+    invoke("agent_send", { sessionPath: A, command: { type: "clear_queue", id: "req-cq" } });
+    await flush();
+
+    expect(rendererLines(A)).toContainEqual({
+      id: "req-cq",
+      type: "response",
+      command: "clear_queue",
+      success: true,
+      data: { steering: ["use 50 EUR"], followUp: [] },
+    });
   });
 
   it("should stream a session's events to the renderer tagged with its path", async () => {

--- a/packages/desktop/src/main/agent/__tests__/host.test.ts
+++ b/packages/desktop/src/main/agent/__tests__/host.test.ts
@@ -16,6 +16,9 @@ function makeSession() {
       opts?.preflightResult?.(true);
     }),
     abort: vi.fn(async () => {}),
+    clearQueue: vi.fn((): { steering: string[]; followUp: string[] } => ({ steering: [], followUp: [] })),
+    getSteeringMessages: vi.fn((): readonly string[] => []),
+    getFollowUpMessages: vi.fn((): readonly string[] => []),
     setModel: vi.fn(async (_model: unknown) => {}),
     setThinkingLevel: vi.fn(),
     setSessionName: vi.fn(),
@@ -237,6 +240,33 @@ describe("commands", () => {
     expect(responses(A)).toEqual([{ id: "1", type: "response", command: "abort", success: true }]);
   });
 
+  it("should clear the session queue and return the cleared messages on clear_queue", async () => {
+    fakes.get(A)?.session.clearQueue.mockReturnValueOnce({ steering: ["use 50 EUR"], followUp: ["and rename it"] });
+    command(A, { type: "clear_queue", id: "1" });
+    await flush();
+    expect(fakes.get(A)?.session.clearQueue).toHaveBeenCalled();
+    expect(responses(A)).toEqual([
+      {
+        id: "1",
+        type: "response",
+        command: "clear_queue",
+        success: true,
+        data: { steering: ["use 50 EUR"], followUp: ["and rename it"] },
+      },
+    ]);
+  });
+
+  it("should respond an error when clearQueue throws", async () => {
+    fakes.get(A)?.session.clearQueue.mockImplementationOnce(() => {
+      throw new Error("session gone");
+    });
+    command(A, { type: "clear_queue", id: "1" });
+    await flush();
+    expect(responses(A)).toEqual([
+      { id: "1", type: "response", command: "clear_queue", success: false, error: "session gone" },
+    ]);
+  });
+
   it("should resolve set_model against the registry and apply it", async () => {
     command(A, { type: "set_model", id: "1", provider: "anthropic", modelId: "claude" });
     await flush();
@@ -312,9 +342,22 @@ describe("commands", () => {
           autoCompactionEnabled: true,
           messageCount: 2,
           pendingMessageCount: 0,
+          steeringMessages: [],
+          followUpMessages: [],
         },
       },
     ]);
+  });
+
+  it("should include pending queued messages in get_state", async () => {
+    fakes.get(A)?.session.getSteeringMessages.mockReturnValueOnce(["use 50 EUR"]);
+    fakes.get(A)?.session.getFollowUpMessages.mockReturnValueOnce(["and rename it"]);
+    command(A, { type: "get_state", id: "1" });
+    await flush();
+    expect(responses(A)[0].data).toMatchObject({
+      steeringMessages: ["use 50 EUR"],
+      followUpMessages: ["and rename it"],
+    });
   });
 
   it("should return the messages on get_messages", async () => {

--- a/packages/desktop/src/main/agent/host/host.ts
+++ b/packages/desktop/src/main/agent/host/host.ts
@@ -21,6 +21,9 @@ export interface HostSession {
     },
   ): Promise<void>;
   abort(): Promise<void>;
+  clearQueue(): { steering: string[]; followUp: string[] };
+  getSteeringMessages(): readonly string[];
+  getFollowUpMessages(): readonly string[];
   setModel(model: unknown): Promise<void>;
   setThinkingLevel(level: never): void;
   setSessionName(name: string): void;
@@ -273,6 +276,12 @@ export class AgentHost {
           this.postEvent(sessionPath, success());
           return;
         }
+        case "clear_queue": {
+          // abort() does not drop queued steering/follow-up messages; the
+          // renderer clears them explicitly when the user stops a run.
+          this.postEvent(sessionPath, success(session.clearQueue()));
+          return;
+        }
         case "set_model": {
           const models = session.modelRuntime.getAvailableSnapshot();
           const model = models.find((m) => m.provider === command.provider && m.id === command.modelId);
@@ -315,6 +324,8 @@ export class AgentHost {
               autoCompactionEnabled: session.autoCompactionEnabled,
               messageCount: session.messages.length,
               pendingMessageCount: session.pendingMessageCount,
+              steeringMessages: session.getSteeringMessages(),
+              followUpMessages: session.getFollowUpMessages(),
             }),
           );
           return;

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/composer-queue.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/composer-queue.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+// Spec for the composer's queued-message chips: one chip per message pending
+// in pi's queue (mid-run sends waiting for the next tool boundary), rendering
+// directives as pills, and nothing at all when the queue is empty.
+
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+// IPC boundary: the mention pill module reads ledger data over the Electron
+// bridge on import; stub it so the chip renders without a main process.
+vi.mock("@/rpc/api", () => ({
+  ledgerApi: { mentions: vi.fn().mockResolvedValue({ accounts: [], payees: [], tags: [] }) },
+}));
+
+import { AssistantRuntimeProvider, type ExternalStoreAdapter, useExternalStoreRuntime } from "@assistant-ui/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { installJsdomPolyfills } from "@/test/jsdomPolyfills";
+import { ComposerQueuedMessages } from "../composer-queue";
+
+beforeAll(() => installJsdomPolyfills());
+afterEach(() => cleanup());
+
+/** A runtime whose queue adapter holds the given pending items. */
+function Chrome({ items }: { items: { id: string; prompt: string }[] }) {
+  const store: ExternalStoreAdapter = {
+    messages: [],
+    isRunning: true,
+    onNew: async () => {},
+    queue: { items, enqueue: () => {}, steer: () => {}, remove: () => {}, clear: () => {} },
+    convertMessage: (m: unknown) => m,
+  } as unknown as ExternalStoreAdapter;
+  const runtime = useExternalStoreRuntime(store);
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <ComposerQueuedMessages />
+    </AssistantRuntimeProvider>
+  );
+}
+
+describe("<ComposerQueuedMessages />", () => {
+  it("should render a chip for each pending queued message", () => {
+    render(
+      <Chrome
+        items={[
+          { id: "steer:0", prompt: "use 50 EUR" },
+          { id: "steer:1", prompt: "and rename it" },
+        ]}
+      />,
+    );
+    expect(screen.getByText("use 50 EUR")).toBeInTheDocument();
+    expect(screen.getByText("and rename it")).toBeInTheDocument();
+  });
+
+  it("should render a skill directive in the queued text as a skill pill", () => {
+    render(<Chrome items={[{ id: "steer:0", prompt: ":skill[pdf] check this" }]} />);
+    const pill = screen.getByText("pdf");
+    expect(pill.closest("[data-directive-type='skill']")).not.toBeNull();
+    expect(screen.getByText("check this")).toBeInTheDocument();
+  });
+
+  it("should render nothing when the queue is empty", () => {
+    const { container } = render(<Chrome items={[]} />);
+    expect(container.querySelector("[data-slot='aui_composer-queue-chip']")).toBeNull();
+  });
+});

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/composer.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/composer.test.tsx
@@ -25,9 +25,11 @@ import {
   type ExternalStoreAdapter,
   SimpleImageAttachmentAdapter,
   ThreadPrimitive,
+  useAui,
   useExternalStoreRuntime,
 } from "@assistant-ui/react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { installJsdomPolyfills } from "@/test/jsdomPolyfills";
 import { Composer, EditComposer, handleComposerFilePaste, isNewChatView } from "../composer";
@@ -157,18 +159,41 @@ const makeDictationAdapter = () => ({
   }),
 });
 
+/** The queue surface production exposes (react-pi's adapter); spies stand in
+ *  so tests can assert the enqueue/clear calls the composer must make. */
+const makeQueueAdapter = (items: { id: string; prompt: string }[] = []) => ({
+  items,
+  enqueue: vi.fn(),
+  steer: vi.fn(),
+  remove: vi.fn(),
+  clear: vi.fn(),
+});
+type QueueAdapter = ReturnType<typeof makeQueueAdapter>;
+
+/** The aui handle of the rendered runtime, for driving composer state the way
+ *  the Lexical input would (jsdom cannot type into Lexical). */
+let aui: ReturnType<typeof useAui> | undefined;
+const CaptureAui = () => {
+  aui = useAui();
+  return null;
+};
+
 function Chrome({
   children,
   isRunning = false,
   messages = [],
   attachments = false,
   dictation = false,
+  queue,
+  onCancel,
 }: {
   children: ReactNode;
   isRunning?: boolean;
   messages?: Msg[];
   attachments?: boolean;
   dictation?: boolean;
+  queue?: QueueAdapter;
+  onCancel?: () => Promise<void>;
 }) {
   const adapters =
     attachments || dictation
@@ -181,11 +206,18 @@ function Chrome({
     messages,
     isRunning,
     onNew: async () => {},
+    ...(onCancel ? { onCancel } : {}),
+    ...(queue ? { queue } : {}),
     convertMessage: (m: unknown) => m,
     adapters,
   } as unknown as ExternalStoreAdapter;
   const runtime = useExternalStoreRuntime(store);
-  return <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>;
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <CaptureAui />
+      {children}
+    </AssistantRuntimeProvider>
+  );
 }
 
 describe("<Composer />", () => {
@@ -212,15 +244,88 @@ describe("<Composer />", () => {
     expect(screen.getByRole("button", { name: "Send message" })).toBeInTheDocument();
   });
 
-  it("should swap the send button for a stop button while the thread is running", () => {
+  it("should show Stop in place of Send while running with an empty composer", () => {
     render(
-      <Chrome isRunning={true}>
+      <Chrome isRunning={true} queue={makeQueueAdapter()}>
         <Composer />
       </Chrome>,
     );
     expect(screen.getByRole("button", { name: "Stop generating" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Send message" })).not.toBeInTheDocument();
   });
+
+  it("should morph Stop into Send when text is entered mid-run", async () => {
+    render(
+      <Chrome isRunning={true} queue={makeQueueAdapter()}>
+        <Composer />
+      </Chrome>,
+    );
+    act(() => aui?.composer().setText("use 50 EUR"));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled());
+    expect(screen.queryByRole("button", { name: "Stop generating" })).not.toBeInTheDocument();
+  });
+
+  it("should morph Send back into Stop when the mid-run text is cleared", async () => {
+    render(
+      <Chrome isRunning={true} queue={makeQueueAdapter()}>
+        <Composer />
+      </Chrome>,
+    );
+    act(() => aui?.composer().setText("use 50 EUR"));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Send message" })).toBeInTheDocument());
+    act(() => aui?.composer().setText(""));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Stop generating" })).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: "Send message" })).not.toBeInTheDocument();
+  });
+
+  it("should enqueue with steer intent when Send is clicked while running", async () => {
+    const queue = makeQueueAdapter();
+    render(
+      <Chrome isRunning={true} queue={queue}>
+        <Composer />
+      </Chrome>,
+    );
+    act(() => aui?.composer().setText("use 50 EUR"));
+    await userEvent.click(await screen.findByRole("button", { name: "Send message" }));
+
+    expect(queue.enqueue).toHaveBeenCalledTimes(1);
+    const [message, options] = queue.enqueue.mock.calls[0];
+    expect(message).toMatchObject({ content: [{ type: "text", text: "use 50 EUR" }] });
+    expect(options).toEqual({ steer: true });
+  });
+
+  it("should enqueue with steer intent when Send is clicked while idle", async () => {
+    // Always-steer by design: pi only reads the flag during a run, so an idle
+    // send is unchanged — and a send racing an unnoticed run start still steers.
+    const queue = makeQueueAdapter();
+    render(
+      <Chrome isRunning={false} queue={queue}>
+        <Composer />
+      </Chrome>,
+    );
+    act(() => aui?.composer().setText("hi"));
+    await userEvent.click(screen.getByRole("button", { name: "Send message" }));
+    expect(queue.enqueue).toHaveBeenCalledTimes(1);
+    expect(queue.enqueue.mock.calls[0][1]).toEqual({ steer: true });
+  });
+
+  it("should restore the pending queued text into the composer when Stop is clicked", async () => {
+    const queue = makeQueueAdapter([{ id: "steer:0", prompt: "use 50 EUR" }]);
+    const onCancel = vi.fn().mockResolvedValue(undefined);
+    render(
+      <Chrome isRunning={true} queue={queue} onCancel={onCancel}>
+        <Composer />
+      </Chrome>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Stop generating" }));
+
+    expect(aui?.composer().getState().text).toBe("use 50 EUR");
+    expect(queue.clear).toHaveBeenCalledWith("cancel-run");
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  // A Stop click with a typed draft is unreachable now (the slot shows Send);
+  // the draft-wins guard is covered by restoreQueuedDraft()'s own unit specs.
 
   it("should route a file paste through the attach handler without inserting text", () => {
     render(

--- a/packages/desktop/src/renderer/components/accountant24/chat-layout.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/chat-layout.tsx
@@ -68,7 +68,14 @@ export function ChatLayout() {
       ]),
     [],
   );
-  const runtime = usePiRuntime({ client, adapters: { attachments } });
+  // onError: mid-run (queued) send failures bypass the transcript's failed
+  // state — the runtime only rolls back its optimistic queue entry — so log
+  // them here; everything else already surfaces on the thread.
+  const runtime = usePiRuntime({
+    client,
+    adapters: { attachments },
+    onError: (error) => console.error("[pi] runtime action failed:", error),
+  });
   const [settingsOpen, setSettingsOpen] = useState(false);
   // Which view fills the inset. The chat is never unmounted (see below); the
   // report pages latch on first open and stay mounted after, so their state

--- a/packages/desktop/src/renderer/components/accountant24/composer-queue.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/composer-queue.tsx
@@ -1,0 +1,27 @@
+// Pending queued messages inside the composer shell: while the agent runs, a
+// mid-run send waits in pi's queue (delivered at the next tool boundary) and
+// shows here as a chip until pi turns it into a real user message. Rendered
+// from `s.composer.queue`, which the react-pi runtime mirrors from pi's
+// queue_update events. No remove control: pi supports no per-item mutation
+// (Stop clears the whole queue and restores the text into the composer).
+
+import { ComposerPrimitive } from "@assistant-ui/react";
+import { CornerDownRightIcon } from "lucide-react";
+import type { FC } from "react";
+import { DirectiveSegments } from "@/components/accountant24/directive-chips";
+
+export const ComposerQueuedMessages: FC = () => (
+  <ComposerPrimitive.Queue>
+    {({ queueItem }) => (
+      <div
+        data-slot="aui_composer-queue-chip"
+        className="bg-muted text-muted-foreground mx-3 mt-2 flex min-w-0 items-center gap-1.5 self-start rounded-lg px-2.5 py-1 text-xs"
+      >
+        <CornerDownRightIcon aria-hidden className="size-3 shrink-0" />
+        <span className="truncate">
+          <DirectiveSegments text={queueItem.prompt} />
+        </span>
+      </div>
+    )}
+  </ComposerPrimitive.Queue>
+);

--- a/packages/desktop/src/renderer/components/accountant24/composer.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/composer.tsx
@@ -10,6 +10,7 @@ import { ArrowUpIcon, MicIcon, SquareIcon } from "lucide-react";
 import type { ClipboardEvent, FC } from "react";
 import { ComposerAddAttachment, ComposerAttachments } from "@/components/accountant24/attachment";
 import { ComposerModelSelector } from "@/components/accountant24/composer-model-selector";
+import { ComposerQueuedMessages } from "@/components/accountant24/composer-queue";
 import { ComposerSkills } from "@/components/accountant24/composer-skills";
 import { DirectiveChip } from "@/components/accountant24/directive-chips";
 import { ComposerMentions } from "@/components/accountant24/mentions";
@@ -17,6 +18,7 @@ import { RotatingPlaceholderInput } from "@/components/accountant24/rotating-pla
 import { TooltipIconButton } from "@/components/accountant24/tooltip-icon-button";
 import { Button } from "@/components/shadcn/button";
 import { InputGroup, InputGroupAddon } from "@/components/shadcn/input-group";
+import { restoreQueuedDraft } from "@/hooks/use-escape-stop";
 
 // Center the composer only for a genuinely new, empty chat. "New chat" is the
 // not-yet-created thread (its id is the runtime's `newThreadId`); switching to an
@@ -64,6 +66,7 @@ export const Composer: FC = () => {
             onPasteCapture={(e) => handleComposerFilePaste(e, aui)}
           >
             <ComposerAttachments />
+            <ComposerQueuedMessages />
             <RotatingPlaceholderInput
               className="aui-composer-input max-h-32 w-full bg-transparent text-base"
               autoFocus
@@ -81,6 +84,7 @@ export const Composer: FC = () => {
 };
 
 const ComposerAction: FC = () => {
+  const aui = useAui();
   return (
     <InputGroupAddon align="block-end" className="aui-composer-action-wrapper justify-between">
       {/* No gap: the attach button's and the model pill's own ghost paddings
@@ -122,8 +126,24 @@ const ComposerAction: FC = () => {
             </ComposerPrimitive.StopDictation>
           </AuiIf>
         </AuiIf>
-        <AuiIf condition={(s) => !s.thread.isRunning}>
-          <ComposerPrimitive.Send asChild>
+        {/* One morphing action slot. While the agent runs with an EMPTY
+            composer the only meaningful action is Stop; the moment text (or an
+            attachment) is entered the slot morphs into Send — a mid-run send
+            is a steering message (pi delivers it after the current tool call
+            and re-plans). Stop stays reachable with a draft via Esc
+            (use-escape-stop) or by clearing the input. */}
+        <AuiIf condition={(s) => !s.thread.isRunning || !s.composer.isEmpty}>
+          {/* The onClick runs before the primitive's built-in send
+              (composeEventHandlers) and preventDefault suppresses it, so every
+              send carries the steer intent — harmless while idle, since pi
+              reads streamingBehavior only during a run. */}
+          <ComposerPrimitive.Send
+            asChild
+            onClick={(e) => {
+              e.preventDefault();
+              aui.composer().send({ steer: true });
+            }}
+          >
             <TooltipIconButton
               tooltip="Send message"
               side="bottom"
@@ -137,17 +157,22 @@ const ComposerAction: FC = () => {
             </TooltipIconButton>
           </ComposerPrimitive.Send>
         </AuiIf>
-        <AuiIf condition={(s) => s.thread.isRunning}>
-          <ComposerPrimitive.Cancel asChild>
-            <Button
+        <AuiIf condition={(s) => s.thread.isRunning && s.composer.isEmpty}>
+          {/* Stop discards a pending (undelivered) steering message; its text
+              goes back into the composer first so nothing typed is lost. Runs
+              before the built-in cancel (queue clear + abort). */}
+          <ComposerPrimitive.Cancel asChild onClick={() => restoreQueuedDraft(aui.composer())}>
+            <TooltipIconButton
+              tooltip="Stop (Esc)"
+              side="bottom"
               type="button"
               variant="default"
               size="icon"
-              className="aui-composer-cancel size-6 p-1"
+              className="aui-composer-cancel"
               aria-label="Stop generating"
             >
               <SquareIcon className="aui-composer-cancel-icon size-2.5 fill-current" />
-            </Button>
+            </TooltipIconButton>
           </ComposerPrimitive.Cancel>
         </AuiIf>
       </div>

--- a/packages/desktop/src/renderer/components/accountant24/directive-chips.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/directive-chips.tsx
@@ -22,9 +22,9 @@ export const DirectiveChip: FC<DirectiveChipProps> = ({ directiveType, label }) 
   <DirectivePill type={directiveType} label={label} />
 );
 
-/** Renders a sent user-message text part, turning directives into the same
- *  inline chips the composer shows (plain text passes through untouched). */
-export const DirectiveText: TextMessagePartComponent = ({ text }) => {
+/** Renders directive-bearing text as inline chips + plain spans — the shared
+ *  body behind sent user messages and the composer's queued-message chip. */
+export const DirectiveSegments: FC<{ text: string }> = ({ text }) => {
   const segments = parseMentions(text);
   if (segments.length === 1 && segments[0]?.kind === "text") {
     return <span className="whitespace-pre-wrap">{text}</span>;
@@ -43,3 +43,7 @@ export const DirectiveText: TextMessagePartComponent = ({ text }) => {
     </>
   );
 };
+
+/** Renders a sent user-message text part, turning directives into the same
+ *  inline chips the composer shows (plain text passes through untouched). */
+export const DirectiveText: TextMessagePartComponent = ({ text }) => <DirectiveSegments text={text} />;

--- a/packages/desktop/src/renderer/components/accountant24/rotating-placeholder.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/rotating-placeholder.tsx
@@ -5,6 +5,8 @@ import { useAuiState } from "@assistant-ui/react";
 import { LexicalComposerInput } from "@assistant-ui/react-lexical";
 import { type ComponentProps, type FC, useEffect, useRef, useState } from "react";
 import { useDeleteLineWithChips } from "@/hooks/use-delete-line-with-chips";
+import { useEscapeStop } from "@/hooks/use-escape-stop";
+import { useSteerEnter } from "@/hooks/use-steer-enter";
 
 const COMPOSER_PLACEHOLDERS = [
   "Write a message...",
@@ -48,6 +50,8 @@ export const RotatingPlaceholderInput: FC<RotatingPlaceholderInputProps> = (prop
   const editorRef = useRef<HTMLDivElement>(null);
   const mainThreadId = useAuiState((s) => s.threads.mainThreadId);
   useDeleteLineWithChips(editorRef);
+  useSteerEnter(editorRef);
+  useEscapeStop(editorRef);
 
   // Refocus the input when switching chats (new or existing) so the user can
   // type immediately — the library's autoFocus only covers the initial mount.

--- a/packages/desktop/src/renderer/hooks/__tests__/use-escape-stop.test.ts
+++ b/packages/desktop/src/renderer/hooks/__tests__/use-escape-stop.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type EscapeStopComposer,
+  escapeStopHandler,
+  makeEscapeStopListener,
+  restoreQueuedDraft,
+} from "../use-escape-stop";
+
+// Spec for Esc while the agent runs: it mirrors the library input's Esc branch
+// (popover plugins first, then cancel when cancellable) and additionally gives
+// a pending queued message's text back to the composer before the cancel.
+
+const makeComposer = (o: { canCancel?: boolean; text?: string; queue?: { id: string; prompt: string }[] } = {}) => {
+  const state = { canCancel: o.canCancel ?? true, text: o.text ?? "", queue: o.queue ?? [] };
+  const composer: EscapeStopComposer = {
+    getState: () => state,
+    setText: vi.fn((text: string) => {
+      state.text = text;
+    }),
+    cancel: vi.fn(),
+  };
+  return composer;
+};
+
+const makeEvent = () => ({ preventDefault: vi.fn() }) as unknown as KeyboardEvent;
+
+const plugin = (consumes: boolean) => ({ handleKeyDown: vi.fn(() => consumes) });
+
+describe("restoreQueuedDraft()", () => {
+  it("should restore the queued text into an empty composer", () => {
+    const composer = makeComposer({ queue: [{ id: "steer:0", prompt: "use 50 EUR" }] });
+    restoreQueuedDraft(composer);
+    expect(composer.setText).toHaveBeenCalledWith("use 50 EUR");
+  });
+
+  it("should join several queued messages with blank lines", () => {
+    const composer = makeComposer({
+      queue: [
+        { id: "steer:0", prompt: "use 50 EUR" },
+        { id: "steer:1", prompt: "and rename it" },
+      ],
+    });
+    restoreQueuedDraft(composer);
+    expect(composer.setText).toHaveBeenCalledWith("use 50 EUR\n\nand rename it");
+  });
+
+  it("should never overwrite a typed draft", () => {
+    const composer = makeComposer({ text: "a fresh draft", queue: [{ id: "steer:0", prompt: "use 50 EUR" }] });
+    restoreQueuedDraft(composer);
+    expect(composer.setText).not.toHaveBeenCalled();
+  });
+
+  it("should do nothing when the queue is empty", () => {
+    const composer = makeComposer();
+    restoreQueuedDraft(composer);
+    expect(composer.setText).not.toHaveBeenCalled();
+  });
+});
+
+describe("escapeStopHandler()", () => {
+  it("should cancel the run and restore the queued text when cancellable", () => {
+    const composer = makeComposer({ queue: [{ id: "steer:0", prompt: "use 50 EUR" }] });
+    const event = makeEvent();
+    expect(escapeStopHandler(event, { composer: () => composer }, [])).toBe(true);
+    expect(composer.setText).toHaveBeenCalledWith("use 50 EUR");
+    expect(composer.cancel).toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it("should keep a typed draft and still cancel", () => {
+    const composer = makeComposer({ text: "a fresh draft", queue: [{ id: "steer:0", prompt: "use 50 EUR" }] });
+    expect(escapeStopHandler(makeEvent(), { composer: () => composer }, [])).toBe(true);
+    expect(composer.setText).not.toHaveBeenCalled();
+    expect(composer.cancel).toHaveBeenCalled();
+  });
+
+  it("should fall through when nothing is cancellable", () => {
+    const composer = makeComposer({ canCancel: false });
+    expect(escapeStopHandler(makeEvent(), { composer: () => composer }, [])).toBe(false);
+    expect(composer.cancel).not.toHaveBeenCalled();
+  });
+
+  it("should let an open popover plugin consume Esc instead of cancelling", () => {
+    const composer = makeComposer();
+    const popover = plugin(true);
+    const event = makeEvent();
+    expect(escapeStopHandler(event, { composer: () => composer }, [popover])).toBe(true);
+    expect(popover.handleKeyDown).toHaveBeenCalledWith(event);
+    expect(composer.cancel).not.toHaveBeenCalled();
+  });
+
+  it("should cancel when no plugin consumes the Esc", () => {
+    const composer = makeComposer();
+    expect(escapeStopHandler(makeEvent(), { composer: () => composer }, [plugin(false)])).toBe(true);
+    expect(composer.cancel).toHaveBeenCalled();
+  });
+
+  it("should cancel on a null event without a preventDefault", () => {
+    const composer = makeComposer();
+    expect(escapeStopHandler(null, { composer: () => composer }, [plugin(true)])).toBe(true);
+    expect(composer.cancel).toHaveBeenCalled();
+  });
+});
+
+describe("makeEscapeStopListener()", () => {
+  it("should read the registry's plugins at key time and cancel", () => {
+    const composer = makeComposer();
+    const popover = plugin(false);
+    const listener = makeEscapeStopListener({ composer: () => composer }, { getPlugins: () => [popover] });
+    expect(listener(makeEvent())).toBe(true);
+    expect(popover.handleKeyDown).toHaveBeenCalled();
+    expect(composer.cancel).toHaveBeenCalled();
+  });
+
+  it("should treat a missing registry as no plugins", () => {
+    const composer = makeComposer();
+    expect(makeEscapeStopListener({ composer: () => composer }, null)(makeEvent())).toBe(true);
+    expect(composer.cancel).toHaveBeenCalled();
+  });
+});

--- a/packages/desktop/src/renderer/hooks/__tests__/use-steer-enter.test.ts
+++ b/packages/desktop/src/renderer/hooks/__tests__/use-steer-enter.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeSteerEnterListener,
+  type SteerEnterAui,
+  type SteerEnterPlugin,
+  steerEnterHandler,
+} from "../use-steer-enter";
+
+// Spec for the mid-run Enter interceptor: while the agent runs, plain Enter
+// sends the composer text as a steering message; every other Enter (idle,
+// modifiers, IME composition, an open popover) falls through to the library
+// input's own handling.
+
+const makeEvent = (overrides: Partial<KeyboardEvent> = {}) =>
+  ({
+    isComposing: false,
+    shiftKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    preventDefault: vi.fn(),
+    ...overrides,
+  }) as unknown as KeyboardEvent;
+
+const makeAui = (isRunning: boolean) => {
+  const send = vi.fn();
+  const aui: SteerEnterAui = {
+    thread: () => ({ getState: () => ({ isRunning }) }),
+    composer: () => ({ send }),
+  };
+  return { aui, send };
+};
+
+const plugin = (consumes: boolean): SteerEnterPlugin => ({ handleKeyDown: vi.fn(() => consumes) });
+
+describe("steerEnterHandler()", () => {
+  it("should let the library handle Enter when the thread is idle", () => {
+    const { aui, send } = makeAui(false);
+    const event = makeEvent();
+    expect(steerEnterHandler(event, aui, [])).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("should send with steer intent when Enter is pressed while the agent runs", () => {
+    const { aui, send } = makeAui(true);
+    const event = makeEvent();
+    expect(steerEnterHandler(event, aui, [])).toBe(true);
+    expect(send).toHaveBeenCalledWith({ steer: true });
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it("should fall through on Shift+Enter while running", () => {
+    const { aui, send } = makeAui(true);
+    expect(steerEnterHandler(makeEvent({ shiftKey: true }), aui, [])).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("should fall through on Ctrl+Enter while running", () => {
+    const { aui, send } = makeAui(true);
+    expect(steerEnterHandler(makeEvent({ ctrlKey: true }), aui, [])).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("should fall through on Meta+Enter while running", () => {
+    const { aui, send } = makeAui(true);
+    expect(steerEnterHandler(makeEvent({ metaKey: true }), aui, [])).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("should fall through while IME composition is active", () => {
+    const { aui, send } = makeAui(true);
+    expect(steerEnterHandler(makeEvent({ isComposing: true }), aui, [])).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("should fall through on a null event", () => {
+    const { aui, send } = makeAui(true);
+    expect(steerEnterHandler(null, aui, [])).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("should let an open popover plugin consume Enter instead of sending", () => {
+    const { aui, send } = makeAui(true);
+    const popover = plugin(true);
+    const event = makeEvent();
+    expect(steerEnterHandler(event, aui, [popover])).toBe(true);
+    expect(popover.handleKeyDown).toHaveBeenCalledWith(event);
+    expect(send).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("should send when no plugin consumes the Enter", () => {
+    const { aui, send } = makeAui(true);
+    const event = makeEvent();
+    expect(steerEnterHandler(event, aui, [plugin(false), plugin(false)])).toBe(true);
+    expect(send).toHaveBeenCalledWith({ steer: true });
+  });
+});
+
+describe("makeSteerEnterListener()", () => {
+  it("should read the registry's plugins at key time and steer", () => {
+    const { aui, send } = makeAui(true);
+    const popover = plugin(false);
+    const listener = makeSteerEnterListener(aui, { getPlugins: () => [popover] });
+    expect(listener(makeEvent())).toBe(true);
+    expect(popover.handleKeyDown).toHaveBeenCalled();
+    expect(send).toHaveBeenCalledWith({ steer: true });
+  });
+
+  it("should treat a missing registry as no plugins", () => {
+    const { aui, send } = makeAui(true);
+    expect(makeSteerEnterListener(aui, null)(makeEvent())).toBe(true);
+    expect(send).toHaveBeenCalledWith({ steer: true });
+  });
+});

--- a/packages/desktop/src/renderer/hooks/use-escape-stop.ts
+++ b/packages/desktop/src/renderer/hooks/use-escape-stop.ts
@@ -1,0 +1,77 @@
+// Esc stops the run (the library input ships cancelOnEscape). With the
+// morphing action slot, Esc is the way to stop while a draft is typed — but
+// the library's own Esc branch clears pi's queue without giving a pending
+// steering message's text back. This CRITICAL-priority handler shadows that
+// branch (Lexical dispatches highest first) to add exactly one step: restore
+// the queued text into the composer before the built-in cancel, the same
+// restore the Stop button does. Popover-open Esc still closes the popover
+// (plugins first); a non-cancellable state falls through untouched.
+
+import { INTERNAL, useAui } from "@assistant-ui/react";
+import { COMMAND_PRIORITY_CRITICAL, KEY_ESCAPE_COMMAND, type LexicalEditor } from "lexical";
+import { type RefObject, useEffect } from "react";
+import type { SteerEnterPlugin, SteerEnterRegistry } from "@/hooks/use-steer-enter";
+
+type LexicalEditorElement = HTMLElement & { __lexicalEditor?: LexicalEditor };
+
+/** The composer surface the restore/cancel path touches, typed structurally
+ *  so tests pass a fake. */
+export interface EscapeStopComposer {
+  getState(): { canCancel: boolean; text: string; queue: readonly { id: string; prompt: string }[] };
+  setText(text: string): void;
+  cancel(): void;
+}
+
+export interface EscapeStopAui {
+  composer(): EscapeStopComposer;
+}
+
+/** Give a pending queued (steering) message's text back to the composer.
+ *  A typed draft wins: a non-empty composer is never overwritten (the queued
+ *  text is dropped with the queue in that case). Shared by the Stop button
+ *  and the Esc handler. */
+export function restoreQueuedDraft(composer: Pick<EscapeStopComposer, "getState" | "setText">): void {
+  const { queue, text } = composer.getState();
+  if (queue.length > 0 && !text.trim()) {
+    composer.setText(queue.map((q) => q.prompt).join("\n\n"));
+  }
+}
+
+/** Exported for tests: the KEY_ESCAPE_COMMAND handler body. Mirrors the
+ *  library's Esc branch (plugins first, then cancel-if-cancellable) with the
+ *  queued-text restore inserted before the cancel. */
+export function escapeStopHandler(
+  event: KeyboardEvent | null,
+  aui: EscapeStopAui,
+  plugins: readonly SteerEnterPlugin[],
+): boolean {
+  if (event) {
+    for (const plugin of plugins) {
+      if (plugin.handleKeyDown(event)) return true;
+    }
+  }
+  const composer = aui.composer();
+  if (!composer.getState().canCancel) return false;
+  restoreQueuedDraft(composer);
+  composer.cancel();
+  event?.preventDefault();
+  return true;
+}
+
+/** Build the Lexical command listener (exported for tests). The plugin list is
+ *  read per keypress, not at registration, so popovers opened later count. */
+export const makeEscapeStopListener =
+  (aui: EscapeStopAui, registry: SteerEnterRegistry | null) =>
+  (event: KeyboardEvent | null): boolean =>
+    escapeStopHandler(event, aui, registry?.getPlugins() ?? []);
+
+/** Wire the handler into the Lexical editor rendered inside `containerRef`. */
+export function useEscapeStop(containerRef: RefObject<HTMLDivElement | null>): void {
+  const aui = useAui();
+  const registry = INTERNAL.useComposerInputPluginRegistryOptional();
+  useEffect(() => {
+    const editor = containerRef.current?.querySelector<LexicalEditorElement>(".aui-lexical-input")?.__lexicalEditor;
+    if (!editor) return;
+    return editor.registerCommand(KEY_ESCAPE_COMMAND, makeEscapeStopListener(aui, registry), COMMAND_PRIORITY_CRITICAL);
+  }, [containerRef, aui, registry]);
+}

--- a/packages/desktop/src/renderer/hooks/use-steer-enter.ts
+++ b/packages/desktop/src/renderer/hooks/use-steer-enter.ts
@@ -1,0 +1,72 @@
+// While the agent runs, plain Enter sends the composer text as a steering
+// message (pi delivers it after the current tool call and re-plans). The
+// library input's own KeyboardPlugin (LexicalComposerInput, priority HIGH)
+// hard-blocks Enter while `thread.isRunning`; this hook registers a
+// KEY_ENTER_COMMAND handler at CRITICAL priority (Lexical dispatches highest
+// first) that takes over ONLY in that blocked case — idle submits, Shift+Enter
+// newlines, and popover navigation all fall through to the library untouched.
+
+import { INTERNAL, useAui } from "@assistant-ui/react";
+import { COMMAND_PRIORITY_CRITICAL, KEY_ENTER_COMMAND, type LexicalEditor } from "lexical";
+import { type RefObject, useEffect } from "react";
+
+/** Lexical exposes the live editor instance on the contenteditable it manages;
+ *  LexicalComposerInput offers no plugin slot, so this is the only way in from
+ *  the outside (same handle as use-delete-line-with-chips). */
+type LexicalEditorElement = HTMLElement & { __lexicalEditor?: LexicalEditor };
+
+/** The aui surface the handler touches, typed structurally so tests pass a fake. */
+export interface SteerEnterAui {
+  thread(): { getState(): { isRunning: boolean } };
+  composer(): { send(options: { steer: boolean }): void };
+}
+
+/** A composer-input plugin (mention/skill popover) that may own the key. */
+export interface SteerEnterPlugin {
+  handleKeyDown(event: KeyboardEvent): boolean;
+}
+
+/** Exported for tests: the KEY_ENTER_COMMAND handler body. Returns true when
+ *  it consumed the Enter (a mid-run steer send), false to fall through. */
+export function steerEnterHandler(
+  event: KeyboardEvent | null,
+  aui: SteerEnterAui,
+  plugins: readonly SteerEnterPlugin[],
+): boolean {
+  if (!event || event.isComposing) return false;
+  if (event.shiftKey || event.ctrlKey || event.metaKey) return false;
+  if (!aui.thread().getState().isRunning) return false;
+  // An open mention/skill popover owns Enter (item selection) — the same
+  // delegation the library input does ahead of its own submit.
+  for (const plugin of plugins) {
+    if (plugin.handleKeyDown(event)) return true;
+  }
+  event.preventDefault();
+  // No-ops on an empty composer (the canSend gate) — Enter then does nothing,
+  // matching the idle behavior.
+  aui.composer().send({ steer: true });
+  return true;
+}
+
+/** The plugin registry surface the listener reads, typed structurally. */
+export interface SteerEnterRegistry {
+  getPlugins(): readonly SteerEnterPlugin[];
+}
+
+/** Build the Lexical command listener (exported for tests). The plugin list is
+ *  read per keypress, not at registration, so popovers opened later count. */
+export const makeSteerEnterListener =
+  (aui: SteerEnterAui, registry: SteerEnterRegistry | null) =>
+  (event: KeyboardEvent | null): boolean =>
+    steerEnterHandler(event, aui, registry?.getPlugins() ?? []);
+
+/** Wire the handler into the Lexical editor rendered inside `containerRef`. */
+export function useSteerEnter(containerRef: RefObject<HTMLDivElement | null>): void {
+  const aui = useAui();
+  const registry = INTERNAL.useComposerInputPluginRegistryOptional();
+  useEffect(() => {
+    const editor = containerRef.current?.querySelector<LexicalEditorElement>(".aui-lexical-input")?.__lexicalEditor;
+    if (!editor) return;
+    return editor.registerCommand(KEY_ENTER_COMMAND, makeSteerEnterListener(aui, registry), COMMAND_PRIORITY_CRITICAL);
+  }, [containerRef, aui, registry]);
+}

--- a/packages/desktop/src/renderer/runtime/__tests__/electronPiClient.test.ts
+++ b/packages/desktop/src/renderer/runtime/__tests__/electronPiClient.test.ts
@@ -40,6 +40,8 @@ const h = vi.hoisted(() => ({
   deleted: [] as string[],
   /** request types that should reject, to exercise error/edge paths. */
   errorTypes: new Set<string>(),
+  /** clear_queue response — per-test override for the cleared texts. */
+  clearQueueResult: { steering: [] as string[], followUp: [] as string[] },
   /** compactionState response — per-test override for the heal-on-subscribe. */
   compaction: undefined as { active: boolean; reason?: string; everCompacted: boolean } | undefined,
   /** skills_list response — feeds the skill_used native/custom lookup. */
@@ -72,6 +74,7 @@ vi.mock("../agentBridge", () => ({
       if (h.errorTypes.has(command.type)) throw new Error(`fail:${command.type}`);
       if (command.type === "get_state") return h.state;
       if (command.type === "get_messages") return { messages: h.messages };
+      if (command.type === "clear_queue") return h.clearQueueResult;
       return {};
     },
     compactionState: () => h.compaction,
@@ -144,6 +147,7 @@ beforeEach(() => {
   h.settingsThrows = false;
   h.deleted.length = 0;
   h.errorTypes = new Set();
+  h.clearQueueResult = { steering: [], followUp: [] };
   h.compaction = undefined;
   resetPendingCompactionMarkers();
   h.state = { model: { provider: "anthropic", id: "claude-x" }, sessionFile: "/ws/sessions/s1.jsonl" };
@@ -372,14 +376,14 @@ describe("createElectronPiClient() analytics", () => {
       const client = createElectronPiClient();
       const snapshot = await client.createThread({});
       await client.sendMessage(snapshot.metadata.id, message("add 12 EUR for coffee"));
-      expect(sentCmds().at(-1)).toMatchObject({ type: "prompt", message: "add 12 EUR for coffee" });
+      expect(requestCmds().at(-1)).toMatchObject({ type: "prompt", message: "add 12 EUR for coffee" });
     });
 
     it("should hoist a skill chip into pi's leading /skill: token on send", async () => {
       const client = createElectronPiClient();
       const snapshot = await client.createThread({});
       await client.sendMessage(snapshot.metadata.id, message(":skill[pdf] summarize this receipt"));
-      expect(sentCmds().at(-1)).toMatchObject({ type: "prompt", message: "/skill:pdf summarize this receipt" });
+      expect(requestCmds().at(-1)).toMatchObject({ type: "prompt", message: "/skill:pdf summarize this receipt" });
     });
 
     it("should collapse pi's expanded skill block back to the directive in transcript snapshots", async () => {
@@ -651,6 +655,26 @@ describe("createElectronPiClient() event mapping", () => {
     expect(events[0]).toMatchObject({ type: "queue_update", steering: ["s1"], followUp: ["f1"] });
   });
 
+  it("should collapse expanded skill blocks in queue_update texts", () => {
+    const { events } = captureLive(createElectronPiClient());
+    emitL({
+      type: "queue_update",
+      steering: ['<skill name="pdf" location="/ws/skills/pdf/SKILL.md">\ninstructions\n</skill>\n\ncheck this'],
+      followUp: ["/skill:pdf later"],
+    });
+    expect(events[0]).toMatchObject({
+      type: "queue_update",
+      steering: [":skill[pdf] check this"],
+      followUp: [":skill[pdf] later"],
+    });
+  });
+
+  it("should forward empty queue_update arrays verbatim", () => {
+    const { events } = captureLive(createElectronPiClient());
+    emitL({ type: "queue_update", steering: [], followUp: [] });
+    expect(events[0]).toMatchObject({ type: "queue_update", steering: [], followUp: [] });
+  });
+
   it("should keep stopReason and errorMessage on a message_end assistant message", () => {
     const { events } = captureLive(createElectronPiClient());
     const msg = { role: "assistant", content: [], stopReason: "error", errorMessage: "boom" };
@@ -792,8 +816,9 @@ describe("createElectronPiClient() per-session routing", () => {
     await client.renameThread(A, "Budget");
     await client.cancelRun(B);
 
-    expect(h.requests.every((r) => r.sessionPath === A)).toBe(true);
-    expect(h.sent).toContainEqual({ sessionPath: B, command: expect.objectContaining({ type: "prompt" }) });
+    // getThread's get_state/get_messages target A; the prompt targets B.
+    expect(h.requests.filter((r) => r.command.type !== "prompt").every((r) => r.sessionPath === A)).toBe(true);
+    expect(h.requests).toContainEqual({ sessionPath: B, command: expect.objectContaining({ type: "prompt" }) });
     expect(h.sent).toContainEqual({
       sessionPath: A,
       command: { type: "set_model", provider: "openai", modelId: "gpt-x" },
@@ -869,7 +894,7 @@ describe("createElectronPiClient() createThread()", () => {
   it("should send the initial message to the freshly minted session", async () => {
     const client = createElectronPiClient();
     await client.createThread({ initialMessage: message("hi") });
-    expect(h.sent).toContainEqual({
+    expect(h.requests).toContainEqual({
       sessionPath: "/ws/sessions/new.jsonl",
       command: expect.objectContaining({ type: "prompt", message: "hi" }),
     });
@@ -960,7 +985,7 @@ describe("createElectronPiClient() getThread() snapshot", () => {
     expect(snap.metadata.status).toBe("idle");
 
     await client.sendMessage("/ws/sessions/old.jsonl", message("continuing"));
-    expect(h.sent).toContainEqual({
+    expect(h.requests).toContainEqual({
       sessionPath: "/ws/sessions/old.jsonl",
       command: expect.objectContaining({ type: "prompt", message: "continuing" }),
     });
@@ -992,6 +1017,44 @@ describe("createElectronPiClient() getThread() snapshot", () => {
     const client = createElectronPiClient();
     const snap = await client.getThread("/ws/sessions/s1.jsonl");
     expect(snap.metadata.title).toBe("Monthly budget");
+  });
+
+  it("should map pending steering and follow-up messages into queuedMessages", async () => {
+    h.state = {
+      model: A_MODEL,
+      sessionFile: "/ws/sessions/s1.jsonl",
+      steeringMessages: ["use 50 EUR"],
+      followUpMessages: ["and rename it"],
+    };
+    const client = createElectronPiClient();
+    const snap = await client.getThread("/ws/sessions/s1.jsonl");
+    expect(snap.metadata.queuedMessages).toEqual([
+      { id: "steer:0", mode: "steer", content: "use 50 EUR" },
+      { id: "followUp:0", mode: "followUp", content: "and rename it" },
+    ]);
+  });
+
+  it("should collapse skill text in queued snapshot messages", async () => {
+    h.state = {
+      model: A_MODEL,
+      sessionFile: "/ws/sessions/s1.jsonl",
+      steeringMessages: ['<skill name="pdf" location="/ws/skills/pdf/SKILL.md">\ninstructions\n</skill>\n\ncheck this'],
+    };
+    const client = createElectronPiClient();
+    const snap = await client.getThread("/ws/sessions/s1.jsonl");
+    expect(snap.metadata.queuedMessages).toEqual([{ id: "steer:0", mode: "steer", content: ":skill[pdf] check this" }]);
+  });
+
+  it("should omit queuedMessages when both queues are empty", async () => {
+    h.state = {
+      model: A_MODEL,
+      sessionFile: "/ws/sessions/s1.jsonl",
+      steeringMessages: [],
+      followUpMessages: [],
+    };
+    const client = createElectronPiClient();
+    const snap = await client.getThread("/ws/sessions/s1.jsonl");
+    expect(snap.metadata).not.toHaveProperty("queuedMessages");
   });
 
   it("should fall back messageCount to the transcript length when pi omits it", async () => {
@@ -1107,6 +1170,43 @@ describe("createElectronPiClient() listThreads()", () => {
   });
 });
 
+describe("createElectronPiClient() sendMessage()", () => {
+  it("should send the prompt as an id-tracked request, never fire-and-forget", async () => {
+    // Regression: a fire-and-forget prompt drops pi's preflight rejection
+    // (e.g. "Agent is already processing") because the response carries no id
+    // to correlate — the failure never reached the UI.
+    const client = createElectronPiClient();
+    await client.sendMessage("/ws/s1.jsonl", message("hi"));
+    expect(requestCmds()).toContainEqual(expect.objectContaining({ type: "prompt", message: "hi" }));
+    expect(sentCmds().some((c) => c.type === "prompt")).toBe(false);
+  });
+
+  it("should reject when pi rejects the prompt preflight", async () => {
+    h.errorTypes.add("prompt");
+    const client = createElectronPiClient();
+    await expect(client.sendMessage("/ws/s1.jsonl", message("hi"))).rejects.toThrow("fail:prompt");
+  });
+
+  it("should forward the steer streaming behavior verbatim on the prompt command", async () => {
+    const client = createElectronPiClient();
+    await client.sendMessage("/ws/s1.jsonl", {
+      content: "use 50 EUR",
+      streamingBehavior: "steer",
+    } as PiSendMessageInput);
+    expect(requestCmds().at(-1)).toMatchObject({
+      type: "prompt",
+      message: "use 50 EUR",
+      streamingBehavior: "steer",
+    });
+  });
+
+  it("should omit streamingBehavior from the prompt command when not queued", async () => {
+    const client = createElectronPiClient();
+    await client.sendMessage("/ws/s1.jsonl", message("hi"));
+    expect(requestCmds().at(-1)).not.toHaveProperty("streamingBehavior");
+  });
+});
+
 describe("createElectronPiClient() thread mutations", () => {
   it("should send abort to the thread's own session on cancelRun", async () => {
     const client = createElectronPiClient();
@@ -1114,9 +1214,38 @@ describe("createElectronPiClient() thread mutations", () => {
     expect(h.sent).toEqual([{ sessionPath: "/ws/s1.jsonl", command: { type: "abort" } }]);
   });
 
-  it("should return empty steering and follow-up queues from clearQueue", async () => {
+  it("should clear pi's queue via the clear_queue command and return the cleared texts", async () => {
+    h.clearQueueResult = { steering: ["use 50 EUR"], followUp: ["and rename it"] };
+    const client = createElectronPiClient();
+    expect(await client.clearQueue("/ws/s1.jsonl")).toEqual({
+      steering: ["use 50 EUR"],
+      followUp: ["and rename it"],
+    });
+    expect(h.requests).toContainEqual({ sessionPath: "/ws/s1.jsonl", command: { type: "clear_queue" } });
+  });
+
+  it("should collapse expanded skill blocks in the cleared queue texts", async () => {
+    h.clearQueueResult = {
+      steering: ['<skill name="pdf" location="/ws/skills/pdf/SKILL.md">\ninstructions\n</skill>\n\ncheck this'],
+      followUp: [],
+    };
+    const client = createElectronPiClient();
+    expect(await client.clearQueue("/ws/s1.jsonl")).toEqual({
+      steering: [":skill[pdf] check this"],
+      followUp: [],
+    });
+  });
+
+  it("should return empty queues when the clear_queue response omits the arrays", async () => {
+    h.clearQueueResult = {} as { steering: string[]; followUp: string[] };
     const client = createElectronPiClient();
     expect(await client.clearQueue("/ws/s1.jsonl")).toEqual({ steering: [], followUp: [] });
+  });
+
+  it("should propagate a clear_queue failure", async () => {
+    h.errorTypes.add("clear_queue");
+    const client = createElectronPiClient();
+    await expect(client.clearQueue("/ws/s1.jsonl")).rejects.toThrow("fail:clear_queue");
   });
 
   it("should send set_thinking_level to the thread's own session", async () => {

--- a/packages/desktop/src/renderer/runtime/electronPiClient.ts
+++ b/packages/desktop/src/renderer/runtime/electronPiClient.ts
@@ -18,6 +18,7 @@ import type {
   PiClientEventBody,
   PiHostUiResponse,
   PiModelInfo,
+  PiQueuedMessage,
   PiRuntimeReadiness,
   PiSendMessageInput,
   PiThinkingLevel,
@@ -25,6 +26,7 @@ import type {
   PiThreadSnapshot,
   PiTranscriptMessage,
 } from "@assistant-ui/react-pi";
+import { piQueueItemId } from "@assistant-ui/react-pi";
 import {
   trackAgentMessageSent,
   trackAgentToolUsed,
@@ -54,6 +56,8 @@ type PiState = {
   sessionId?: string;
   sessionName?: string;
   messageCount?: number;
+  steeringMessages?: string[];
+  followUpMessages?: string[];
 };
 
 /** Session events pi emits that our pinned assistant-ui runtime has no reducer
@@ -178,15 +182,27 @@ export function createElectronPiClient(): PiClient {
     return changed ? ({ ...m, content } as T) : message;
   };
 
+  /** Pending steering/follow-up messages in the shape the runtime's queue
+   *  adapter mirrors — same id scheme as react-pi's own ThreadSupervisor.
+   *  Queued strings arrive post skill-expansion; collapse them like transcript
+   *  user messages so the queue chip renders the `:skill[name]` directive. */
+  const toQueuedMessages = (state: PiState): readonly PiQueuedMessage[] =>
+    [
+      ...(state.steeringMessages ?? []).map((content, i) => ({ mode: "steer" as const, content, i })),
+      ...(state.followUpMessages ?? []).map((content, i) => ({ mode: "followUp" as const, content, i })),
+    ].map(({ mode, content, i }) => ({ id: piQueueItemId(mode, i), mode, content: collapseSkillText(content) }));
+
   const buildSnapshot = (threadId: string, state: PiState, messages: unknown): PiThreadSnapshot => {
     if (state.model) modelByThread.set(threadId, `${state.model.provider}/${state.model.id}`);
     const list = Array.isArray(messages) ? messages.map(collapseUserMessage) : [];
+    const queuedMessages = toQueuedMessages(state);
     return {
       metadata: {
         id: threadId,
         status: running.has(threadId) || state.isStreaming ? "running" : "idle",
         ...(state.sessionName ? { title: mentionsToPlainText(state.sessionName) } : {}),
         ...(state.sessionFile ? { sessionFile: state.sessionFile } : {}),
+        ...(queuedMessages.length > 0 ? { queuedMessages } : {}),
         messageCount: state.messageCount ?? list.length,
         config: state.model
           ? { provider: state.model.provider, modelId: state.model.id, thinkingLevel: state.thinkingLevel }
@@ -236,6 +252,15 @@ export function createElectronPiClient(): PiClient {
         };
       case "tool_execution_end":
         return { type: "tool_execution_end", toolCallId: e.toolCallId, result: e.result, isError: Boolean(e.isError) };
+      case "queue_update":
+        // Queued texts arrive post skill-expansion, like transcript user
+        // messages — collapse them so the composer's queue chip renders the
+        // `:skill[name]` directive instead of pi's expanded block.
+        return {
+          type: "queue_update",
+          steering: e.steering.map(collapseSkillText),
+          followUp: e.followUp.map(collapseSkillText),
+        };
       default: {
         // Forward everything else with its full payload, as node/mapping.ts
         // does — the reducer needs e.g. `agent_end.willRetry` (keeps runStatus
@@ -320,22 +345,39 @@ export function createElectronPiClient(): PiClient {
       const message = hoistSkillDirective(input.content);
       const skillToken = /^\/skill:(\S+)/.exec(message)?.[1];
       if (skillToken) trackSkillByName(skillToken, "manual");
-      running.add(threadId); // optimistic — flips status to running before agent_start arrives
-      await agentBridge.send(threadId, {
-        type: "prompt",
-        message,
-        ...(input.attachments?.length ? { images: input.attachments } : {}),
-        ...(input.streamingBehavior ? { streamingBehavior: input.streamingBehavior } : {}),
-      });
+      running.add(threadId); // optimistic — flips status to running before agent_start arrives; a mid-run send is a no-op here
+      // An id-tracked request, not fire-and-forget: pi's preflight rejection
+      // (e.g. a mid-run send during compaction) must reject this promise so
+      // the runtime rolls back its optimistic message/queue entry.
+      await agentBridge.request<void>(
+        threadId,
+        {
+          type: "prompt",
+          message,
+          ...(input.attachments?.length ? { images: input.attachments } : {}),
+          ...(input.streamingBehavior ? { streamingBehavior: input.streamingBehavior } : {}),
+        },
+        "prompt",
+      );
     },
 
     async cancelRun(threadId) {
       await agentBridge.send(threadId, { type: "abort" });
     },
 
-    async clearQueue() {
-      // pi exposes no clear-and-return; queue is still reflected via queue_update.
-      return { steering: [], followUp: [] };
+    async clearQueue(threadId) {
+      // pi's abort keeps queued messages; clearing is its own command. The
+      // cleared texts go back to the composer, so collapse them like any
+      // transcript user message.
+      const cleared = await agentBridge.request<{ steering?: string[]; followUp?: string[] }>(
+        threadId,
+        { type: "clear_queue" },
+        "clear_queue",
+      );
+      return {
+        steering: (cleared.steering ?? []).map(collapseSkillText),
+        followUp: (cleared.followUp ?? []).map(collapseSkillText),
+      };
     },
 
     async getAvailableModels() {

--- a/packages/desktop/src/renderer/test/jsdomPolyfills.ts
+++ b/packages/desktop/src/renderer/test/jsdomPolyfills.ts
@@ -48,4 +48,10 @@ export function installJsdomPolyfills(): void {
   // on a timer; without the stub every grid test run drowns in unhandled
   // TypeErrors after unmount.
   Element.prototype.getAnimations ??= () => [];
+
+  // jsdom Ranges have no layout: Lexical's scroll-into-view reads the
+  // selection Range's rect whenever the editor is focused and its content
+  // changes (e.g. composer setText in tests).
+  Range.prototype.getBoundingClientRect ??= () =>
+    ({ x: 0, y: 0, width: 0, height: 0, top: 0, right: 0, bottom: 0, left: 0, toJSON: () => ({}) }) as DOMRect;
 }


### PR DESCRIPTION
- Keep the composer active while the agent runs: Enter or Send delivers the message as a steering message at the next tool boundary
- Morph the composer's action button by state: Stop while running with an empty composer, Send as soon as text is entered
- Show pending steering messages as chips above the composer input (`ComposerQueuedMessages`)
- Restore an undelivered queued message's text into the composer on Stop or Esc
- Add a `clear_queue` agent-host command and include pending queue messages in `get_state` snapshots
- Send prompts as id-tracked requests so pi's mid-run rejections reach the renderer instead of being dropped
- Collapse expanded skill blocks in queued and cleared message texts