### PR TITLE
feat: set initial window size and position and remember user changes

### DIFF
--- a/packages/desktop/src/main/__tests__/window-state.test.ts
+++ b/packages/desktop/src/main/__tests__/window-state.test.ts
@@ -1,0 +1,271 @@
+// Spec for the window size & placement policy: first launch = 80% of the
+// work area capped at 1600×1000 and centered on the active display; later
+// launches restore the saved state when it is still reachable on a
+// connected display; the maximized choice survives a display-layout change.
+// The state file I/O is best-effort and debounced.
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  defaultBounds,
+  isVisibleOnSomeDisplay,
+  loadWindowState,
+  parseWindowState,
+  type Rect,
+  restoreWindowState,
+  type TrackableWindow,
+  trackWindowState,
+} from "../window-state";
+
+describe("defaultBounds()", () => {
+  it("should size to 80% of a laptop work area and center in it", () => {
+    // 1512×950 at y=25 (menu bar): 80% → 1210×760, centered.
+    expect(defaultBounds({ x: 0, y: 25, width: 1512, height: 950 })).toEqual({
+      x: 151,
+      y: 120,
+      width: 1210,
+      height: 760,
+    });
+  });
+
+  it("should cap at 1600×1000 on a large display and stay centered", () => {
+    expect(defaultBounds({ x: 0, y: 25, width: 2560, height: 1415 })).toEqual({
+      x: 480,
+      y: 233,
+      width: 1600,
+      height: 1000,
+    });
+  });
+
+  it("should never go below the window minimums on a tiny display", () => {
+    const bounds = defaultBounds({ x: 0, y: 0, width: 500, height: 400 });
+    expect(bounds.width).toBe(560);
+    expect(bounds.height).toBe(480);
+  });
+
+  it("should center within a secondary display's own offset work area", () => {
+    expect(defaultBounds({ x: 1512, y: 0, width: 1000, height: 800 })).toEqual({
+      x: 1612,
+      y: 80,
+      width: 800,
+      height: 640,
+    });
+  });
+});
+
+describe("parseWindowState()", () => {
+  it("should accept a complete state and default maximized to false", () => {
+    expect(parseWindowState({ x: 10, y: 20, width: 800, height: 600 })).toEqual({
+      x: 10,
+      y: 20,
+      width: 800,
+      height: 600,
+      maximized: false,
+    });
+  });
+
+  it("should keep maximized only when it is literally true", () => {
+    expect(parseWindowState({ x: 0, y: 0, width: 800, height: 600, maximized: true })?.maximized).toBe(true);
+    expect(parseWindowState({ x: 0, y: 0, width: 800, height: 600, maximized: "yes" })?.maximized).toBe(false);
+  });
+
+  it.each([
+    ["null", null],
+    ["a string", "state"],
+    ["a number", 42],
+    ["a missing key", { x: 0, y: 0, width: 800 }],
+    ["a string coordinate", { x: "0", y: 0, width: 800, height: 600 }],
+    ["a non-finite coordinate", { x: Number.NaN, y: 0, width: 800, height: 600 }],
+    ["a sub-minimum width", { x: 0, y: 0, width: 559, height: 600 }],
+    ["a sub-minimum height", { x: 0, y: 0, width: 800, height: 479 }],
+  ])("should reject %s", (_label, raw) => {
+    expect(parseWindowState(raw)).toBeNull();
+  });
+});
+
+describe("isVisibleOnSomeDisplay()", () => {
+  const display: Rect = { x: 0, y: 0, width: 1600, height: 1000 };
+
+  it("should accept a rect fully inside the display", () => {
+    expect(isVisibleOnSomeDisplay({ x: 100, y: 100, width: 800, height: 600 }, [display])).toBe(true);
+  });
+
+  it("should accept a rect with exactly the 160px grabbable overlap", () => {
+    expect(isVisibleOnSomeDisplay({ x: 1440, y: 840, width: 800, height: 600 }, [display])).toBe(true);
+  });
+
+  it("should reject a rect one pixel short of the grabbable overlap", () => {
+    expect(isVisibleOnSomeDisplay({ x: 1441, y: 840, width: 800, height: 600 }, [display])).toBe(false);
+  });
+
+  it("should reject a rect entirely off every display", () => {
+    expect(isVisibleOnSomeDisplay({ x: 1700, y: 0, width: 800, height: 600 }, [display])).toBe(false);
+  });
+
+  it("should accept a rect visible only on a secondary display", () => {
+    const second: Rect = { x: 1600, y: 0, width: 1200, height: 900 };
+    expect(isVisibleOnSomeDisplay({ x: 1700, y: 100, width: 800, height: 600 }, [display, second])).toBe(true);
+  });
+
+  it("should reject everything when no display is connected", () => {
+    expect(isVisibleOnSomeDisplay({ x: 0, y: 0, width: 800, height: 600 }, [])).toBe(false);
+  });
+});
+
+describe("restoreWindowState()", () => {
+  const active: Rect = { x: 0, y: 25, width: 1512, height: 950 };
+  const displays: Rect[] = [{ x: 0, y: 25, width: 1512, height: 950 }];
+
+  it("should restore a saved state that is still visible, maximized included", () => {
+    const saved = { x: 40, y: 50, width: 900, height: 700, maximized: true };
+    expect(restoreWindowState(saved, displays, active)).toEqual({ ...saved, maximized: true });
+  });
+
+  it("should fall back to the centered default when the saved state is off every display", () => {
+    const saved = { x: 5000, y: 5000, width: 900, height: 700 };
+    expect(restoreWindowState(saved, displays, active)).toEqual({ ...defaultBounds(active), maximized: false });
+  });
+
+  it("should keep the maximized choice even when the position is no longer valid", () => {
+    const saved = { x: 5000, y: 5000, width: 900, height: 700, maximized: true };
+    expect(restoreWindowState(saved, displays, active).maximized).toBe(true);
+  });
+
+  it("should fall back to the centered default when nothing was saved", () => {
+    expect(restoreWindowState(null, displays, active)).toEqual({ ...defaultBounds(active), maximized: false });
+  });
+
+  it("should fall back to the centered default when the saved state is malformed", () => {
+    expect(restoreWindowState({ width: "big" }, displays, active)).toEqual({
+      ...defaultBounds(active),
+      maximized: false,
+    });
+  });
+});
+
+describe("state file I/O", () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "a24-window-state-"));
+    file = path.join(dir, "window-state.json");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const fakeWin = (over: Partial<TrackableWindow> = {}) => {
+    const listeners = new Map<string, () => void>();
+    const win: TrackableWindow = {
+      on: (event, listener) => listeners.set(event, listener),
+      getNormalBounds: () => ({ x: 10, y: 20, width: 900, height: 700 }),
+      isMaximized: () => false,
+      isFullScreen: () => false,
+      ...over,
+    };
+    return { win, fire: (event: string) => listeners.get(event)?.() };
+  };
+
+  describe("loadWindowState()", () => {
+    it("should return null when the file does not exist", () => {
+      expect(loadWindowState(file)).toBeNull();
+    });
+
+    it("should return null on unparseable JSON", () => {
+      writeFileSync(file, "{not json");
+      expect(loadWindowState(file)).toBeNull();
+    });
+
+    it("should return the parsed JSON as-is", () => {
+      writeFileSync(file, '{"x":1,"y":2,"width":800,"height":600}');
+      expect(loadWindowState(file)).toEqual({ x: 1, y: 2, width: 800, height: 600 });
+    });
+  });
+
+  describe("trackWindowState()", () => {
+    it("should save the normal bounds half a second after a resize, not immediately", () => {
+      vi.useFakeTimers();
+      const { win, fire } = fakeWin();
+      trackWindowState(win, file);
+      fire("resize");
+      expect(existsSync(file)).toBe(false);
+      vi.advanceTimersByTime(500);
+      expect(JSON.parse(readFileSync(file, "utf8"))).toEqual({
+        x: 10,
+        y: 20,
+        width: 900,
+        height: 700,
+        maximized: false,
+      });
+    });
+
+    it("should collapse a burst of resize/move events into one delayed save", () => {
+      vi.useFakeTimers();
+      const { win, fire } = fakeWin();
+      trackWindowState(win, file);
+      fire("resize");
+      vi.advanceTimersByTime(400);
+      fire("move");
+      vi.advanceTimersByTime(400);
+      expect(existsSync(file)).toBe(false);
+      vi.advanceTimersByTime(100);
+      expect(existsSync(file)).toBe(true);
+    });
+
+    it("should save immediately on close and cancel the pending debounce", () => {
+      vi.useFakeTimers();
+      const { win, fire } = fakeWin();
+      trackWindowState(win, file);
+      fire("resize");
+      fire("close");
+      expect(existsSync(file)).toBe(true);
+      // The debounce was cancelled; nothing rewrites later.
+      writeFileSync(file, "sentinel");
+      vi.advanceTimersByTime(500);
+      expect(readFileSync(file, "utf8")).toBe("sentinel");
+    });
+
+    it("should record maximized (and the normal bounds to restore to) when the window is maximized", () => {
+      const { win, fire } = fakeWin({ isMaximized: () => true });
+      trackWindowState(win, file);
+      fire("close");
+      expect(JSON.parse(readFileSync(file, "utf8"))).toEqual({
+        x: 10,
+        y: 20,
+        width: 900,
+        height: 700,
+        maximized: true,
+      });
+    });
+
+    it("should record fullscreen as maximized, never as a restored fullscreen", () => {
+      const { win, fire } = fakeWin({ isFullScreen: () => true });
+      trackWindowState(win, file);
+      fire("close");
+      expect(JSON.parse(readFileSync(file, "utf8"))).toMatchObject({ maximized: true });
+    });
+
+    it("should create the parent directory when it is missing", () => {
+      const nested = path.join(dir, "deep", "window-state.json");
+      const { win, fire } = fakeWin();
+      trackWindowState(win, nested);
+      fire("close");
+      expect(existsSync(nested)).toBe(true);
+    });
+
+    it("should swallow a failed save instead of crashing the app", () => {
+      // The target path is an existing directory — writeFileSync must throw,
+      // and trackWindowState must absorb it.
+      const asDir = path.join(dir, "state-as-dir");
+      mkdirSync(asDir);
+      const { win, fire } = fakeWin();
+      trackWindowState(win, asDir);
+      expect(() => fire("close")).not.toThrow();
+    });
+  });
+});

