### PR TITLE
feat: preselect a default model for connected providers

### DIFF
--- a/packages/desktop/src/main/__tests__/settings.integration.test.ts
+++ b/packages/desktop/src/main/__tests__/settings.integration.test.ts
@@ -59,6 +59,17 @@ describe("settings persistence (real fs)", () => {
     expect(merged).toEqual({ enabledModels: ["a/1", "b/2"], defaultModel: "a/1" });
   });
 
+  it("should drop the default model from the file when it is cleared", async () => {
+    // Removing the last provider clears the default this way; the key must
+    // leave the file rather than persist as a dangling id.
+    await load();
+    set({ defaultModel: "anthropic/opus", enabledModels: ["a/1"] });
+    const merged = set({ defaultModel: undefined });
+    expect(merged.defaultModel).toBeUndefined();
+    expect(readJson("app-settings.json")).toEqual({ enabledModels: ["a/1"] });
+    expect(get()).toEqual({ enabledModels: ["a/1"] });
+  });
+
   it("should ignore foreign (pi) keys present in the file", async () => {
     await load();
     // Seed the file with an app key + a pi-owned key.

--- a/packages/desktop/src/main/llm-providers/__tests__/auth.test.ts
+++ b/packages/desktop/src/main/llm-providers/__tests__/auth.test.ts
@@ -44,6 +44,9 @@ vi.mock("@earendil-works/pi-coding-agent", () => ({
   ModelRuntime: { create: async () => h.modelRuntime },
   CredentialSynchronizationError: h.CredentialSynchronizationError,
 }));
+// pi's real default-model table is exercised in pi-defaults.test.ts; here it is
+// just another input, so a stub keeps these specs independent of pi's catalog.
+vi.mock("../pi-defaults", () => ({ providerDefaults: async () => ({ p: "m" }) }));
 
 /** Import auth.ts fresh and register its handlers. */
 async function setup() {
@@ -205,7 +208,15 @@ describe("auth_models", () => {
     expect(await invoke("auth_models")).toEqual({
       type: "models",
       models: [{ provider: "p", id: "m", name: "M", reasoning: true, input: ["text"], contextWindow: 100 }],
+      providerDefaults: { p: "m" },
     });
+  });
+
+  it("should carry pi's default model per provider so the renderer can preselect one", async () => {
+    await setup();
+
+    const models = (await invoke("auth_models")) as { providerDefaults: Record<string, string> };
+    expect(models.providerDefaults).toEqual({ p: "m" });
   });
 });
 

--- a/packages/desktop/src/main/llm-providers/__tests__/pi-defaults.test.ts
+++ b/packages/desktop/src/main/llm-providers/__tests__/pi-defaults.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { asProviderDefaults } from "../pi-defaults";
+
+// providerDefaults() deliberately loads the REAL pi package rather than a mock:
+// the whole point of pi-defaults.ts is that it can still reach pi's
+// default-model table, which pi does not export. A pi bump that moves or
+// renames the table must fail here instead of silently degrading every
+// automatic model pick to "first available model".
+
+describe("providerDefaults()", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("node:url");
+  });
+
+  it("should expose a default model id for pi's mainstream providers", async () => {
+    const { providerDefaults } = await import("../pi-defaults");
+    const table = await providerDefaults();
+
+    for (const provider of ["anthropic", "openai", "google"]) {
+      expect(typeof table[provider]).toBe("string");
+      expect(table[provider].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("should expose only string model ids", async () => {
+    const { providerDefaults } = await import("../pi-defaults");
+    const table = await providerDefaults();
+
+    expect(Object.keys(table).length).toBeGreaterThan(0);
+    for (const id of Object.values(table)) expect(typeof id).toBe("string");
+  });
+
+  it("should read the table once and reuse it", async () => {
+    const { providerDefaults } = await import("../pi-defaults");
+
+    expect(await providerDefaults()).toBe(await providerDefaults());
+  });
+
+  it("should return an empty table when pi cannot be located", async () => {
+    vi.doMock("node:url", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("node:url")>()),
+      fileURLToPath: () => {
+        throw new Error("Cannot find package '@earendil-works/pi-coding-agent'");
+      },
+    }));
+
+    const { providerDefaults } = await import("../pi-defaults");
+
+    expect(await providerDefaults()).toEqual({});
+  });
+
+  it("should return an empty table when pi no longer ships the resolver file", async () => {
+    vi.doMock("node:url", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("node:url")>()),
+      fileURLToPath: () => "/nonexistent/pi/dist/index.js",
+    }));
+
+    const { providerDefaults } = await import("../pi-defaults");
+
+    expect(await providerDefaults()).toEqual({});
+  });
+});
+
+describe("asProviderDefaults()", () => {
+  it("should pass a table of provider ids through unchanged", () => {
+    const table = { anthropic: "claude-x", openai: "gpt-x" };
+
+    expect(asProviderDefaults(table)).toEqual(table);
+  });
+
+  it("should return an empty table when pi renamed the export away", () => {
+    expect(asProviderDefaults(undefined)).toEqual({});
+  });
+
+  it("should return an empty table when the export is not an object", () => {
+    expect(asProviderDefaults("claude-x")).toEqual({});
+  });
+
+  it("should return an empty table when the export is null", () => {
+    expect(asProviderDefaults(null)).toEqual({});
+  });
+});

