### PR TITLE
feat: add action buttons to the empty Transactions and Net Worth pages

### DIFF
--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-view.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth-view.test.tsx
@@ -21,7 +21,7 @@ vi.mock("@/rpc/api", () => ({
 }));
 
 import { AssistantRuntimeProvider, type ExternalStoreAdapter, useExternalStoreRuntime } from "@assistant-ui/react";
-import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { ledgerApi } from "@/rpc/api";
@@ -725,6 +725,25 @@ describe("<NetWorthView />", () => {
     vi.mocked(ledgerApi.netWorth).mockRejectedValue(new Error("bridge down"));
     renderView();
     expect(await screen.findByText("No transactions yet")).toBeInTheDocument();
+  });
+
+  it("should fire onNewChat from the empty state's New Chat button", async () => {
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(EMPTY);
+    const onNewChat = vi.fn();
+    render(
+      <Chrome>
+        <NetWorthView onNewChat={onNewChat} />
+      </Chrome>,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "New Chat" }));
+    expect(onNewChat).toHaveBeenCalledTimes(1);
+  });
+
+  it("should show no action button when the page has no onNewChat route", async () => {
+    vi.mocked(ledgerApi.netWorth).mockResolvedValue(EMPTY);
+    renderView();
+    await screen.findByText("No transactions yet");
+    expect(screen.queryByRole("button", { name: "New Chat" })).not.toBeInTheDocument();
   });
 
   it("should refetch the report when the agent goes from running to idle", async () => {

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth.integration.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/net-worth.integration.test.tsx
@@ -21,8 +21,9 @@ vi.mock("@assistant-ui/react", () => ({
   CompositeAttachmentAdapter: class {},
   useAuiState: (sel: (s: unknown) => unknown) => sel({ thread: { isRunning: false } }),
 }));
+const switchToNewThread = vi.hoisted(() => vi.fn());
 vi.mock("@assistant-ui/react-pi", () => ({
-  usePiRuntime: () => ({ threads: { switchToNewThread: vi.fn() } }),
+  usePiRuntime: () => ({ threads: { switchToNewThread } }),
 }));
 vi.mock("@/runtime/electronPiClient", () => ({
   createElectronPiClient: () => ({ getThread: vi.fn() }),
@@ -115,6 +116,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   bridge.reset();
+  switchToNewThread.mockClear();
   bridge.setHandler("update_pending", () => null);
   bridge.setHandler("ledger_net_worth", () => DATA);
   // The Columns choice persists here; every spec starts from the default.
@@ -223,5 +225,24 @@ describe("Net Worth view flow", () => {
 
     expect(await screen.findByText("No transactions yet")).toBeInTheDocument();
     expect(screen.queryByRole("table")).toBeNull();
+  });
+
+  it("should open a new chat from the empty state's New Chat button", async () => {
+    bridge.setHandler("ledger_net_worth", () => ({
+      sections: [],
+      net: { amounts: [], value: [] },
+      baseCommodity: null,
+    }));
+    render(<ChatLayout />);
+    openSheet();
+
+    fireEvent.click(await screen.findByRole("button", { name: "New Chat" }));
+
+    // Back on the chat view, in a fresh thread — the sidebar's New Chat
+    // action, triggered from the report page.
+    const thread = screen.getByTestId("thread");
+    expect((thread.parentElement as HTMLElement).className).not.toContain("hidden");
+    expect(screen.getByRole("button", { name: "Net Worth" })).not.toHaveAttribute("data-active");
+    expect(switchToNewThread).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/page-empty.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/page-empty.test.tsx
@@ -1,12 +1,12 @@
 // @vitest-environment jsdom
 
-// Spec for the shared full-page empty view: the icon, title, and
-// description all come straight from the props — the pages (Transactions,
-// Net Worth) differ only in what they pass.
+// Spec for the shared full-page empty view: the icon, title, description,
+// and the optional action button all come straight from the props — the
+// pages (Transactions, Net Worth) differ only in what they pass.
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { FC } from "react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { PageEmpty } from "../page-empty";
 
 afterEach(() => cleanup());
@@ -21,5 +21,39 @@ describe("<PageEmpty />", () => {
     expect(screen.getByRole("img", { name: "Test icon" })).toBeInTheDocument();
     expect(screen.getByText("Nothing here yet")).toBeInTheDocument();
     expect(screen.getByText("Ask the agent and it will show up")).toBeInTheDocument();
+  });
+
+  it("should render no button when no action is given", () => {
+    render(<PageEmpty icon={TestIcon} title="Nothing here yet" description="Ask the agent and it will show up" />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("should render the action as a button that fires its onClick", () => {
+    const onClick = vi.fn();
+    render(
+      <PageEmpty
+        icon={TestIcon}
+        title="Nothing here yet"
+        description="Ask the agent and it will show up"
+        action={{ label: "Take action", onClick }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Take action" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render the action's icon inside the button when given", () => {
+    const ActionIcon: FC<{ className?: string }> = () => <svg role="img" aria-label="Action icon" />;
+    render(
+      <PageEmpty
+        icon={TestIcon}
+        title="Nothing here yet"
+        description="Ask the agent and it will show up"
+        action={{ label: "Take action", icon: ActionIcon, onClick: vi.fn() }}
+      />,
+    );
+    const button = screen.getByRole("button", { name: /Take action/ });
+    expect(screen.getByRole("img", { name: "Action icon" })).toBeInTheDocument();
+    expect(button).toContainElement(screen.getByRole("img", { name: "Action icon" }));
   });
 });

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/transactions-view.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/transactions-view.test.tsx
@@ -854,6 +854,39 @@ describe("<TransactionsView />", () => {
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
   });
 
+  it("should fire onNewChat from the empty view's New Chat button", async () => {
+    vi.mocked(ledgerApi.transactions).mockResolvedValue([]);
+    const onNewChat = vi.fn();
+    render(
+      <Chrome>
+        <TransactionsView now={NOW} onNewChat={onNewChat} />
+      </Chrome>,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "New Chat" }));
+    expect(onNewChat).toHaveBeenCalledTimes(1);
+  });
+
+  it("should carry the same New Chat button on the unreadable-journal view", async () => {
+    // Checking the journal is an agent job too, so the broken state routes
+    // to a chat the same way the empty one does.
+    vi.mocked(ledgerApi.transactions).mockRejectedValue(new Error("register query failed"));
+    const onNewChat = vi.fn();
+    render(
+      <Chrome>
+        <TransactionsView now={NOW} onNewChat={onNewChat} />
+      </Chrome>,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "New Chat" }));
+    expect(onNewChat).toHaveBeenCalledTimes(1);
+  });
+
+  it("should show no action button when the page has no onNewChat route", async () => {
+    vi.mocked(ledgerApi.transactions).mockResolvedValue([]);
+    renderView();
+    await screen.findByText("No transactions yet");
+    expect(screen.queryByRole("button", { name: "New Chat" })).not.toBeInTheDocument();
+  });
+
   it("should refetch the register when the agent goes from running to idle", async () => {
     vi.mocked(ledgerApi.transactions).mockResolvedValue(DATA);
     const { rerender } = renderView(false);

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/transactions.integration.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/transactions.integration.test.tsx
@@ -20,8 +20,9 @@ vi.mock("@assistant-ui/react", () => ({
   CompositeAttachmentAdapter: class {},
   useAuiState: (sel: (s: unknown) => unknown) => sel({ thread: { isRunning: false } }),
 }));
+const switchToNewThread = vi.hoisted(() => vi.fn());
 vi.mock("@assistant-ui/react-pi", () => ({
-  usePiRuntime: () => ({ threads: { switchToNewThread: vi.fn() } }),
+  usePiRuntime: () => ({ threads: { switchToNewThread } }),
 }));
 vi.mock("@/runtime/electronPiClient", () => ({
   createElectronPiClient: () => ({ getThread: vi.fn() }),
@@ -80,6 +81,7 @@ beforeAll(() => {
 beforeEach(() => {
   window.localStorage.clear();
   bridge.reset();
+  switchToNewThread.mockClear();
   bridge.setHandler("update_pending", () => null);
   // The sidebar's Net Worth badge fetches on layout mount, page open or not.
   bridge.setHandler("ledger_net_worth", () => ({ sections: [], net: { amounts: [], value: [] } }));
@@ -165,5 +167,20 @@ describe("Transactions view flow", () => {
     openPage();
 
     expect(await screen.findByText(/No transactions yet/)).toBeInTheDocument();
+  });
+
+  it("should open a new chat from the empty state's New Chat button", async () => {
+    bridge.setHandler("ledger_transactions", () => []);
+    render(<ChatLayout />);
+    openPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "New Chat" }));
+
+    // Back on the chat view, in a fresh thread — the sidebar's New Chat
+    // action, triggered from the report page.
+    const thread = screen.getByTestId("thread");
+    expect((thread.parentElement as HTMLElement).className).not.toContain("hidden");
+    expect(screen.getByRole("button", { name: "Transactions" })).not.toHaveAttribute("data-active");
+    expect(switchToNewThread).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/desktop/src/renderer/components/accountant24/chat-layout.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/chat-layout.tsx
@@ -95,6 +95,15 @@ export function ChatLayout() {
     setNetWorthMounted(true);
   }, []);
   const showChat = useCallback(() => setView("chat"), []);
+  // The report pages' empty states carry the sidebar's New Chat action:
+  // into a fresh chat with the composer focused, ready to type.
+  const newChatFromPage = useCallback(() => {
+    setView("chat");
+    void runtime.threads.switchToNewThread();
+    // Focus only after React commits the switch — the chat is display:none
+    // while a report page is open, and a hidden input can't take focus.
+    requestAnimationFrame(() => document.querySelector<HTMLElement>(".aui-lexical-input")?.focus());
+  }, [runtime]);
   // Non-null once an update is downloaded and staged; drives the footer banner.
   const updateVersion = useUpdateStatus();
   // Read once on mount; afterwards SidebarResizeHandle mutates the CSS var live.
@@ -228,7 +237,7 @@ export function ChatLayout() {
                   view !== "transactions" && "pointer-events-none invisible opacity-0",
                 )}
               >
-                <TransactionsView active={view === "transactions"} />
+                <TransactionsView active={view === "transactions"} onNewChat={newChatFromPage} />
               </div>
             )}
             {/* Same treatment as Transactions: sort, search, resized
@@ -241,7 +250,7 @@ export function ChatLayout() {
                   view !== "net-worth" && "pointer-events-none invisible opacity-0",
                 )}
               >
-                <NetWorthView active={view === "net-worth"} />
+                <NetWorthView active={view === "net-worth"} onNewChat={newChatFromPage} />
               </div>
             )}
           </SidebarInset>

--- a/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/net-worth-view.tsx
@@ -18,7 +18,7 @@
 // presentation happens here. Data refreshes when the agent finishes a turn.
 
 import type { Column, ColumnDef, SortingState, Updater } from "@tanstack/react-table";
-import { InfoIcon, WalletIcon } from "lucide-react";
+import { InfoIcon, PlusIcon, WalletIcon } from "lucide-react";
 import { type FC, type ReactNode, useState } from "react";
 import { AppColumnHeader } from "@/components/accountant24/app-column-header";
 import { MentionPill } from "@/components/accountant24/mentions";
@@ -393,11 +393,14 @@ const SheetSkeleton: FC<{
 // "No transactions yet", not "no accounts": the default workspace already
 // declares accounts on first start — what an empty report is missing is
 // postings to give them balances.
-const SheetEmpty: FC = () => (
+const SheetEmpty: FC<{ onNewChat?: () => void }> = ({ onNewChat }) => (
   <PageEmpty
     icon={WalletIcon}
     title="No transactions yet"
     description="Ask the agent to record your first transactions and your net worth will show up here"
+    // Asking happens in a chat — the button carries the sidebar's New Chat
+    // action (same label and icon), teaching where that action lives.
+    action={onNewChat && { label: "New Chat", icon: PlusIcon, onClick: onNewChat }}
   />
 );
 
@@ -410,8 +413,9 @@ const SheetEmpty: FC = () => (
  *  column widens the page — past the window width the page scrolls
  *  horizontally, like the Transactions register. `active` = the page is the
  *  visible view; the layout keeps it mounted while hidden, and a hidden
- *  page defers its idle-edge refetches to the next show. */
-export const NetWorthView: FC<{ active?: boolean }> = ({ active = true }) => {
+ *  page defers its idle-edge refetches to the next show. `onNewChat` backs
+ *  the empty state's New Chat button (the layout's new-chat action). */
+export const NetWorthView: FC<{ active?: boolean; onNewChat?: () => void }> = ({ active = true, onNewChat }) => {
   const sheet = useNetWorth(active);
   const [search, setSearch] = useState("");
   // One config (visibility + sizing) drives every section grid and the
@@ -450,7 +454,7 @@ export const NetWorthView: FC<{ active?: boolean }> = ({ active = true }) => {
         {/* The empty view sits directly in the scroll container (not the
             width column) so it can center itself in the body's height. */}
         {sheet !== null && sections.length === 0 ? (
-          <SheetEmpty />
+          <SheetEmpty onNewChat={onNewChat} />
         ) : (
           // The body is exactly as wide as the tables' columns (never below
           // the 52rem page floor — the same span as the toolbar's content

--- a/packages/desktop/src/renderer/components/accountant24/page-empty.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/page-empty.tsx
@@ -1,16 +1,19 @@
 // The dedicated empty view shared by the full-page views (Transactions,
-// Net Worth): the stock shadcn Empty — icon, title, one-line description —
-// vertically centered in the page body. Rendered directly inside the page's
-// scroll container, in place of the content it stands in for.
+// Net Worth): the stock shadcn Empty — icon, title, one-line description,
+// and an optional action button — vertically centered in the page body.
+// Rendered directly inside the page's scroll container, in place of the
+// content it stands in for.
 
 import type { FC } from "react";
-import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/shadcn/empty";
+import { Button } from "@/components/shadcn/button";
+import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/shadcn/empty";
 
 export const PageEmpty: FC<{
   icon: FC<{ className?: string }>;
   title: string;
   description: string;
-}> = ({ icon: Icon, title, description }) => (
+  action?: { label: string; icon?: FC<{ className?: string }>; onClick: () => void };
+}> = ({ icon: Icon, title, description, action }) => (
   // min-h-full (not h-full): Empty is flex-1, so the column centers it in
   // the body's height; a window too short to fit it grows the column past
   // 100% and scrolls instead of clipping the top. The pb-12 biases the
@@ -26,6 +29,14 @@ export const PageEmpty: FC<{
         <EmptyTitle>{title}</EmptyTitle>
         <EmptyDescription>{description}</EmptyDescription>
       </EmptyHeader>
+      {action && (
+        <EmptyContent>
+          <Button size="sm" onClick={action.onClick}>
+            {action.icon && <action.icon />}
+            {action.label}
+          </Button>
+        </EmptyContent>
+      )}
     </Empty>
   </div>
 );

--- a/packages/desktop/src/renderer/components/accountant24/transactions-view.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/transactions-view.tsx
@@ -21,6 +21,7 @@ import {
   CoinsIcon,
   DollarSignIcon,
   FileWarningIcon,
+  PlusIcon,
   ReceiptTextIcon,
   XIcon,
 } from "lucide-react";
@@ -528,29 +529,40 @@ const DateFilterChip: FC<{
  *  while there is nothing to show: search, chips, and column headers say
  *  nothing about an empty journal, so they step aside — the same treatment
  *  as the Net Worth page. An unreadable journal reports an empty register
- *  too, so it lands here with its own wording. */
-const RegisterEmpty: FC<{ failed: boolean }> = ({ failed }) =>
-  failed ? (
+ *  too, so it lands here with its own wording. Both wordings say "ask the
+ *  agent", and asking happens in a chat — so both carry the sidebar's New
+ *  Chat action (same label and icon), teaching where that action lives. */
+const RegisterEmpty: FC<{ failed: boolean; onNewChat?: () => void }> = ({ failed, onNewChat }) => {
+  const action = onNewChat && { label: "New Chat", icon: PlusIcon, onClick: onNewChat };
+  return failed ? (
     <PageEmpty
       icon={FileWarningIcon}
       title="The journal could not be read"
       description="Ask the agent to check the journal"
+      action={action}
     />
   ) : (
     <PageEmpty
       icon={ReceiptTextIcon}
       title="No transactions yet"
       description="Ask the agent to record your first transactions and they will show up here"
+      action={action}
     />
   );
+};
 
 /** The Transactions page, shown in place of the chat thread: pinned title
  *  over the data-table toolbar (search, filter chips, Reset, View) and the
  *  stock data grid. `now` anchors the Date chip's presets (injectable so
  *  tests pin the calendar). `active` = the page is the visible view; the
  *  layout keeps it mounted while hidden, and a hidden page defers its
- *  idle-edge refetches to the next show. */
-export const TransactionsView: FC<{ now?: Date; active?: boolean }> = ({ now, active = true }) => {
+ *  idle-edge refetches to the next show. `onNewChat` backs the empty
+ *  state's New Chat button (the layout's new-chat action). */
+export const TransactionsView: FC<{ now?: Date; active?: boolean; onNewChat?: () => void }> = ({
+  now,
+  active = true,
+  onNewChat,
+}) => {
   const { transactions: data, failed } = useTransactions(active);
   const [search, setSearch] = useState("");
   // Newest first by default (the payee tiebreak lives in the date column's
@@ -762,7 +774,7 @@ export const TransactionsView: FC<{ now?: Date; active?: boolean }> = ({ now, ac
           backdrop covers the rows sliding beneath instead. */}
       <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
         {empty ? (
-          <RegisterEmpty failed={failed} />
+          <RegisterEmpty failed={failed} onNewChat={onNewChat} />
         ) : (
           <>
             {/* The table area is exactly as wide as its columns (never below


### PR DESCRIPTION
- Add a New Chat button to the empty states on the Transactions and Net Worth pages, including the unreadable-journal view
- Match the sidebar's New Chat action: open a fresh chat and focus the composer
- Support an optional action button in `PageEmpty`
- Cover the button with unit and integration tests