--- a/packages/desktop/src/main/__tests__/window.test.ts
+++ b/packages/desktop/src/main/__tests__/window.test.ts
@@ -1,18 +1,25 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // window.ts creates the single app window and wires its security policy:
 // hardened webPreferences, an external-only window-open handler, an
-// off-origin-blocking will-navigate guard, and a CSP for packaged builds.
-// Electron (BrowserWindow + shell) is the faked boundary; the real ./urls
-// helpers make the actual open/navigate/CSP decisions (they're pure and
-// separately tested), so this suite verifies the wiring, not a re-mock of them.
+// off-origin-blocking will-navigate guard, and a CSP for packaged builds —
+// plus the window-state policy (first launch centered on the active
+// display, saved state restored after). Electron (BrowserWindow + screen +
+// app + shell) is the faked boundary; the real ./urls and ./window-state
+// helpers make the actual decisions (pure and separately tested), so this
+// suite verifies the wiring, not a re-mock of them.
 
 type Fn = (...args: unknown[]) => unknown;
 
 const h = vi.hoisted(() => ({
   ctorOpts: undefined as Record<string, unknown> | undefined,
   show: vi.fn(),
+  maximize: vi.fn(),
   once: new Map<string, Fn>(),
+  winOn: new Map<string, Fn>(),
   on: new Map<string, Fn>(),
   windowOpenHandler: undefined as ((d: { url: string }) => { action: string }) | undefined,
   onHeadersReceived: undefined as ((details: unknown, cb: Fn) => void) | undefined,
@@ -20,6 +27,9 @@ const h = vi.hoisted(() => ({
   loadURL: vi.fn(() => Promise.resolve()),
   loadFile: vi.fn(() => Promise.resolve()),
   openExternal: vi.fn(() => Promise.resolve()),
+  // One display: a 2000×1200 work area below a 25px menu bar.
+  workArea: { x: 0, y: 25, width: 2000, height: 1200 },
+  userDataDir: "",
 }));
 
 class FakeBrowserWindow {
@@ -42,9 +52,21 @@ class FakeBrowserWindow {
   loadURL = h.loadURL;
   loadFile = h.loadFile;
   show = h.show;
+  maximize = h.maximize;
   once = (evt: string, fn: Fn) => {
     h.once.set(evt, fn);
   };
+  on = (evt: string, fn: Fn) => {
+    h.winOn.set(evt, fn);
+  };
+  getNormalBounds = () => ({
+    x: (h.ctorOpts?.x as number) ?? 0,
+    y: (h.ctorOpts?.y as number) ?? 0,
+    width: (h.ctorOpts?.width as number) ?? 0,
+    height: (h.ctorOpts?.height as number) ?? 0,
+  });
+  isMaximized = () => false;
+  isFullScreen = () => false;
   constructor(opts: Record<string, unknown>) {
     h.ctorOpts = opts;
   }
@@ -53,6 +75,12 @@ class FakeBrowserWindow {
 vi.mock("electron", () => ({
   BrowserWindow: FakeBrowserWindow,
   shell: { openExternal: h.openExternal },
+  app: { getPath: () => h.userDataDir },
+  screen: {
+    getCursorScreenPoint: () => ({ x: 0, y: 0 }),
+    getDisplayNearestPoint: () => ({ workArea: h.workArea }),
+    getAllDisplays: () => [{ workArea: h.workArea }],
+  },
 }));
 
 let prevRendererUrl: string | undefined;
@@ -62,22 +90,28 @@ async function createWindow() {
   return createWindow();
 }
 
+const stateFile = () => path.join(h.userDataDir, "window-state.json");
+
 beforeEach(() => {
   prevRendererUrl = process.env.ELECTRON_RENDERER_URL;
   h.ctorOpts = undefined;
   h.once.clear();
+  h.winOn.clear();
   h.on.clear();
   h.windowOpenHandler = undefined;
   h.onHeadersReceived = undefined;
   h.currentUrl = "app://index/";
   h.show.mockClear();
+  h.maximize.mockClear();
   h.loadURL.mockClear();
   h.loadFile.mockClear();
   h.openExternal.mockClear();
+  h.userDataDir = mkdtempSync(path.join(tmpdir(), "a24-window-test-"));
   vi.resetModules();
 });
 
 afterEach(() => {
+  rmSync(h.userDataDir, { recursive: true, force: true });
   if (prevRendererUrl === undefined) delete process.env.ELECTRON_RENDERER_URL;
   else process.env.ELECTRON_RENDERER_URL = prevRendererUrl;
 });
@@ -94,17 +128,66 @@ describe("createWindow()", () => {
       expect(String(web.preload)).toMatch(/preload[/\\]index\.mjs$/);
     });
 
-    it("should use the documented size, minimums, and inset title bar and start hidden", async () => {
+    it("should open first launch centered on the active display at the capped default size", async () => {
+      // 2000×1200 work area at y=25: 80% → 1600 wide (at the cap) × 960, centered.
       process.env.ELECTRON_RENDERER_URL = "http://localhost:5173/";
       await createWindow();
       expect(h.ctorOpts).toMatchObject({
-        width: 980,
-        height: 720,
+        x: 200,
+        y: 145,
+        width: 1600,
+        height: 960,
         minWidth: 560,
         minHeight: 480,
         show: false,
         titleBarStyle: "hiddenInset",
         trafficLightPosition: { x: 14, y: 14 },
+      });
+    });
+  });
+
+  describe("window state", () => {
+    it("should reopen at the saved bounds when they are still on a display", async () => {
+      process.env.ELECTRON_RENDERER_URL = "http://localhost:5173/";
+      writeFileSync(stateFile(), JSON.stringify({ x: 40, y: 50, width: 900, height: 700 }));
+      await createWindow();
+      expect(h.ctorOpts).toMatchObject({ x: 40, y: 50, width: 900, height: 700 });
+    });
+
+    it("should fall back to the centered default when the saved bounds are off-screen", async () => {
+      process.env.ELECTRON_RENDERER_URL = "http://localhost:5173/";
+      writeFileSync(stateFile(), JSON.stringify({ x: 9000, y: 9000, width: 900, height: 700 }));
+      await createWindow();
+      expect(h.ctorOpts).toMatchObject({ x: 200, y: 145, width: 1600, height: 960 });
+    });
+
+    it("should re-maximize on ready-to-show when the window was left maximized", async () => {
+      process.env.ELECTRON_RENDERER_URL = "http://localhost:5173/";
+      writeFileSync(stateFile(), JSON.stringify({ x: 40, y: 50, width: 900, height: 700, maximized: true }));
+      await createWindow();
+      expect(h.maximize).not.toHaveBeenCalled();
+      h.once.get("ready-to-show")?.();
+      expect(h.maximize).toHaveBeenCalledTimes(1);
+      expect(h.show).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not maximize a window that was left normal", async () => {
+      process.env.ELECTRON_RENDERER_URL = "http://localhost:5173/";
+      await createWindow();
+      h.once.get("ready-to-show")?.();
+      expect(h.maximize).not.toHaveBeenCalled();
+    });
+
+    it("should persist the window bounds when the window closes", async () => {
+      process.env.ELECTRON_RENDERER_URL = "http://localhost:5173/";
+      await createWindow();
+      h.winOn.get("close")?.();
+      expect(JSON.parse(readFileSync(stateFile(), "utf8"))).toEqual({
+        x: 200,
+        y: 145,
+        width: 1600,
+        height: 960,
+        maximized: false,
       });
     });
   });

--- a/packages/desktop/src/main/window-state.ts
+++ b/packages/desktop/src/main/window-state.ts
@@ -1,0 +1,118 @@
+// Window size & placement policy. First launch opens a large window sized
+// to the display (80% of the work area, capped at 1600×1000), centered on
+// the display the user is working on; afterwards the window reopens exactly
+// where the user left it (size, position, maximized) — the standard desktop
+// convention. Native macOS fullscreen is restored as a maximized window
+// instead: taking over the whole screen stays a per-session user choice.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+export type Rect = { x: number; y: number; width: number; height: number };
+export type WindowState = Rect & { maximized: boolean };
+
+export const MIN_WIDTH = 560;
+export const MIN_HEIGHT = 480;
+
+// 80% of the work area reads as "the app fills my screen" while keeping the
+// desktop visible around it; the cap keeps the window a comfortable reading
+// width on large monitors instead of scaling up forever.
+const WORK_AREA_FRACTION = 0.8;
+const MAX_DEFAULT_WIDTH = 1600;
+const MAX_DEFAULT_HEIGHT = 1000;
+
+/** First-launch bounds: a large window centered in the given work area. */
+export function defaultBounds(workArea: Rect): Rect {
+  const width = Math.max(MIN_WIDTH, Math.min(MAX_DEFAULT_WIDTH, Math.round(workArea.width * WORK_AREA_FRACTION)));
+  const height = Math.max(MIN_HEIGHT, Math.min(MAX_DEFAULT_HEIGHT, Math.round(workArea.height * WORK_AREA_FRACTION)));
+  return {
+    x: workArea.x + Math.round((workArea.width - width) / 2),
+    y: workArea.y + Math.round((workArea.height - height) / 2),
+    width,
+    height,
+  };
+}
+
+/** Parse a saved state file's content, or null when the shape is wrong
+ *  (missing keys, wrong types, non-finite numbers, sub-minimum size). */
+export function parseWindowState(raw: unknown): WindowState | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const isNum = (n: unknown): n is number => typeof n === "number" && Number.isFinite(n);
+  if (!isNum(r.x) || !isNum(r.y) || !isNum(r.width) || !isNum(r.height)) return null;
+  if (r.width < MIN_WIDTH || r.height < MIN_HEIGHT) return null;
+  return { x: r.x, y: r.y, width: r.width, height: r.height, maximized: r.maximized === true };
+}
+
+// A window can be grabbed again if at least this much of it is visible.
+const VISIBLE_PX = 160;
+
+/** Whether a grabbable chunk of the rect is visible on some display —
+ *  monitors come and go between launches, and a window restored onto a
+ *  now-unplugged display would be unreachable. */
+export function isVisibleOnSomeDisplay(rect: Rect, workAreas: Rect[]): boolean {
+  return workAreas.some((wa) => {
+    const overlapW = Math.min(rect.x + rect.width, wa.x + wa.width) - Math.max(rect.x, wa.x);
+    const overlapH = Math.min(rect.y + rect.height, wa.y + wa.height) - Math.max(rect.y, wa.y);
+    return overlapW >= VISIBLE_PX && overlapH >= VISIBLE_PX;
+  });
+}
+
+/** The bounds to open with: the saved state when it is still reachable on a
+ *  connected display, else the first-launch default on the active display.
+ *  A maximized flag survives even when the position does not (the display
+ *  layout changed, but the user's "I keep it maximized" choice did not). */
+export function restoreWindowState(saved: unknown, workAreas: Rect[], activeWorkArea: Rect): WindowState {
+  const state = parseWindowState(saved);
+  if (state && isVisibleOnSomeDisplay(state, workAreas)) return state;
+  return { ...defaultBounds(activeWorkArea), maximized: state?.maximized ?? false };
+}
+
+/** Read the state file's raw JSON (unvalidated — restoreWindowState parses). */
+export function loadWindowState(file: string): unknown {
+  try {
+    if (!existsSync(file)) return null;
+    return JSON.parse(readFileSync(file, "utf8")) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function saveWindowState(file: string, state: WindowState): void {
+  try {
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, `${JSON.stringify(state)}\n`);
+  } catch {
+    // Best-effort: a failed save only costs the next launch's placement.
+  }
+}
+
+/** The window surface trackWindowState needs — structural, so tests can pass
+ *  a plain fake and window.ts passes the real BrowserWindow. */
+export type TrackableWindow = {
+  on(event: "resize" | "move" | "close", listener: () => void): unknown;
+  /** Bounds as if not maximized/fullscreen — the size to un-maximize back to. */
+  getNormalBounds(): Rect;
+  isMaximized(): boolean;
+  isFullScreen(): boolean;
+};
+
+const SAVE_DEBOUNCE_MS = 500;
+
+/** Keep the state file current: debounced on resize/move (a crash loses at
+ *  most the last half-second), final write on close. */
+export function trackWindowState(win: TrackableWindow, file: string): void {
+  let timer: NodeJS.Timeout | undefined;
+  const write = () =>
+    saveWindowState(file, { ...win.getNormalBounds(), maximized: win.isMaximized() || win.isFullScreen() });
+  const debounced = () => {
+    clearTimeout(timer);
+    timer = setTimeout(write, SAVE_DEBOUNCE_MS);
+  };
+  win.on("resize", debounced);
+  win.on("move", debounced);
+  win.on("close", () => {
+    clearTimeout(timer);
+    write();
+  });
+}

--- a/packages/desktop/src/main/window.ts
+++ b/packages/desktop/src/main/window.ts
@@ -1,15 +1,29 @@
 import path from "node:path";
-import { BrowserWindow, shell } from "electron";
+import { app, BrowserWindow, screen, shell } from "electron";
 import { isInternalNavigation, isOpenableExternalUrl, rendererCsp } from "./urls";
+import { loadWindowState, MIN_HEIGHT, MIN_WIDTH, restoreWindowState, trackWindowState } from "./window-state";
+
+// Device-local UI state, so it lives in Electron's per-app userData dir,
+// not in the (portable) Accountant24 workspace.
+const windowStateFile = () => path.join(app.getPath("userData"), "window-state.json");
 
 /** Create the single app window. macOS chrome mirrors the old Tauri config:
- *  inset traffic lights, no native title bar; the renderer paints the top strip. */
+ *  inset traffic lights, no native title bar; the renderer paints the top strip.
+ *  Size/placement policy lives in window-state.ts: first launch large and
+ *  centered on the active display, afterwards wherever the user left it. */
 export function createWindow(): BrowserWindow {
+  // The display the user is working on (cursor), not necessarily the primary.
+  const active = screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).workArea;
+  const workAreas = screen.getAllDisplays().map((d) => d.workArea);
+  const state = restoreWindowState(loadWindowState(windowStateFile()), workAreas, active);
+
   const win = new BrowserWindow({
-    width: 980,
-    height: 720,
-    minWidth: 560,
-    minHeight: 480,
+    x: state.x,
+    y: state.y,
+    width: state.width,
+    height: state.height,
+    minWidth: MIN_WIDTH,
+    minHeight: MIN_HEIGHT,
     show: false,
     titleBarStyle: "hiddenInset",
     trafficLightPosition: { x: 14, y: 14 },
@@ -23,7 +37,12 @@ export function createWindow(): BrowserWindow {
     },
   });
 
-  win.once("ready-to-show", () => win.show());
+  win.once("ready-to-show", () => {
+    // Maximize only here: on a still-hidden window it can force an early show.
+    if (state.maximized) win.maximize();
+    win.show();
+  });
+  trackWindowState(win, windowStateFile());
 
   // Links (target=_blank / window.open) never open as app windows. Only
   // http/https/mailto reach the system browser; every other scheme (file:,


### PR DESCRIPTION
- Open first launch at 80% of the display's work area (capped at 1600×1000), centered on the display the cursor is on
- Restore the window's size, position, and maximized state on later launches
- Fall back to the centered default when the saved position is off every connected display
- Restore fullscreen as a maximized window
- Persist state to `window-state.json` in the app's `userData` dir, debounced on resize/move and on close