--- a/packages/desktop/src/main/llm-providers/auth.ts
+++ b/packages/desktop/src/main/llm-providers/auth.ts
@@ -5,6 +5,7 @@ import type { AuthInteraction, Credential } from "@earendil-works/pi-ai";
 import { CredentialSynchronizationError, type ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { ipcMain } from "electron";
 import { trackProviderConnected } from "../analytics";
+import { providerDefaults as piProviderDefaults } from "./pi-defaults";
 import { createProviderRuntime } from "./registry";
 
 function uniqueProviders(runtime: ModelRuntime): string[] {
@@ -95,7 +96,7 @@ async function authProviders() {
 }
 
 async function authModels() {
-  const runtime = await createProviderRuntime();
+  const [runtime, providerDefaults] = await Promise.all([createProviderRuntime(), piProviderDefaults()]);
   const models = runtime.getAvailableSnapshot().map((m) => ({
     provider: m.provider,
     id: m.id,
@@ -104,7 +105,9 @@ async function authModels() {
     input: m.input,
     contextWindow: m.contextWindow,
   }));
-  return { type: "models", models };
+  // pi's default per provider rides along so the renderer can preselect a
+  // default model without knowing about pi.
+  return { type: "models", models, providerDefaults };
 }
 
 /** Answers pi's api-key login with a key the user already pasted. Standard

--- a/packages/desktop/src/main/llm-providers/pi-defaults.ts
+++ b/packages/desktop/src/main/llm-providers/pi-defaults.ts
@@ -1,0 +1,45 @@
+// pi's opinionated default model per provider — the table the app uses to
+// preselect a default model when a provider is connected.
+//
+// pi keeps this table in dist/core/model-resolver.js but does not re-export it
+// (its package exports map only exposes ".", "./rpc-entry" and "./client"), so
+// it is loaded from the file next to pi's resolved entry point. Importing by
+// absolute file path bypasses the exports map, and packaged builds ship pi's
+// dist/ as real files (asar is off), so the same path resolves in dev and in
+// production. If pi ever moves the file, the load fails softly and the table is
+// empty — callers then fall back to the provider's first model, which is pi's
+// own last resort. __tests__/pi-defaults.test.ts loads the real file, so a pi
+// bump that breaks this turns red in CI instead of silently degrading.
+
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+/** provider id -> pi's default model id for it. */
+export type ProviderDefaults = Record<string, string>;
+
+/** Accept pi's table only if it still looks like one, so a renamed export
+ *  yields no opinion instead of breaking the models IPC. */
+export function asProviderDefaults(table: unknown): ProviderDefaults {
+  return typeof table === "object" && table !== null ? (table as ProviderDefaults) : {};
+}
+
+let cached: Promise<ProviderDefaults> | undefined;
+
+async function load(): Promise<ProviderDefaults> {
+  try {
+    // import.meta.resolve, not createRequire().resolve: pi's exports map offers
+    // the "import" condition only, which CommonJS resolution cannot satisfy.
+    const entry = fileURLToPath(import.meta.resolve("@earendil-works/pi-coding-agent"));
+    const resolver = join(dirname(entry), "core", "model-resolver.js");
+    const module: { defaultModelPerProvider?: unknown } = await import(pathToFileURL(resolver).href);
+    return asProviderDefaults(module.defaultModelPerProvider);
+  } catch {
+    return {};
+  }
+}
+
+/** pi's default model per provider. Loaded once per process. */
+export function providerDefaults(): Promise<ProviderDefaults> {
+  cached ??= load();
+  return cached;
+}

--- a/packages/desktop/src/renderer/App.tsx
+++ b/packages/desktop/src/renderer/App.tsx
@@ -5,10 +5,13 @@
 import { ChatLayout } from "./components/accountant24/chat-layout";
 import { Onboarding } from "./components/accountant24/onboarding";
 import { TooltipProvider } from "./components/shadcn/tooltip";
+import { useEnsureDefaultModel } from "./hooks/use-default-model";
 import { useHasModels } from "./hooks/use-provider-status";
 
 export default function App() {
   const hasModels = useHasModels();
+  // Fills in a default model for setups that have models but never chose one.
+  useEnsureDefaultModel();
   if (hasModels === null) return null;
   return (
     // The app's one tooltip provider: every tooltip opens on dwell (400ms —

--- a/packages/desktop/src/renderer/__tests__/App.test.tsx
+++ b/packages/desktop/src/renderer/__tests__/App.test.tsx
@@ -12,10 +12,14 @@ import { installJsdomPolyfills } from "@/test/jsdomPolyfills";
 const status = vi.hoisted(() => vi.fn());
 const onModelsChanged = vi.hoisted(() => vi.fn());
 const version = vi.hoisted(() => vi.fn().mockResolvedValue("9.9.9"));
+const models = vi.hoisted(() => vi.fn());
+const settingsGet = vi.hoisted(() => vi.fn());
+const settingsSet = vi.hoisted(() => vi.fn());
 vi.mock("@/rpc/api", () => ({
-  authApi: { status },
+  authApi: { status, models },
   agentApi: { onModelsChanged },
   appApi: { version },
+  settingsApi: { get: settingsGet, set: settingsSet },
 }));
 
 // Stub the heavy chat layout so the gate is what's under test.
@@ -29,12 +33,20 @@ let modelsChangedCb: (() => void) | null;
 
 beforeAll(() => installJsdomPolyfills());
 
+const MODELS = [
+  { provider: "alpha", id: "alpha-mini", name: "Alpha Mini" },
+  { provider: "alpha", id: "alpha-pro", name: "Alpha Pro" },
+];
+
 beforeEach(() => {
   modelsChangedCb = null;
   onModelsChanged.mockImplementation((cb: () => void) => {
     modelsChangedCb = cb;
     return () => {};
   });
+  models.mockResolvedValue({ type: "models", models: MODELS, providerDefaults: { alpha: "alpha-pro" } });
+  settingsGet.mockResolvedValue({});
+  settingsSet.mockResolvedValue({});
 });
 
 afterEach(() => cleanup());
@@ -74,5 +86,30 @@ describe("App gate", () => {
     status.mockResolvedValue(statusWith(1));
     modelsChangedCb?.();
     await waitFor(() => expect(screen.getByTestId("chat-layout")).toBeInTheDocument());
+  });
+});
+
+describe("App default model", () => {
+  it("should choose a default model at start-up when none is set", async () => {
+    status.mockResolvedValue(statusWith(2));
+    render(<App />);
+    // pi recommends alpha-pro, so it wins over the first-listed alpha-mini.
+    await waitFor(() => expect(settingsSet).toHaveBeenCalledWith({ defaultModel: "alpha/alpha-pro" }));
+  });
+
+  it("should keep the default model the user already chose", async () => {
+    status.mockResolvedValue(statusWith(2));
+    settingsGet.mockResolvedValue({ defaultModel: "alpha/alpha-mini" });
+    render(<App />);
+    await waitFor(() => expect(screen.getByTestId("chat-layout")).toBeInTheDocument());
+    expect(settingsSet).not.toHaveBeenCalled();
+  });
+
+  it("should not choose a default model on a fresh install with no models", async () => {
+    status.mockResolvedValue(statusWith(0));
+    models.mockResolvedValue({ type: "models", models: [], providerDefaults: {} });
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("Local-first AI agent for personal finance")).toBeInTheDocument());
+    expect(settingsSet).not.toHaveBeenCalled();
   });
 });

--- a/packages/desktop/src/renderer/components/accountant24/settings/__tests__/models-settings.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/settings/__tests__/models-settings.test.tsx
@@ -130,6 +130,20 @@ describe("ModelsSettings — enable/disable toggles", () => {
   });
 });
 
+describe("ModelsSettings — load failures", () => {
+  it("should still offer the default-model picker when the settings cannot be read", async () => {
+    h.get.mockRejectedValue(new Error("unreadable"));
+    render(<ModelsSettings />);
+    expect(await screen.findByRole("switch", { name: "GPT-5" })).toBeInTheDocument();
+  });
+
+  it("should fall back to the empty state when the model list cannot be read", async () => {
+    h.models.mockRejectedValue(new Error("offline"));
+    renderWith({ defaultModel: GPT });
+    expect(await screen.findByText("Connect a provider to choose a default model.")).toBeInTheDocument();
+  });
+});
+
 describe("ModelsSettings — save errors", () => {
   it("should surface a banner when saving fails", async () => {
     h.set.mockRejectedValue(new Error("disk full"));

--- a/packages/desktop/src/renderer/components/accountant24/settings/__tests__/providers-settings.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/settings/__tests__/providers-settings.test.tsx
@@ -98,7 +98,7 @@ beforeEach(() => {
   vi.mocked(authApi.logout).mockResolvedValue({ type: "ok" });
   vi.mocked(authApi.removeOllama).mockResolvedValue({ type: "ok" });
   vi.mocked(authApi.addAllOllama).mockResolvedValue({ type: "ok", count: 1 });
-  vi.mocked(authApi.models).mockResolvedValue({ type: "models", models: [] });
+  vi.mocked(authApi.models).mockResolvedValue({ type: "models", models: [], providerDefaults: {} });
   vi.mocked(agentApi.restart).mockResolvedValue(undefined);
   vi.mocked(settingsApi.get).mockResolvedValue({});
   vi.mocked(settingsApi.set).mockResolvedValue({});
@@ -291,6 +291,105 @@ describe("ProvidersSettings", () => {
   });
 
   describe("disconnect flow", () => {
+    it("should hand the default model to a remaining provider", async () => {
+      vi.mocked(authApi.status).mockResolvedValue(
+        status([row({ provider: "openai", displayName: "OpenAI", configured: true, removable: true })]),
+      );
+      vi.mocked(settingsApi.get).mockResolvedValue({ defaultModel: "openai/gpt-4" });
+      // What is left once OpenAI is gone.
+      vi.mocked(authApi.models).mockResolvedValue({
+        type: "models",
+        models: [
+          { provider: "groq", id: "llama" },
+          { provider: "groq", id: "mixtral" },
+        ],
+        providerDefaults: {},
+      } as never);
+
+      render(<ProvidersSettings />);
+      fireEvent.click(await screen.findByRole("button", { name: "Disconnect" }));
+
+      await waitFor(() => expect(settingsApi.set).toHaveBeenCalledWith({ defaultModel: "groq/llama" }));
+      expect(authApi.logout).toHaveBeenCalledWith("openai");
+    });
+
+    it("should hand the default model to the remaining provider's recommended model", async () => {
+      vi.mocked(authApi.status).mockResolvedValue(
+        status([row({ provider: "openai", displayName: "OpenAI", configured: true, removable: true })]),
+      );
+      vi.mocked(settingsApi.get).mockResolvedValue({ defaultModel: "openai/gpt-4" });
+      vi.mocked(authApi.models).mockResolvedValue({
+        type: "models",
+        models: [
+          { provider: "groq", id: "llama" },
+          { provider: "groq", id: "mixtral" },
+        ],
+        providerDefaults: { groq: "mixtral" },
+      } as never);
+
+      render(<ProvidersSettings />);
+      fireEvent.click(await screen.findByRole("button", { name: "Disconnect" }));
+
+      await waitFor(() => expect(settingsApi.set).toHaveBeenCalledWith({ defaultModel: "groq/mixtral" }));
+    });
+
+    it("should enable the replacement default when the allow-list excludes it", async () => {
+      vi.mocked(authApi.status).mockResolvedValue(
+        status([row({ provider: "openai", displayName: "OpenAI", configured: true, removable: true })]),
+      );
+      vi.mocked(settingsApi.get).mockResolvedValue({
+        defaultModel: "openai/gpt-4",
+        enabledModels: ["openai/gpt-4", "groq/mixtral"],
+      });
+      vi.mocked(authApi.models).mockResolvedValue({
+        type: "models",
+        models: [
+          { provider: "groq", id: "llama" },
+          { provider: "groq", id: "mixtral" },
+          { provider: "groq", id: "gemma" },
+        ],
+        providerDefaults: {},
+      } as never);
+
+      render(<ProvidersSettings />);
+      fireEvent.click(await screen.findByRole("button", { name: "Disconnect" }));
+
+      // The replacement joins the list, the departed provider's stale id drops
+      // out, and the model the user had switched off stays off.
+      await waitFor(() =>
+        expect(settingsApi.set).toHaveBeenCalledWith({
+          defaultModel: "groq/llama",
+          enabledModels: ["groq/llama", "groq/mixtral"],
+        }),
+      );
+    });
+
+    it("should enable every model when the replacement completes the allow-list", async () => {
+      vi.mocked(authApi.status).mockResolvedValue(
+        status([row({ provider: "openai", displayName: "OpenAI", configured: true, removable: true })]),
+      );
+      vi.mocked(settingsApi.get).mockResolvedValue({
+        defaultModel: "openai/gpt-4",
+        enabledModels: ["openai/gpt-4", "groq/mixtral"],
+      });
+      vi.mocked(authApi.models).mockResolvedValue({
+        type: "models",
+        models: [
+          { provider: "groq", id: "llama" },
+          { provider: "groq", id: "mixtral" },
+        ],
+        providerDefaults: {},
+      } as never);
+
+      render(<ProvidersSettings />);
+      fireEvent.click(await screen.findByRole("button", { name: "Disconnect" }));
+
+      // Nothing is left switched off, which is stored as the canonical empty list.
+      await waitFor(() =>
+        expect(settingsApi.set).toHaveBeenCalledWith({ defaultModel: "groq/llama", enabledModels: [] }),
+      );
+    });
+
     it("should log out, clear a dangling default model, restart the agent, and reload", async () => {
       vi.mocked(authApi.status).mockResolvedValue(
         status([row({ provider: "openai", displayName: "OpenAI", configured: true, removable: true })]),
@@ -302,7 +401,8 @@ describe("ProvidersSettings", () => {
       await waitFor(() => expect(agentApi.restart).toHaveBeenCalledTimes(1));
       expect(authApi.logout).toHaveBeenCalledWith("openai");
       expect(authApi.removeOllama).not.toHaveBeenCalled();
-      // The default model belonged to the removed provider, so it's cleared.
+      // The default belonged to the removed provider and no model is left to
+      // take its place, so it's cleared.
       expect(settingsApi.set).toHaveBeenCalledWith({ defaultModel: undefined });
       // reload() re-reads status: once on mount, once after disconnect.
       expect(vi.mocked(authApi.status).mock.calls.length).toBeGreaterThanOrEqual(2);
@@ -339,7 +439,11 @@ describe("ProvidersSettings", () => {
         status([row({ provider: "groq", displayName: "Groq", configured: false, oauth: false })]),
       );
       // A scoped list that doesn't yet include Groq's model (so adding it must widen).
-      vi.mocked(settingsApi.get).mockResolvedValue({ enabledModels: ["openai/gpt-4"] });
+      // A default model is already chosen, so this test sees widening alone.
+      vi.mocked(settingsApi.get).mockResolvedValue({
+        enabledModels: ["openai/gpt-4"],
+        defaultModel: "openai/gpt-4",
+      });
       vi.mocked(authApi.models).mockResolvedValue({
         type: "models",
         models: [
@@ -347,6 +451,7 @@ describe("ProvidersSettings", () => {
           { provider: "openai", id: "gpt-5" },
           { provider: "groq", id: "llama" },
         ],
+        providerDefaults: {},
       } as never);
       vi.mocked(authApi.setKey).mockResolvedValue({ type: "ok" });
 
@@ -367,10 +472,12 @@ describe("ProvidersSettings", () => {
         status([row({ provider: "groq", displayName: "Groq", configured: false, oauth: false })]),
       );
       // No scoped list means "all enabled": adding a provider needs no widening.
-      vi.mocked(settingsApi.get).mockResolvedValue({});
+      // A default model is already chosen, so nothing is written at all.
+      vi.mocked(settingsApi.get).mockResolvedValue({ defaultModel: "groq/llama" });
       vi.mocked(authApi.models).mockResolvedValue({
         type: "models",
         models: [{ provider: "groq", id: "llama" }],
+        providerDefaults: {},
       } as never);
       vi.mocked(authApi.setKey).mockResolvedValue({ type: "ok" });
 
@@ -387,7 +494,10 @@ describe("ProvidersSettings", () => {
       vi.mocked(authApi.status).mockResolvedValue(
         status([row({ provider: "anthropic", displayName: "Anthropic", configured: false, oauth: true })]),
       );
-      vi.mocked(settingsApi.get).mockResolvedValue({ enabledModels: ["openai/gpt-4"] });
+      vi.mocked(settingsApi.get).mockResolvedValue({
+        enabledModels: ["openai/gpt-4"],
+        defaultModel: "openai/gpt-4",
+      });
       vi.mocked(authApi.models).mockResolvedValue({
         type: "models",
         models: [
@@ -395,6 +505,7 @@ describe("ProvidersSettings", () => {
           { provider: "openai", id: "gpt-5" },
           { provider: "anthropic", id: "claude" },
         ],
+        providerDefaults: {},
       } as never);
 
       render(<ProvidersSettings />);
@@ -407,6 +518,131 @@ describe("ProvidersSettings", () => {
 
       await waitFor(() => expect(agentApi.restart).toHaveBeenCalledTimes(1));
       expect(settingsApi.set).toHaveBeenCalledWith({ enabledModels: ["openai/gpt-4", "anthropic/claude"] });
+    });
+
+    it("should choose a default model and widen the list in one write when no default is set", async () => {
+      vi.mocked(authApi.status).mockResolvedValue(
+        status([row({ provider: "groq", displayName: "Groq", configured: false, oauth: false })]),
+      );
+      vi.mocked(settingsApi.get).mockResolvedValue({ enabledModels: ["openai/gpt-4"] });
+      vi.mocked(authApi.models).mockResolvedValue({
+        type: "models",
+        models: [
+          { provider: "openai", id: "gpt-4" },
+          { provider: "openai", id: "gpt-5" },
+          { provider: "groq", id: "llama" },
+        ],
+        providerDefaults: {},
+      } as never);
+      vi.mocked(authApi.setKey).mockResolvedValue({ type: "ok" });
+
+      render(<ProvidersSettings />);
+      fireEvent.click(await screen.findByRole("button", { name: "API Key" }));
+      fireEvent.change(await screen.findByLabelText("API Key"), { target: { value: "sk-groq" } });
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+      await waitFor(() => expect(settingsApi.set).toHaveBeenCalledTimes(1));
+      // One write, so the composer only reacts once.
+      expect(settingsApi.set).toHaveBeenCalledWith({
+        enabledModels: ["openai/gpt-4", "groq/llama"],
+        defaultModel: "groq/llama",
+      });
+    });
+
+    it("should choose the model pi recommends for the added provider", async () => {
+      vi.mocked(authApi.status).mockResolvedValue(
+        status([row({ provider: "anthropic", displayName: "Anthropic", configured: false, oauth: false })]),
+      );
+      vi.mocked(settingsApi.get).mockResolvedValue({});
+      vi.mocked(authApi.models).mockResolvedValue({
+        type: "models",
+        models: [
+          { provider: "anthropic", id: "claude-mini" },
+          { provider: "anthropic", id: "claude-pro" },
+        ],
+        providerDefaults: { anthropic: "claude-pro" },
+      } as never);
+      vi.mocked(authApi.setKey).mockResolvedValue({ type: "ok" });
+
+      render(<ProvidersSettings />);
+      fireEvent.click(await screen.findByRole("button", { name: "API Key" }));
+      fireEvent.change(await screen.findByLabelText("API Key"), { target: { value: "sk-a" } });
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+      // pi's recommendation wins over the provider's first model.
+      await waitFor(() => expect(settingsApi.set).toHaveBeenCalledWith({ defaultModel: "anthropic/claude-pro" }));
+    });
+
+    it("should choose a default model for the provider just added, not another one", async () => {
+      vi.mocked(authApi.status).mockResolvedValue(
+        status([row({ provider: "groq", displayName: "Groq", configured: false, oauth: false })]),
+      );
+      vi.mocked(settingsApi.get).mockResolvedValue({});
+      vi.mocked(authApi.models).mockResolvedValue({
+        type: "models",
+        models: [
+          { provider: "openai", id: "gpt-4" },
+          { provider: "groq", id: "llama" },
+        ],
+        providerDefaults: { openai: "gpt-4" },
+      } as never);
+      vi.mocked(authApi.setKey).mockResolvedValue({ type: "ok" });
+
+      render(<ProvidersSettings />);
+      fireEvent.click(await screen.findByRole("button", { name: "API Key" }));
+      fireEvent.change(await screen.findByLabelText("API Key"), { target: { value: "sk-groq" } });
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+      await waitFor(() => expect(settingsApi.set).toHaveBeenCalledWith({ defaultModel: "groq/llama" }));
+    });
+
+    it("should keep the default model the user already chose", async () => {
+      vi.mocked(authApi.status).mockResolvedValue(
+        status([row({ provider: "groq", displayName: "Groq", configured: false, oauth: false })]),
+      );
+      vi.mocked(settingsApi.get).mockResolvedValue({
+        enabledModels: ["openai/gpt-4"],
+        defaultModel: "openai/gpt-4",
+      });
+      vi.mocked(authApi.models).mockResolvedValue({
+        type: "models",
+        models: [
+          { provider: "openai", id: "gpt-4" },
+          { provider: "openai", id: "gpt-5" },
+          { provider: "groq", id: "llama" },
+        ],
+        providerDefaults: { groq: "llama" },
+      } as never);
+      vi.mocked(authApi.setKey).mockResolvedValue({ type: "ok" });
+
+      render(<ProvidersSettings />);
+      fireEvent.click(await screen.findByRole("button", { name: "API Key" }));
+      fireEvent.change(await screen.findByLabelText("API Key"), { target: { value: "sk-groq" } });
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+      await waitFor(() => expect(settingsApi.set).toHaveBeenCalledTimes(1));
+      expect(settingsApi.set).toHaveBeenCalledWith({ enabledModels: ["openai/gpt-4", "groq/llama"] });
+    });
+
+    it("should not choose a default model when the new provider has none available", async () => {
+      vi.mocked(authApi.status).mockResolvedValue(
+        status([row({ provider: "groq", displayName: "Groq", configured: false, oauth: false })]),
+      );
+      vi.mocked(settingsApi.get).mockResolvedValue({});
+      vi.mocked(authApi.models).mockResolvedValue({
+        type: "models",
+        models: [{ provider: "openai", id: "gpt-4" }],
+        providerDefaults: {},
+      } as never);
+      vi.mocked(authApi.setKey).mockResolvedValue({ type: "ok" });
+
+      render(<ProvidersSettings />);
+      fireEvent.click(await screen.findByRole("button", { name: "API Key" }));
+      fireEvent.change(await screen.findByLabelText("API Key"), { target: { value: "sk-groq" } });
+      fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+      await waitFor(() => expect(agentApi.restart).toHaveBeenCalledTimes(1));
+      expect(settingsApi.set).not.toHaveBeenCalled();
     });
 
     it("should just reload without an add when a sign-in completes with no provider armed", async () => {

--- a/packages/desktop/src/renderer/components/accountant24/settings/models-settings.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/settings/models-settings.tsx
@@ -8,7 +8,7 @@ import { Badge } from "@/components/shadcn/badge";
 import { ItemActions, ItemContent, ItemDescription, ItemTitle } from "@/components/shadcn/item";
 import { Label } from "@/components/shadcn/label";
 import { Switch } from "@/components/shadcn/switch";
-import { addEnabledModels } from "@/lib/enabledModels";
+import { defaultModelPatch } from "@/lib/defaultModelPick";
 import { authApi, settingsApi } from "@/rpc/api";
 import type { AppSettings, ModelInfo } from "@/rpc/types";
 import { ErrorBanner, Section, SettingsRow, SettingsRows } from "./parts";
@@ -190,18 +190,8 @@ export function ModelsSettings() {
       .catch((e) => setSaveError(`Couldn’t save settings: ${e instanceof Error ? e.message : String(e)}`));
   }, []);
 
-  // Picking a default also enables it — the default must always be available to
-  // new chats.
   const setDefault = useCallback(
-    (id: string) => {
-      const current = settings.enabledModels;
-      if (current && current.length > 0 && !current.includes(id)) {
-        const allIds = models.map(idOf);
-        patch({ defaultModel: id, enabledModels: addEnabledModels(current, [id], allIds) });
-      } else {
-        patch({ defaultModel: id });
-      }
-    },
+    (id: string) => patch(defaultModelPatch(id, settings.enabledModels, models)),
     [models, settings.enabledModels, patch],
   );
 

--- a/packages/desktop/src/renderer/components/accountant24/settings/providers-settings.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/settings/providers-settings.tsx
@@ -9,9 +9,10 @@ import { Button } from "@/components/shadcn/button";
 import { ItemActions, ItemContent, ItemTitle } from "@/components/shadcn/item";
 import { Spinner } from "@/components/shadcn/spinner";
 import { useOAuthLogin } from "@/hooks/use-oauth-login";
+import { defaultModelPatch, pickDefaultModel } from "@/lib/defaultModelPick";
 import { addEnabledModels, parseModelId } from "@/lib/enabledModels";
 import { agentApi, authApi, settingsApi } from "@/rpc/api";
-import type { AuthProviderRow, AuthStatus } from "@/rpc/types";
+import type { AppSettings, AuthProviderRow, AuthStatus } from "@/rpc/types";
 import { ErrorBanner, Section, SettingsRow, SettingsRows } from "./parts";
 import { ApiKeyDialog, OAuthSignInDialog } from "./provider-dialogs";
 
@@ -25,16 +26,26 @@ function ProvidersList({ status, reload }: { status: AuthStatus | null; reload: 
   const signingProvider = useRef<string | null>(null);
 
   // When a provider is added, make sure its models show in the composer — adding
-  // a provider shouldn't leave its models hidden behind an existing scoped list.
-  const enableProviderModels = useCallback(async (provider: string) => {
+  // a provider shouldn't leave its models hidden behind an existing scoped list —
+  // and start new chats on one of them when no default has been chosen yet.
+  const adoptProviderModels = useCallback(async (provider: string) => {
     try {
       const [models, settings] = await Promise.all([authApi.models(), settingsApi.get()]);
       const toEnable = models.models.filter((m) => m.provider === provider).map((m) => `${m.provider}/${m.id}`);
       const allIds = models.models.map((m) => `${m.provider}/${m.id}`);
       const next = addEnabledModels(settings.enabledModels, toEnable, allIds);
+      const patch: Partial<AppSettings> = {};
       if (next !== undefined && JSON.stringify(next) !== JSON.stringify(settings.enabledModels ?? [])) {
-        await settingsApi.set({ enabledModels: next });
+        patch.enabledModels = next;
       }
+      if (!settings.defaultModel) {
+        // The pick comes from the provider just added, whose models are enabled
+        // above, so the default is always one the user can actually chat with.
+        const picked = pickDefaultModel(models.models, models.providerDefaults, provider);
+        if (picked) patch.defaultModel = picked;
+      }
+      // One write, so the composer sees a single settings-changed event.
+      if (Object.keys(patch).length > 0) await settingsApi.set(patch);
     } catch {
       // Best-effort: failing to widen the composer list shouldn't block the add.
     }
@@ -45,10 +56,10 @@ function ProvidersList({ status, reload }: { status: AuthStatus | null; reload: 
       // The agent caches auth/models at startup, so restart it to pick up the new
       // provider; this also notifies the composer to re-fetch its model list.
       await agentApi.restart();
-      await enableProviderModels(provider);
+      await adoptProviderModels(provider);
       await reload();
     },
-    [enableProviderModels, reload],
+    [adoptProviderModels, reload],
   );
 
   const oauth = useOAuthLogin(() => {
@@ -70,10 +81,20 @@ function ProvidersList({ status, reload }: { status: AuthStatus | null; reload: 
       // its own path; auth.json-backed providers are logged out.
       if (provider === "ollama") await authApi.removeOllama();
       else await authApi.logout(provider);
-      // A default model from the removed provider is now dangling — clear it.
+      // The default model came from the provider just removed, so it is now
+      // dangling: hand the spot to a model that still works, or clear it when
+      // nothing is left. The model list is re-read after the removal, so it
+      // already excludes what went away.
       const settings = await settingsApi.get();
-      if (parseModelId(settings.defaultModel ?? "")?.provider === provider)
-        await settingsApi.set({ defaultModel: undefined });
+      if (parseModelId(settings.defaultModel ?? "")?.provider === provider) {
+        const models = await authApi.models();
+        const replacement = pickDefaultModel(models.models, models.providerDefaults);
+        await settingsApi.set(
+          replacement
+            ? defaultModelPatch(replacement, settings.enabledModels, models.models)
+            : { defaultModel: undefined },
+        );
+      }
       // Restart the agent so it drops the removed provider's models (it caches
       // them at startup); this also tells the composer to re-fetch its list.
       await agentApi.restart();

--- a/packages/desktop/src/renderer/hooks/__tests__/use-default-model.test.ts
+++ b/packages/desktop/src/renderer/hooks/__tests__/use-default-model.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The hook reaches the main process through @/rpc/api; mock that boundary.
+const models = vi.hoisted(() => vi.fn());
+const get = vi.hoisted(() => vi.fn());
+const set = vi.hoisted(() => vi.fn());
+vi.mock("@/rpc/api", () => ({
+  authApi: { models },
+  settingsApi: { get, set },
+}));
+
+import { useEnsureDefaultModel } from "../use-default-model";
+
+const MODELS = [
+  { provider: "alpha", id: "alpha-mini", name: "Alpha Mini" },
+  { provider: "alpha", id: "alpha-pro", name: "Alpha Pro" },
+  { provider: "beta", id: "beta-max", name: "Beta Max" },
+];
+const MINI = "alpha/alpha-mini";
+const PRO = "alpha/alpha-pro";
+const MAX = "beta/beta-max";
+
+const availableModels = (providerDefaults: Record<string, string> = {}) => ({
+  type: "models",
+  models: MODELS,
+  providerDefaults,
+});
+
+beforeEach(() => {
+  models.mockResolvedValue(availableModels());
+  get.mockResolvedValue({});
+  set.mockResolvedValue({});
+});
+
+afterEach(() => cleanup());
+
+/** Let the hook's async work settle before asserting nothing happened. */
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+describe("useEnsureDefaultModel()", () => {
+  it("should choose a default model when none is set", async () => {
+    renderHook(() => useEnsureDefaultModel());
+    await waitFor(() => expect(set).toHaveBeenCalledWith({ defaultModel: MINI }));
+  });
+
+  it("should choose the model pi recommends for the provider", async () => {
+    models.mockResolvedValue(availableModels({ alpha: "alpha-pro" }));
+    renderHook(() => useEnsureDefaultModel());
+    await waitFor(() => expect(set).toHaveBeenCalledWith({ defaultModel: PRO }));
+  });
+
+  it("should keep the default model the user already chose", async () => {
+    get.mockResolvedValue({ defaultModel: MAX });
+    renderHook(() => useEnsureDefaultModel());
+    await settle();
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("should not choose a default model when no models are available", async () => {
+    models.mockResolvedValue({ type: "models", models: [], providerDefaults: {} });
+    renderHook(() => useEnsureDefaultModel());
+    await settle();
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("should enable the chosen model when the user's allow-list excludes it", async () => {
+    models.mockResolvedValue(availableModels({ alpha: "alpha-pro" }));
+    get.mockResolvedValue({ enabledModels: [MAX] });
+    renderHook(() => useEnsureDefaultModel());
+    await waitFor(() => expect(set).toHaveBeenCalledWith({ defaultModel: PRO, enabledModels: [PRO, MAX] }));
+  });
+
+  it("should leave the allow-list alone when it already holds the chosen model", async () => {
+    get.mockResolvedValue({ enabledModels: [MINI, MAX] });
+    renderHook(() => useEnsureDefaultModel());
+    await waitFor(() => expect(set).toHaveBeenCalledWith({ defaultModel: MINI }));
+  });
+
+  it("should not write an allow-list when every model is already enabled", async () => {
+    get.mockResolvedValue({ enabledModels: [] });
+    renderHook(() => useEnsureDefaultModel());
+    await waitFor(() => expect(set).toHaveBeenCalledWith({ defaultModel: MINI }));
+  });
+
+  it("should write once per mount", async () => {
+    renderHook(() => useEnsureDefaultModel());
+    await waitFor(() => expect(set).toHaveBeenCalledTimes(1));
+    await settle();
+    expect(set).toHaveBeenCalledTimes(1);
+  });
+
+  it("should stay quiet when the model list cannot be read", async () => {
+    models.mockRejectedValue(new Error("offline"));
+    renderHook(() => useEnsureDefaultModel());
+    await settle();
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("should stay quiet when the settings cannot be read", async () => {
+    get.mockRejectedValue(new Error("unreadable"));
+    renderHook(() => useEnsureDefaultModel());
+    await settle();
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("should not throw when saving the default fails", async () => {
+    set.mockRejectedValue(new Error("disk full"));
+    renderHook(() => useEnsureDefaultModel());
+    await waitFor(() => expect(set).toHaveBeenCalledTimes(1));
+  });
+});

--- a/packages/desktop/src/renderer/hooks/use-default-model.ts
+++ b/packages/desktop/src/renderer/hooks/use-default-model.ts
@@ -1,0 +1,28 @@
+// Give the app an explicit default model as soon as any model is available.
+// Without one, the composer's model picker sits empty while chats quietly run
+// on pi's own fallback, and someone who never opens Settings would never see it
+// filled in. Connecting a provider picks a default from that provider (see
+// providers-settings), so this only fills the gap for setups that predate the
+// automatic pick.
+
+import { useEffect } from "react";
+import { defaultModelPatch, pickDefaultModel } from "@/lib/defaultModelPick";
+import { authApi, settingsApi } from "../rpc/api";
+
+/** Choose and persist a default model when none is set. Runs once at app start. */
+export function useEnsureDefaultModel(): void {
+  useEffect(() => {
+    void (async () => {
+      try {
+        const [models, settings] = await Promise.all([authApi.models(), settingsApi.get()]);
+        // Never override the user's own pick.
+        if (settings.defaultModel) return;
+        const picked = pickDefaultModel(models.models, models.providerDefaults);
+        if (picked) await settingsApi.set(defaultModelPatch(picked, settings.enabledModels, models.models));
+      } catch {
+        // Best-effort: without a stored default pi still falls back on its own,
+        // so a failure here must not break start-up.
+      }
+    })();
+  }, []);
+}

--- a/packages/desktop/src/renderer/lib/__tests__/defaultModelPick.test.ts
+++ b/packages/desktop/src/renderer/lib/__tests__/defaultModelPick.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { defaultModelPatch, pickDefaultModel } from "../defaultModelPick";
+
+const m = (provider: string, id: string) => ({ provider, id });
+
+/** Stand-in for pi's table, with generic ids so the specs don't depend on
+ *  whichever models pi favours today. */
+const DEFAULTS = { alpha: "alpha-pro", beta: "beta-max" };
+
+describe("pickDefaultModel()", () => {
+  describe("for one provider", () => {
+    it("should return the model named by the provider default", () => {
+      const models = [m("alpha", "alpha-mini"), m("alpha", "alpha-pro"), m("alpha", "alpha-nano")];
+      expect(pickDefaultModel(models, DEFAULTS, "alpha")).toBe("alpha/alpha-pro");
+    });
+
+    it("should match a dated release of the named model", () => {
+      const models = [m("alpha", "alpha-mini"), m("alpha", "alpha-pro-20260115")];
+      expect(pickDefaultModel(models, DEFAULTS, "alpha")).toBe("alpha/alpha-pro-20260115");
+    });
+
+    it("should pick the newest release when several match the named model", () => {
+      const models = [
+        m("alpha", "alpha-pro-20260115"),
+        m("alpha", "alpha-pro-20251201"),
+        m("alpha", "alpha-pro-20260320"),
+      ];
+      expect(pickDefaultModel(models, DEFAULTS, "alpha")).toBe("alpha/alpha-pro-20260320");
+    });
+
+    it("should prefer an exact match over a longer dated one", () => {
+      const models = [m("alpha", "alpha-pro-20260320"), m("alpha", "alpha-pro")];
+      expect(pickDefaultModel(models, DEFAULTS, "alpha")).toBe("alpha/alpha-pro");
+    });
+
+    it("should fall back to the first model when the provider has no default", () => {
+      const models = [m("local", "qwen3-vl:8b"), m("local", "llama4:70b")];
+      expect(pickDefaultModel(models, DEFAULTS, "local")).toBe("local/qwen3-vl:8b");
+    });
+
+    it("should fall back to the first model when the named default is unavailable", () => {
+      const models = [m("alpha", "alpha-mini"), m("alpha", "alpha-nano")];
+      expect(pickDefaultModel(models, DEFAULTS, "alpha")).toBe("alpha/alpha-mini");
+    });
+
+    it("should never return a model from another provider", () => {
+      const models = [m("beta", "beta-max"), m("alpha", "alpha-mini")];
+      expect(pickDefaultModel(models, DEFAULTS, "alpha")).toBe("alpha/alpha-mini");
+    });
+
+    it("should return undefined when the provider has no models", () => {
+      expect(pickDefaultModel([m("beta", "beta-max")], DEFAULTS, "alpha")).toBeUndefined();
+    });
+
+    it("should return undefined when there are no models at all", () => {
+      expect(pickDefaultModel([], DEFAULTS, "alpha")).toBeUndefined();
+    });
+  });
+
+  describe("across providers", () => {
+    it("should prefer a provider with a known default over an earlier one without", () => {
+      const models = [m("local", "qwen3-vl:8b"), m("alpha", "alpha-mini"), m("alpha", "alpha-pro")];
+      expect(pickDefaultModel(models, DEFAULTS)).toBe("alpha/alpha-pro");
+    });
+
+    it("should use the first provider that has a known default", () => {
+      const models = [m("beta", "beta-max"), m("alpha", "alpha-pro")];
+      expect(pickDefaultModel(models, DEFAULTS)).toBe("beta/beta-max");
+    });
+
+    it("should match a dated release when choosing across providers", () => {
+      const models = [m("local", "qwen3-vl:8b"), m("beta", "beta-max-20260115")];
+      expect(pickDefaultModel(models, DEFAULTS)).toBe("beta/beta-max-20260115");
+    });
+
+    it("should fall back to the very first model when no provider has a known default", () => {
+      const models = [m("local", "qwen3-vl:8b"), m("alpha", "alpha-mini")];
+      expect(pickDefaultModel(models, DEFAULTS)).toBe("local/qwen3-vl:8b");
+    });
+
+    it("should fall back to the first model when the table is empty", () => {
+      const models = [m("alpha", "alpha-mini"), m("alpha", "alpha-pro")];
+      expect(pickDefaultModel(models, {})).toBe("alpha/alpha-mini");
+    });
+
+    it("should return undefined when there are no models at all", () => {
+      expect(pickDefaultModel([], DEFAULTS)).toBeUndefined();
+    });
+  });
+});
+
+describe("several providers connected", () => {
+  it("should pick the recommended model of whichever provider comes first", () => {
+    // Both providers have a recommended model available; beta is listed first.
+    const models = [m("beta", "beta-mini"), m("beta", "beta-max"), m("alpha", "alpha-pro")];
+    expect(pickDefaultModel(models, DEFAULTS)).toBe("beta/beta-max");
+  });
+
+  it("should skip a provider with no recommendation in favour of one with it", () => {
+    const models = [m("local", "qwen3-vl:8b"), m("local", "llama4:70b"), m("beta", "beta-max")];
+    expect(pickDefaultModel(models, DEFAULTS)).toBe("beta/beta-max");
+  });
+
+  it("should skip a provider whose recommended model is unavailable", () => {
+    // alpha is listed first but only ships models pi does not name.
+    const models = [m("alpha", "alpha-mini"), m("alpha", "alpha-nano"), m("beta", "beta-max")];
+    expect(pickDefaultModel(models, DEFAULTS)).toBe("beta/beta-max");
+  });
+
+  it("should fall back to the first model overall when no provider has a recommendation", () => {
+    const models = [m("local", "qwen3-vl:8b"), m("alpha", "alpha-mini")];
+    expect(pickDefaultModel(models, DEFAULTS)).toBe("local/qwen3-vl:8b");
+  });
+
+  it("should keep the pick within the named provider when one is given", () => {
+    // The just-connected provider wins even though beta also has a recommendation.
+    const models = [m("beta", "beta-max"), m("alpha", "alpha-mini"), m("alpha", "alpha-pro")];
+    expect(pickDefaultModel(models, DEFAULTS, "alpha")).toBe("alpha/alpha-pro");
+  });
+});
+
+describe("defaultModelPatch()", () => {
+  const models = [m("alpha", "alpha-mini"), m("alpha", "alpha-pro"), m("beta", "beta-max")];
+
+  it("should set only the default when there is no allow-list", () => {
+    expect(defaultModelPatch("alpha/alpha-pro", undefined, models)).toEqual({ defaultModel: "alpha/alpha-pro" });
+  });
+
+  it("should set only the default when the empty allow-list already means all enabled", () => {
+    expect(defaultModelPatch("alpha/alpha-pro", [], models)).toEqual({ defaultModel: "alpha/alpha-pro" });
+  });
+
+  it("should set only the default when the allow-list already holds it", () => {
+    expect(defaultModelPatch("alpha/alpha-pro", ["alpha/alpha-pro", "beta/beta-max"], models)).toEqual({
+      defaultModel: "alpha/alpha-pro",
+    });
+  });
+
+  it("should enable the default when the allow-list excludes it", () => {
+    expect(defaultModelPatch("alpha/alpha-pro", ["beta/beta-max"], models)).toEqual({
+      defaultModel: "alpha/alpha-pro",
+      enabledModels: ["alpha/alpha-pro", "beta/beta-max"],
+    });
+  });
+
+  it("should collapse the allow-list to all enabled when the default completes it", () => {
+    expect(defaultModelPatch("alpha/alpha-pro", ["alpha/alpha-mini", "beta/beta-max"], models)).toEqual({
+      defaultModel: "alpha/alpha-pro",
+      enabledModels: [],
+    });
+  });
+
+  it("should order the widened allow-list by the available models", () => {
+    expect(defaultModelPatch("alpha/alpha-mini", ["beta/beta-max"], models).enabledModels).toEqual([
+      "alpha/alpha-mini",
+      "beta/beta-max",
+    ]);
+  });
+});

--- a/packages/desktop/src/renderer/lib/defaultModelPick.ts
+++ b/packages/desktop/src/renderer/lib/defaultModelPick.ts
@@ -1,0 +1,78 @@
+// Which model to preselect as the default — used when a provider is connected
+// and when an existing user has models but no default yet.
+//
+// The opinion comes from pi (`providerDefaults`, its default model per
+// provider, loaded by the main process). This module only applies it to the
+// models actually available, so a provider pi has no opinion about (Ollama) or
+// a table entry that has since been renamed still yields a usable pick.
+
+import type { AppSettings, ProviderDefaults } from "@/rpc/types";
+import { addEnabledModels } from "./enabledModels";
+
+/** A model as the models IPC reports it. */
+type Model = { provider: string; id: string };
+
+/** The stable id for a model in settings: `provider/id`. */
+function idOf(model: Model): string {
+  return `${model.provider}/${model.id}`;
+}
+
+/**
+ * The model pi names for a provider, found among that provider's models:
+ * matched by id, or by prefix so a dated release still counts
+ * (`claude-x-20260115` for a default naming `claude-x`). Undefined when pi has
+ * no opinion or names something unavailable.
+ */
+function preferredOf(candidates: readonly Model[], wanted: string | undefined): Model | undefined {
+  if (!wanted) return undefined;
+  const exact = candidates.find((m) => m.id === wanted);
+  if (exact) return exact;
+  // Several dated releases of the same model: the newest sorts highest.
+  const dated = candidates.filter((m) => m.id.startsWith(wanted));
+  return dated.length > 0 ? dated.reduce((best, m) => (m.id > best.id ? m : best)) : undefined;
+}
+
+/**
+ * Pick a default model, as a `provider/id` id.
+ *
+ * With a `provider`, the pick is restricted to that provider (used right after
+ * connecting one) and falls back to its first model, which is pi's own
+ * fallback. Without, providers are considered in the order they first appear in
+ * `models`: one pi has an opinion about wins, otherwise the very first model is
+ * used. Returns undefined when there is nothing to pick.
+ */
+export function pickDefaultModel(
+  models: readonly Model[],
+  providerDefaults: ProviderDefaults,
+  provider?: string,
+): string | undefined {
+  if (provider !== undefined) {
+    const candidates = models.filter((m) => m.provider === provider);
+    if (candidates.length === 0) return undefined;
+    return idOf(preferredOf(candidates, providerDefaults[provider]) ?? candidates[0]);
+  }
+  for (const candidate of models) {
+    const preferred = preferredOf(
+      models.filter((m) => m.provider === candidate.provider),
+      providerDefaults[candidate.provider],
+    );
+    if (preferred) return idOf(preferred);
+  }
+  return models.length > 0 ? idOf(models[0]) : undefined;
+}
+
+/**
+ * The settings patch that makes a model the default. Choosing a default also
+ * enables it, since the default must always be available to new chats. An
+ * empty/absent allow-list already means "all enabled", so it is left alone
+ * rather than frozen into an explicit list that would hide models added later.
+ */
+export function defaultModelPatch(
+  id: string,
+  enabled: readonly string[] | undefined,
+  models: readonly Model[],
+): Partial<AppSettings> {
+  if (enabled && enabled.length > 0 && !enabled.includes(id))
+    return { defaultModel: id, enabledModels: addEnabledModels(enabled, [id], models.map(idOf)) };
+  return { defaultModel: id };
+}

--- a/packages/desktop/src/renderer/rpc/types.ts
+++ b/packages/desktop/src/renderer/rpc/types.ts
@@ -31,6 +31,9 @@ export interface ModelInfo {
   contextWindow?: number;
 }
 
+/** provider id -> pi's default model id for it. */
+export type ProviderDefaults = Record<string, string>;
+
 // ---- App settings (app-owned config in ~/Accountant24/settings.json) -----
 
 /** A concrete model pick: provider + the provider's model id. */
@@ -93,6 +96,9 @@ export interface AuthProviders {
 export interface AuthModels {
   type: "models";
   models: ModelInfo[];
+  /** pi's opinionated default model id per provider, used to preselect a
+   *  default. Absent providers (e.g. Ollama) have no opinion. */
+  providerDefaults: ProviderDefaults;
 }
 
 export interface OllamaInfo {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -67,10 +67,10 @@ export default defineConfig({
       // Kept just under the current effective baseline so the gate is honest
       // (green today) and each new test suite raises it.
       thresholds: {
-        statements: 98.05,
-        branches: 93.45,
-        functions: 98.0,
-        lines: 99.0,
+        statements: 98.3,
+        branches: 94.15,
+        functions: 98.15,
+        lines: 99.3,
       },
     },
   },


### PR DESCRIPTION
- Preselect a default model at app start via `useEnsureDefaultModel` when none is set.
- Set a default model from the provider just connected, in the same `settingsApi.set` call that widens `enabledModels`.
- Replace the default with a model from a remaining provider when its own provider is disconnected, and clear it when no model is left.
- Load pi's `defaultModelPerProvider` table from the installed package at runtime in `pi-defaults.ts`, and carry it to the renderer on `auth_models`.
- Add `pickDefaultModel`: match the recommended model by id, then by prefix so a dated release counts, then fall back to the provider's first model.
- Add `defaultModelPatch`: enable the chosen model when a scoped `enabledModels` list would hide it, and leave that list untouched when every model is already enabled.
- Keep a default the user chose, never overwriting it.
- Raise the coverage thresholds in `vitest.config.ts`.