### PR TITLE
feat!: move the workspace to ~/.accountant24 and add a --workspace flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-> Keep entries in this file brief and high-level: principles and conventions, not implementation detail.
+> This file is a high-level overview and guidance, not a manual. Whenever you add or change a rule here, keep it brief, conceptual, and clearly written: principles and conventions, never implementation detail. The code is the source of truth for the details, and the agent is trusted to decide the specifics.
 
 # Tech Stack
 
@@ -26,7 +26,7 @@ The Electron desktop app:
 
 `packages/desktop` follows the standard electron-vite layout (`src/main`, `src/preload`, `src/renderer`), plus one addition:
 
-- `src/main/` — Electron main process: window, IPC handlers, workspace setup (`workspace.ts`, run at launch), the agent (`agent/`), LLM provider connections (`llm-providers/`), vendored binaries (hledger).
+- `src/main/` — Electron main process: window, IPC handlers, the workspace (location `cli.ts` + `env.ts`, `migrations/`, setup `workspace.ts`), the agent (`agent/`), LLM provider connections (`llm-providers/`), vendored binaries (hledger).
 - `src/main/agent/` — the chat runtime: the IPC router plus `host/`, which runs in a single agent-host utilityProcess hosting one pi SDK session per chat. Nothing in `host/` may import Electron APIs.
 - `src/main/llm-providers/` — LLM provider auth, OAuth login, models, Ollama. `llm-providers/` and `agent/` never import each other; their only interface is the workspace files (`auth.json`/`models.json`).
 - `src/preload/` — the `window.api` bridge; every IPC channel must be allowlisted here.
@@ -34,6 +34,18 @@ The Electron desktop app:
 - `src/shared/` — IPC payload types used by both main and renderer (and the agent host). Types only, imported with `import type` from both sides; never add runtime code here.
 
 The agent itself is `packages/pi-extension`, bundled and loaded into the agent-host utilityProcess that main forks lazily (one process for all chats).
+
+# Workspace
+
+One folder holds all user data. It is resolved once per launch (`--workspace` flag > `ACCOUNTANT24_WORKSPACE` > `~/.accountant24`) and exported as `ACCOUNTANT24_WORKSPACE` to every child process, so every part of the app agrees on it.
+
+## Migrations
+
+A change to an existing workspace's layout or contents ships as a numbered migration in `src/main/migrations/`, applied once per workspace at launch before anything reads the folder.
+
+- One file per change; append it to the list; never edit a shipped one.
+- Idempotent, confined to the given workspace, failing loudly on anything unexpected (a failed migration aborts startup).
+- Tested over a real temp directory.
 
 # System Prompt
 
@@ -111,8 +123,9 @@ Four tiers, all on Vitest (`npm test`); the first three run in CI on every PR.
 
 - **Unit** — mock only at fs/child_process; keep functions small and pure.
 - **Component** — assert on roles/text, not classes or DOM structure; use the shared `src/renderer/test/jsdomPolyfills.ts` preamble; drive interaction with `@testing-library/user-event`.
-- **Integration** — assert **both** the resulting UI/state **and** the exact IPC calls (`fakeApi.calls` / invoked main handlers). Use a temp `ACCOUNTANT24_HOME`, never a global `node:fs` mock.
+- **Integration** — assert **both** the resulting UI/state **and** the exact IPC calls (`fakeApi.calls` / invoked main handlers). Use a temp `ACCOUNTANT24_WORKSPACE`, never a global `node:fs` mock.
 - **E2E** — deterministic and small; stub the agent (no real LLM/network); leave logic coverage to the lower tiers.
+- **Running the app** (e2e, manual smoke runs, the verify skill, a second dev instance) — never against the real workspace; always create a fresh test workspace and launch on it (`--workspace <temp dir>` or `ACCOUNTANT24_WORKSPACE`), delete it afterwards.
 
 ## Coverage
 

--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -8,6 +8,10 @@ description: "Answers to common questions about Accountant24: data privacy, offl
 
 Yes. Everything stays on your machine as plain-text files. Nothing is uploaded unless you choose to push your git repo to a remote you control. Run a local model with Ollama and even the AI runs on your device, so nothing leaves your computer.
 
+## Where is my data stored?
+
+In one folder on your machine, the workspace: `~/.accountant24` by default. It holds your ledger, documents, memory, skills, and settings, all as plain files in a git repository. **Settings → About** shows the path and opens the folder. You can also run the app on a different folder, see [Settings](/docs/settings#workspace).
+
 ## Does it work offline?
 
 Yes, with a local model via Ollama. Cloud providers (OpenAI, Anthropic) need a connection, but you can switch to a local model anytime and keep working fully offline.

--- a/docs/docs/settings.mdx
+++ b/docs/docs/settings.mdx
@@ -1,10 +1,30 @@
 ---
 title: "Settings"
 sidebarTitle: "Settings"
-description: "Every option in Accountant24's app-settings.json settings file and the values each one accepts."
+description: "Where Accountant24 keeps your data, how to run it on a different workspace, and every option in its app-settings.json settings file."
 ---
 
-Accountant24 stores its settings in `~/Accountant24/app-settings.json`. The app updates the file when you change options in **Settings**. You can also edit it by hand; restart the app afterwards to apply the changes.
+## Workspace
+
+Everything Accountant24 knows about your money lives in one folder, the workspace: the ledger (`ledger/`), your stored documents (`files/`), the agent's memory (`memory.md`), installed skills (`skills/`), chat sessions, provider logins, and the app settings. The folder is a git repository, so every change to your books is recoverable.
+
+By default the workspace is `~/.accountant24`, a hidden folder in your home directory. **Settings → About** shows the exact path; click the row to open the folder in the Finder.
+
+### Use a different workspace
+
+You can point the app at another folder, for example a second set of books or a demo. Launch it with the `--workspace` flag from the terminal:
+
+```sh
+open -a Accountant24 --args --workspace ~/Demo
+```
+
+The path may be relative or start with `~`. A folder that does not exist yet is created and seeded with a fresh ledger, so a new workspace is just a new path. The flag applies to that launch only; without it the app opens `~/.accountant24` again.
+
+The app refuses to start, with an error message, when `--workspace` has no path or points to a file instead of a folder. It never falls back to another workspace silently.
+
+## App settings
+
+Accountant24 stores its settings in `app-settings.json` in the workspace. The app updates the file when you change options in **Settings**. You can also edit it by hand; restart the app afterwards to apply the changes.
 
 ```json
 {

--- a/docs/docs/skills.mdx
+++ b/docs/docs/skills.mdx
@@ -28,7 +28,7 @@ You can add skills from any public GitHub repository:
 2. Click **Add skill**.
 3. Enter the repository as `owner/repo` or a full GitHub URL.
 
-The app downloads the repository and copies the skills it finds into `~/Accountant24/skills`.
+The app downloads the repository and copies the skills it finds into `~/.accountant24/skills`.
 
 Only add skills you trust. A skill can run commands with full access to your workspace, so treat adding one like installing software.
 
@@ -42,4 +42,4 @@ The agent writes the skill into your workspace. Enable it in **Settings → Skil
 
 ### Create manually
 
-A skill is a folder containing a `SKILL.md` file: a name and description in the frontmatter, followed by the instructions the agent should follow. It can also include scripts, for example in Python, that the agent runs as part of the skill. Put the folder into `~/Accountant24/skills`, then enable it in **Settings → Skills**.
+A skill is a folder containing a `SKILL.md` file: a name and description in the frontmatter, followed by the instructions the agent should follow. It can also include scripts, for example in Python, that the agent runs as part of the skill. Put the folder into `~/.accountant24/skills`, then enable it in **Settings → Skills**.

--- a/packages/desktop/.claude/skills/verify/SKILL.md
+++ b/packages/desktop/.claude/skills/verify/SKILL.md
@@ -7,17 +7,28 @@ description: Verify desktop-app UI changes by launching the Electron dev app and
 
 ## Launch
 
-From `packages/desktop`, run `npm run dev` in the background. The main process
-(`src/main/index.ts`) auto-enables CDP on **port 9223** in dev — no extra
-flags needed.
+Never run against the real workspace (`~/.accountant24`): always create a fresh
+test workspace and launch on it. From `packages/desktop`, in the background:
+
+```sh
+npm run dev -- -- --workspace "$(mktemp -d /tmp/a24-verify-XXXX)" --remote-debugging-port=9224
+```
+
+The main process logs `[workspace] using <dir> (flag|env|default)` at startup;
+`(default)` means the instance is on the user's real data: stop it and relaunch.
+A fresh workspace boots to the onboarding screen (no providers), where Cmd+,
+does nothing: open Settings by clicking "Use an API key", or seed the folder
+first (e.g. an `auth.json`) to boot into the chat layout.
 
 Gotchas:
 
-- **Check for leftovers first**: `lsof -nP -iTCP:9223 -iTCP:5173 -sTCP:LISTEN`.
-  A previous dev instance (possibly the user's) may hold 9223; a second launch
-  then fails to bind CDP with `bind() failed: Address already in use` but still
-  opens a window you can't drive. A leftover with an **empty** `/json/list` is
-  a windowless instance (macOS keeps the app alive after the window closes).
+- **Check for leftovers first**: `lsof -nP -iTCP:9223 -iTCP:9224 -iTCP:5173 -sTCP:LISTEN`.
+  The user's own dev instance usually holds CDP 9223 and vite 5173, which is why
+  you launch on 9224 (vite auto-increments to 5174). A second launch on an
+  occupied CDP port fails to bind with `bind() failed: Address already in use`
+  but still opens a window you can't drive. A leftover with an **empty**
+  `/json/list` is a windowless instance (macOS keeps the app alive after the
+  window closes).
 - Port 9222 is usually the user's Chrome — don't use it.
 - Wait for a `"type": "page"` target to appear before driving (~10s).
 - Don't `echo ===` in zsh compound commands — zsh treats `=word` as path
@@ -40,10 +51,10 @@ with commands: `targets`, `eval <js>` (Runtime.evaluate with awaitPromise),
 - Rows re-sort after toggles (enabled/available lists) — re-query coordinates
   before every tap; never tap the same coordinates twice.
 
-## Restore state
+## Clean up
 
-Toggles persist to `~/Accountant24/app-settings.json` immediately. If probing
-changed `enabledModels`, restore the file afterwards
-(all-models-enabled is stored as `enabledModels: []`). Kill your dev instance
-when done: `pkill -f "accountant24/node_modules/electron"` and
-`pkill -f "accountant24/node_modules/.bin/electron-vite"`.
+Kill only your own instance: the Electron PID listening on your CDP port
+(`lsof -nP -iTCP:9224 -sTCP:LISTEN -t`), its `electron-vite` parent, and the
+`npm run dev` grandparent. Never `pkill -f electron` or
+`pkill -f electron-vite`: those also match the user's running instance and other
+worktrees. Then delete the test workspace folder.

--- a/packages/desktop/e2e/helpers.ts
+++ b/packages/desktop/e2e/helpers.ts
@@ -1,6 +1,6 @@
 // Shared helpers for the Electron E2E smoke tests.
 //
-// Each test launches the built app pointed at a fresh temp ACCOUNTANT24_HOME.
+// Each test launches the built app pointed at a fresh temp ACCOUNTANT24_WORKSPACE.
 // Empty, it boots deterministically to the onboarding screen (no providers =>
 // no models => onboarding, and the pi agent child is never spawned); a `seed`
 // callback can pre-populate the home (e.g. auth.json) to boot into the chat
@@ -23,18 +23,21 @@ export interface LaunchedApp {
   close(): Promise<void>;
 }
 
-/** Launch the built app with an isolated temp workspace. */
+/** Launch the built app with an isolated temp workspace. ACCOUNTANT24_WORKSPACE is
+ *  always set, even for tests that pass `--workspace` via `args`: a broken
+ *  flag parser must fall through to a temp dir, never to the developer's real
+ *  default workspace. */
 export async function launchApp(
-  opts: { env?: Record<string, string>; seed?: (home: string) => void } = {},
+  opts: { args?: string[]; env?: Record<string, string>; seed?: (home: string) => void } = {},
 ): Promise<LaunchedApp> {
   const home = mkdtempSync(path.join(tmpdir(), "a24-e2e-"));
   opts.seed?.(home);
   const app = await electron.launch({
-    args: [MAIN_ENTRY],
+    args: [MAIN_ENTRY, ...(opts.args ?? [])],
     cwd: DESKTOP_DIR,
     env: {
       ...process.env,
-      ACCOUNTANT24_HOME: home,
+      ACCOUNTANT24_WORKSPACE: home,
       // Never talk to the update feed or analytics in tests.
       A24_FAKE_UPDATE: "",
       CI: "1",

--- a/packages/desktop/e2e/workspace.e2e.ts
+++ b/packages/desktop/e2e/workspace.e2e.ts
@@ -1,0 +1,39 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { type LaunchedApp, launchApp } from "./helpers";
+
+// E4 — the `--workspace <path>` launch flag over the real wiring: main parses
+// argv, the flag beats ACCOUNTANT24_WORKSPACE (which the helper always sets to a
+// decoy temp dir), the workspace is seeded at the flagged path, and Settings →
+// About shows that path through the preload allowlist + workspace_dir IPC.
+
+let launched: LaunchedApp;
+let flagHome: string;
+
+test.beforeEach(async () => {
+  flagHome = mkdtempSync(path.join(tmpdir(), "a24-e2e-flag-"));
+  launched = await launchApp({ args: ["--workspace", flagHome] });
+});
+
+test.afterEach(async () => {
+  await launched?.close();
+  rmSync(flagHome, { recursive: true, force: true });
+});
+
+test("uses the --workspace folder instead of ACCOUNTANT24_WORKSPACE and shows it in Settings → About", async () => {
+  const window = await launched.app.firstWindow();
+  await window.waitForLoadState("domcontentloaded");
+
+  // Seeded at the flagged path, not in the env-var decoy.
+  expect(existsSync(path.join(flagHome, "ledger", "main.journal"))).toBe(true);
+  expect(existsSync(path.join(flagHome, ".git"))).toBe(true);
+  expect(existsSync(path.join(launched.home, "ledger"))).toBe(false);
+
+  // Settings → About → the Workspace row shows the absolute path. (Never click
+  // it here: it would open the Finder on the test machine.)
+  await window.getByText("Use an API key").click();
+  await window.getByRole("button", { name: "About", exact: true }).click();
+  await expect(window.getByText(flagHome)).toBeVisible();
+});

--- a/packages/desktop/src/main/__tests__/analytics.test.ts
+++ b/packages/desktop/src/main/__tests__/analytics.test.ts
@@ -40,7 +40,6 @@ vi.mock("electron", () => ({
 vi.mock("../env", () => ({
   workspaceDir: () => "/ws",
   appSettingsPath: () => "/ws/app-settings.json",
-  legacySettingsPath: () => "/ws/settings.json",
 }));
 
 const SETTINGS_PATH = "/ws/app-settings.json";

--- a/packages/desktop/src/main/__tests__/cli.test.ts
+++ b/packages/desktop/src/main/__tests__/cli.test.ts
@@ -1,0 +1,180 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// cli.ts parses the app's launch flags and pins the workspace for the process.
+// The filesystem and the home directory are the faked I/O boundaries; the env
+// var it writes is the observable result.
+
+const h = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  statSync: vi.fn(),
+  homedir: vi.fn(() => "/home/user"),
+}));
+
+vi.mock("node:fs", () => ({ existsSync: h.existsSync, statSync: h.statSync }));
+vi.mock("node:os", () => ({ homedir: h.homedir }));
+
+/** Run `fn` with ACCOUNTANT24_WORKSPACE set to `value` (or unset), restoring it after. */
+async function withHome(value: string | undefined, fn: () => Promise<void>): Promise<void> {
+  const prev = process.env.ACCOUNTANT24_WORKSPACE;
+  if (value === undefined) delete process.env.ACCOUNTANT24_WORKSPACE;
+  else process.env.ACCOUNTANT24_WORKSPACE = value;
+  try {
+    await fn();
+  } finally {
+    if (prev === undefined) delete process.env.ACCOUNTANT24_WORKSPACE;
+    else process.env.ACCOUNTANT24_WORKSPACE = prev;
+  }
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  h.existsSync.mockReset();
+  h.statSync.mockReset();
+  h.homedir.mockReset();
+  h.homedir.mockReturnValue("/home/user");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("parseWorkspaceFlag()", () => {
+  it("should return undefined when argv has no --workspace", async () => {
+    const { parseWorkspaceFlag } = await import("../cli");
+    expect(parseWorkspaceFlag(["/bin/electron", ".", "--remote-debugging-port=9223"])).toBeUndefined();
+  });
+
+  it("should read the space-separated form `--workspace <path>`", async () => {
+    const { parseWorkspaceFlag } = await import("../cli");
+    expect(parseWorkspaceFlag(["/app/Accountant24", "--workspace", "/tmp/demo"])).toEqual({ path: "/tmp/demo" });
+  });
+
+  it("should read the equals form `--workspace=<path>`", async () => {
+    const { parseWorkspaceFlag } = await import("../cli");
+    expect(parseWorkspaceFlag(["/app/Accountant24", "--workspace=/tmp/demo"])).toEqual({ path: "/tmp/demo" });
+  });
+
+  it("should let the last occurrence win", async () => {
+    const { parseWorkspaceFlag } = await import("../cli");
+    expect(parseWorkspaceFlag(["x", "--workspace", "/one", "--workspace=/two"])).toEqual({ path: "/two" });
+  });
+
+  it("should ignore other switches around the flag", async () => {
+    const { parseWorkspaceFlag } = await import("../cli");
+    const argv = ["/bin/electron", ".", "--inspect=0", "--workspace", "/tmp/demo", "--remote-debugging-port=9224"];
+    expect(parseWorkspaceFlag(argv)).toEqual({ path: "/tmp/demo" });
+  });
+
+  it("should report an error when --workspace is the last argument", async () => {
+    const { parseWorkspaceFlag } = await import("../cli");
+    expect(parseWorkspaceFlag(["x", "--workspace"])).toEqual({ error: expect.stringContaining("--workspace") });
+  });
+
+  it("should report an error when --workspace is followed by another switch", async () => {
+    const { parseWorkspaceFlag } = await import("../cli");
+    expect(parseWorkspaceFlag(["x", "--workspace", "--foo"])).toEqual({
+      error: expect.stringContaining("--workspace"),
+    });
+  });
+
+  it("should report an error for an empty `--workspace=`", async () => {
+    const { parseWorkspaceFlag } = await import("../cli");
+    expect(parseWorkspaceFlag(["x", "--workspace="])).toEqual({ error: expect.stringContaining("--workspace") });
+  });
+
+  it("should not mistake a prefixed switch like --workspaces for the flag", async () => {
+    const { parseWorkspaceFlag } = await import("../cli");
+    expect(parseWorkspaceFlag(["x", "--workspaces", "/tmp/demo"])).toBeUndefined();
+  });
+});
+
+describe("applyWorkspaceFlag()", () => {
+  it("should export an absolute --workspace path as ACCOUNTANT24_WORKSPACE and report the flag as the source", async () => {
+    await withHome(undefined, async () => {
+      const { applyWorkspaceFlag } = await import("../cli");
+      h.existsSync.mockReturnValue(false);
+      expect(applyWorkspaceFlag(["x", "--workspace", "/tmp/demo"])).toBe("flag");
+      expect(process.env.ACCOUNTANT24_WORKSPACE).toBe("/tmp/demo");
+    });
+  });
+
+  it("should let the flag override an ACCOUNTANT24_WORKSPACE that is already set", async () => {
+    await withHome("/from/env", async () => {
+      const { applyWorkspaceFlag } = await import("../cli");
+      h.existsSync.mockReturnValue(false);
+      expect(applyWorkspaceFlag(["x", "--workspace=/from/flag"])).toBe("flag");
+      expect(process.env.ACCOUNTANT24_WORKSPACE).toBe("/from/flag");
+    });
+  });
+
+  it("should expand a leading ~ against the home directory", async () => {
+    await withHome(undefined, async () => {
+      h.homedir.mockReturnValue("/home/erin");
+      const { applyWorkspaceFlag } = await import("../cli");
+      h.existsSync.mockReturnValue(false);
+      applyWorkspaceFlag(["x", "--workspace", "~/Demo"]);
+      expect(process.env.ACCOUNTANT24_WORKSPACE).toBe("/home/erin/Demo");
+    });
+  });
+
+  it("should resolve a relative path against the current working directory", async () => {
+    await withHome(undefined, async () => {
+      const { applyWorkspaceFlag } = await import("../cli");
+      h.existsSync.mockReturnValue(false);
+      applyWorkspaceFlag(["x", "--workspace", "demo-ws"]);
+      expect(process.env.ACCOUNTANT24_WORKSPACE).toBe(path.resolve("demo-ws"));
+    });
+  });
+
+  it("should accept a folder that already exists", async () => {
+    await withHome(undefined, async () => {
+      const { applyWorkspaceFlag } = await import("../cli");
+      h.existsSync.mockReturnValue(true);
+      h.statSync.mockReturnValue({ isDirectory: () => true });
+      expect(applyWorkspaceFlag(["x", "--workspace", "/tmp/existing"])).toBe("flag");
+      expect(process.env.ACCOUNTANT24_WORKSPACE).toBe("/tmp/existing");
+    });
+  });
+
+  it("should throw and leave the env untouched when the path exists but is a file", async () => {
+    await withHome(undefined, async () => {
+      const { applyWorkspaceFlag } = await import("../cli");
+      h.existsSync.mockReturnValue(true);
+      h.statSync.mockReturnValue({ isDirectory: () => false });
+      expect(() => applyWorkspaceFlag(["x", "--workspace", "/tmp/notes.txt"])).toThrow(/\/tmp\/notes\.txt is a file/);
+      expect(process.env.ACCOUNTANT24_WORKSPACE).toBeUndefined();
+    });
+  });
+
+  it("should throw and leave the env untouched for a flag without a value", async () => {
+    await withHome("/from/env", async () => {
+      const { applyWorkspaceFlag } = await import("../cli");
+      expect(() => applyWorkspaceFlag(["x", "--workspace"])).toThrow(/--workspace needs a folder path/);
+      expect(process.env.ACCOUNTANT24_WORKSPACE).toBe("/from/env");
+    });
+  });
+
+  it("should report the env var as the source when there is no flag but ACCOUNTANT24_WORKSPACE is set", async () => {
+    await withHome("/from/env", async () => {
+      const { applyWorkspaceFlag } = await import("../cli");
+      expect(applyWorkspaceFlag(["x"])).toBe("env");
+      expect(process.env.ACCOUNTANT24_WORKSPACE).toBe("/from/env");
+    });
+  });
+
+  it("should report the default as the source when neither the flag nor the env var is set", async () => {
+    await withHome(undefined, async () => {
+      const { applyWorkspaceFlag } = await import("../cli");
+      expect(applyWorkspaceFlag(["x"])).toBe("default");
+      expect(process.env.ACCOUNTANT24_WORKSPACE).toBeUndefined();
+    });
+  });
+
+  it("should treat an empty ACCOUNTANT24_WORKSPACE as unset when reporting the source", async () => {
+    await withHome("", async () => {
+      const { applyWorkspaceFlag } = await import("../cli");
+      expect(applyWorkspaceFlag(["x"])).toBe("default");
+    });
+  });
+});

--- a/packages/desktop/src/main/__tests__/env.test.ts
+++ b/packages/desktop/src/main/__tests__/env.test.ts
@@ -31,72 +31,79 @@ afterEach(() => {
 
 describe("workspace paths", () => {
   it("should all live directly under the workspace", async () => {
-    const prev = process.env.ACCOUNTANT24_HOME;
-    process.env.ACCOUNTANT24_HOME = "/ws";
+    const prev = process.env.ACCOUNTANT24_WORKSPACE;
+    process.env.ACCOUNTANT24_WORKSPACE = "/ws";
     try {
       const mod = await import("../env");
       expect(mod.skillsDir()).toBe("/ws/skills");
       expect(mod.sessionsDir()).toBe("/ws/sessions");
       expect(mod.mainJournalPath()).toBe("/ws/ledger/main.journal");
       expect(mod.appSettingsPath()).toBe("/ws/app-settings.json");
-      expect(mod.legacySettingsPath()).toBe("/ws/settings.json");
     } finally {
-      if (prev === undefined) delete process.env.ACCOUNTANT24_HOME;
-      else process.env.ACCOUNTANT24_HOME = prev;
+      if (prev === undefined) delete process.env.ACCOUNTANT24_WORKSPACE;
+      else process.env.ACCOUNTANT24_WORKSPACE = prev;
     }
   });
 });
 
 describe("workspaceDir()", () => {
-  it("should use ACCOUNTANT24_HOME verbatim when it is a non-empty path", async () => {
-    const prev = process.env.ACCOUNTANT24_HOME;
-    process.env.ACCOUNTANT24_HOME = "/custom/ws";
+  it("should use ACCOUNTANT24_WORKSPACE verbatim when it is a non-empty path", async () => {
+    const prev = process.env.ACCOUNTANT24_WORKSPACE;
+    process.env.ACCOUNTANT24_WORKSPACE = "/custom/ws";
     try {
       const mod = await import("../env");
       expect(mod.workspaceDir()).toBe("/custom/ws");
     } finally {
-      if (prev === undefined) delete process.env.ACCOUNTANT24_HOME;
-      else process.env.ACCOUNTANT24_HOME = prev;
+      if (prev === undefined) delete process.env.ACCOUNTANT24_WORKSPACE;
+      else process.env.ACCOUNTANT24_WORKSPACE = prev;
     }
   });
 
-  it("should fall back to <homedir>/Accountant24 when ACCOUNTANT24_HOME is unset", async () => {
-    const prev = process.env.ACCOUNTANT24_HOME;
-    delete process.env.ACCOUNTANT24_HOME;
+  it("should fall back to <homedir>/.accountant24 when ACCOUNTANT24_WORKSPACE is unset", async () => {
+    const prev = process.env.ACCOUNTANT24_WORKSPACE;
+    delete process.env.ACCOUNTANT24_WORKSPACE;
     h.homedir.mockReturnValue("/home/alice");
     try {
       const mod = await import("../env");
-      expect(mod.workspaceDir()).toBe("/home/alice/Accountant24");
+      expect(mod.workspaceDir()).toBe("/home/alice/.accountant24");
     } finally {
-      if (prev === undefined) delete process.env.ACCOUNTANT24_HOME;
-      else process.env.ACCOUNTANT24_HOME = prev;
+      if (prev === undefined) delete process.env.ACCOUNTANT24_WORKSPACE;
+      else process.env.ACCOUNTANT24_WORKSPACE = prev;
     }
   });
 
-  it("should fall back to the homedir default when ACCOUNTANT24_HOME is the empty string", async () => {
-    const prev = process.env.ACCOUNTANT24_HOME;
-    process.env.ACCOUNTANT24_HOME = "";
+  it("should fall back to the homedir default when ACCOUNTANT24_WORKSPACE is the empty string", async () => {
+    const prev = process.env.ACCOUNTANT24_WORKSPACE;
+    process.env.ACCOUNTANT24_WORKSPACE = "";
     h.homedir.mockReturnValue("/home/bob");
     try {
       const mod = await import("../env");
-      expect(mod.workspaceDir()).toBe("/home/bob/Accountant24");
+      expect(mod.workspaceDir()).toBe("/home/bob/.accountant24");
     } finally {
-      if (prev === undefined) delete process.env.ACCOUNTANT24_HOME;
-      else process.env.ACCOUNTANT24_HOME = prev;
+      if (prev === undefined) delete process.env.ACCOUNTANT24_WORKSPACE;
+      else process.env.ACCOUNTANT24_WORKSPACE = prev;
     }
   });
 
   it("should place mainJournalPath under the homedir default workspace", async () => {
-    const prev = process.env.ACCOUNTANT24_HOME;
-    delete process.env.ACCOUNTANT24_HOME;
+    const prev = process.env.ACCOUNTANT24_WORKSPACE;
+    delete process.env.ACCOUNTANT24_WORKSPACE;
     h.homedir.mockReturnValue("/home/carol");
     try {
       const mod = await import("../env");
-      expect(mod.mainJournalPath()).toBe("/home/carol/Accountant24/ledger/main.journal");
+      expect(mod.mainJournalPath()).toBe("/home/carol/.accountant24/ledger/main.journal");
     } finally {
-      if (prev === undefined) delete process.env.ACCOUNTANT24_HOME;
-      else process.env.ACCOUNTANT24_HOME = prev;
+      if (prev === undefined) delete process.env.ACCOUNTANT24_WORKSPACE;
+      else process.env.ACCOUNTANT24_WORKSPACE = prev;
     }
+  });
+});
+
+describe("defaultWorkspaceDir()", () => {
+  it("should be the hidden .accountant24 folder in the home directory", async () => {
+    h.homedir.mockReturnValue("/home/dave");
+    const mod = await import("../env");
+    expect(mod.defaultWorkspaceDir()).toBe("/home/dave/.accountant24");
   });
 });
 
@@ -122,20 +129,20 @@ describe("binDir()", () => {
 });
 
 describe("agentEnv()", () => {
-  it("should point ACCOUNTANT24_HOME and PI_CODING_AGENT_DIR at the workspace", async () => {
-    const prev = process.env.ACCOUNTANT24_HOME;
+  it("should point ACCOUNTANT24_WORKSPACE and PI_CODING_AGENT_DIR at the workspace", async () => {
+    const prev = process.env.ACCOUNTANT24_WORKSPACE;
     const origRes = process.resourcesPath;
-    process.env.ACCOUNTANT24_HOME = "/ws";
+    process.env.ACCOUNTANT24_WORKSPACE = "/ws";
     Object.defineProperty(process, "resourcesPath", { value: "/pkg-res", configurable: true });
     h.existsSync.mockReturnValue(false);
     try {
       const mod = await import("../env");
       const env = mod.agentEnv();
-      expect(env.ACCOUNTANT24_HOME).toBe("/ws");
+      expect(env.ACCOUNTANT24_WORKSPACE).toBe("/ws");
       expect(env.PI_CODING_AGENT_DIR).toBe("/ws");
     } finally {
-      if (prev === undefined) delete process.env.ACCOUNTANT24_HOME;
-      else process.env.ACCOUNTANT24_HOME = prev;
+      if (prev === undefined) delete process.env.ACCOUNTANT24_WORKSPACE;
+      else process.env.ACCOUNTANT24_WORKSPACE = prev;
       Object.defineProperty(process, "resourcesPath", { value: origRes, configurable: true });
     }
   });
@@ -245,9 +252,9 @@ describe("agentHostEntryPath()", () => {
 
 describe("agentHostConfig()", () => {
   it("should assemble every path the host needs from the workspace and resources", async () => {
-    const prev = process.env.ACCOUNTANT24_HOME;
+    const prev = process.env.ACCOUNTANT24_WORKSPACE;
     const origRes = process.resourcesPath;
-    process.env.ACCOUNTANT24_HOME = "/ws";
+    process.env.ACCOUNTANT24_WORKSPACE = "/ws";
     Object.defineProperty(process, "resourcesPath", { value: "/pkg-res", configurable: true });
     try {
       const mod = await import("../env");
@@ -260,8 +267,8 @@ describe("agentHostConfig()", () => {
         systemPromptPath: "/pkg-res/system.md",
       });
     } finally {
-      if (prev === undefined) delete process.env.ACCOUNTANT24_HOME;
-      else process.env.ACCOUNTANT24_HOME = prev;
+      if (prev === undefined) delete process.env.ACCOUNTANT24_WORKSPACE;
+      else process.env.ACCOUNTANT24_WORKSPACE = prev;
       Object.defineProperty(process, "resourcesPath", { value: origRes, configurable: true });
     }
   });

--- a/packages/desktop/src/main/__tests__/files.test.ts
+++ b/packages/desktop/src/main/__tests__/files.test.ts
@@ -6,7 +6,7 @@ import { makeTmpWorkspace } from "./tmpWorkspace";
 // files.ts archives renderer-supplied bytes (base64) into the workspace under
 // files/YYYY/MM with a timestamped name, and returns the workspace-relative
 // path. Electron IPC is the only faked boundary; the fs is real (a temp
-// ACCOUNTANT24_HOME via makeTmpWorkspace) so the round-trip is honest.
+// ACCOUNTANT24_WORKSPACE via makeTmpWorkspace) so the round-trip is honest.
 type Handler = (event: unknown, payload?: unknown) => unknown;
 
 const h = vi.hoisted(() => ({ handlers: new Map<string, Handler>() }));

--- a/packages/desktop/src/main/__tests__/ledger.test.ts
+++ b/packages/desktop/src/main/__tests__/ledger.test.ts
@@ -31,7 +31,7 @@ vi.mock("../env", () => ({
   workspaceDir: () => "/ws",
   binDir: () => "/vendored/bin",
   mainJournalPath: () => "/ws/ledger/main.journal",
-  agentEnv: () => ({ PATH: "/vendored/bin", ACCOUNTANT24_HOME: "/ws" }),
+  agentEnv: () => ({ PATH: "/vendored/bin", ACCOUNTANT24_WORKSPACE: "/ws" }),
 }));
 
 /** A canned hledger result per subcommand: an array of stdout lines, or an
@@ -177,7 +177,7 @@ describe("ledger_mentions", () => {
       const opts = call[2] as { cwd: string; env: unknown; maxBuffer: number };
       expect(args).toEqual([args[0], "-f", journal]);
       expect(opts.cwd).toBe("/ws");
-      expect(opts.env).toEqual({ PATH: "/vendored/bin", ACCOUNTANT24_HOME: "/ws" });
+      expect(opts.env).toEqual({ PATH: "/vendored/bin", ACCOUNTANT24_WORKSPACE: "/ws" });
       expect(opts.maxBuffer).toBe(16 * 1024 * 1024);
     }
   });
@@ -311,7 +311,7 @@ describe("ledger_net_worth", () => {
     for (const call of h.execFile.mock.calls) {
       const opts = call[2] as { cwd: string; env: unknown; maxBuffer: number };
       expect(opts.cwd).toBe("/ws");
-      expect(opts.env).toEqual({ PATH: "/vendored/bin", ACCOUNTANT24_HOME: "/ws" });
+      expect(opts.env).toEqual({ PATH: "/vendored/bin", ACCOUNTANT24_WORKSPACE: "/ws" });
       expect(opts.maxBuffer).toBe(16 * 1024 * 1024);
     }
   });
@@ -461,7 +461,7 @@ describe("ledger_transactions", () => {
     expect(call[1]).toEqual(["print", "-O", "json", "-I", "-f", "/ws/ledger/main.journal"]);
     const opts = call[2] as { cwd: string; env: unknown; maxBuffer: number };
     expect(opts.cwd).toBe("/ws");
-    expect(opts.env).toEqual({ PATH: "/vendored/bin", ACCOUNTANT24_HOME: "/ws" });
+    expect(opts.env).toEqual({ PATH: "/vendored/bin", ACCOUNTANT24_WORKSPACE: "/ws" });
     // A journal of ~6k transactions overflows the 16 MB default; the register
     // needs the raised cap so years of history don't render as "empty".
     expect(opts.maxBuffer).toBe(256 * 1024 * 1024);

--- a/packages/desktop/src/main/__tests__/settings.integration.test.ts
+++ b/packages/desktop/src/main/__tests__/settings.integration.test.ts
@@ -1,7 +1,7 @@
 // Integration: app-settings persistence over a REAL filesystem (a temp
-// ACCOUNTANT24_HOME via makeTmpWorkspace). Unlike the unit test (settings.test.ts,
-// in-memory fs map), this exercises the actual node:fs round-trip + the legacy
-// migration end-to-end. Only `electron` is faked (the IPC boundary).
+// ACCOUNTANT24_WORKSPACE via makeTmpWorkspace). Unlike the unit test (settings.test.ts,
+// in-memory fs map), this exercises the actual node:fs round-trip end-to-end.
+// Only `electron` is faked (the IPC boundary).
 
 import { readFileSync, writeFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -44,6 +44,18 @@ describe("settings persistence (real fs)", () => {
     expect(get()).toEqual({});
   });
 
+  it("should leave pi's settings.json alone: never read as ours, never rewritten", async () => {
+    await load();
+    // pi's own file in the same workspace, holding keys that look like ours.
+    const piSettings = JSON.stringify({ defaultModel: "a/1", enabledModels: ["a/1"], defaultProvider: "pi" });
+    writeFileSync(ws.path("settings.json"), piSettings);
+
+    expect(get()).toEqual({});
+    set({ defaultModel: "b/2" });
+    expect(readFileSync(ws.path("settings.json"), "utf8")).toBe(piSettings);
+    expect(readJson("app-settings.json")).toEqual({ defaultModel: "b/2" });
+  });
+
   it("should persist a set and read it back from app-settings.json on disk", async () => {
     await load();
     const merged = set({ defaultModel: "anthropic/opus" });
@@ -84,30 +96,6 @@ describe("settings persistence (real fs)", () => {
       JSON.stringify({ defaultModel: { provider: "anthropic", modelId: "opus" } }),
     );
     expect(get()).toEqual({ defaultModel: "anthropic/opus" });
-  });
-
-  describe("legacy migration (settings.json -> app-settings.json)", () => {
-    it("should move app keys out and leave pi keys behind", async () => {
-      await load();
-      // Only the legacy shared file exists, mixing app + pi keys.
-      writeFileSync(
-        ws.path("settings.json"),
-        JSON.stringify({ defaultModel: "a/1", enabledModels: ["a/1"], defaultProvider: "pi" }),
-      );
-
-      expect(get()).toEqual({ defaultModel: "a/1", enabledModels: ["a/1"] });
-      // app-settings.json now holds our keys...
-      expect(readJson("app-settings.json")).toEqual({ defaultModel: "a/1", enabledModels: ["a/1"] });
-      // ...and settings.json keeps only pi's.
-      expect(readJson("settings.json")).toEqual({ defaultProvider: "pi" });
-    });
-
-    it("should prefer an existing app-settings.json over the legacy file", async () => {
-      await load();
-      writeFileSync(ws.path("app-settings.json"), JSON.stringify({ defaultModel: "new/model" }));
-      writeFileSync(ws.path("settings.json"), JSON.stringify({ defaultModel: "old/model" }));
-      expect(get()).toEqual({ defaultModel: "new/model" });
-    });
   });
 
   describe("consumeOnce()", () => {

--- a/packages/desktop/src/main/__tests__/settings.test.ts
+++ b/packages/desktop/src/main/__tests__/settings.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// settings.ts persists app config in ~/Accountant24/app-settings.json. The fs is
+// settings.ts persists app config in <workspace>/app-settings.json. The fs is
 // the faked I/O boundary (an in-memory file map, so persistence semantics are
 // real); the module's own logic — key filtering, merging, one-time markers —
 // runs for real.
@@ -33,7 +33,6 @@ vi.mock("electron", () => ({
 vi.mock("../env", () => ({
   workspaceDir: () => "/ws",
   appSettingsPath: () => "/ws/app-settings.json",
-  legacySettingsPath: () => "/ws/settings.json",
 }));
 
 const SETTINGS_PATH = "/ws/app-settings.json";

--- a/packages/desktop/src/main/__tests__/tmpWorkspace.ts
+++ b/packages/desktop/src/main/__tests__/tmpWorkspace.ts
@@ -1,7 +1,7 @@
-// Isolated temp ACCOUNTANT24_HOME for main-process integration tests.
+// Isolated temp ACCOUNTANT24_WORKSPACE for main-process integration tests.
 //
 // The main modules (settings.ts, files.ts, ledger.ts, analytics.ts, …) resolve
-// their storage under `workspaceDir()`, which reads process.env.ACCOUNTANT24_HOME
+// their storage under `workspaceDir()`, which reads process.env.ACCOUNTANT24_WORKSPACE
 // (see ../env.ts). Pointing that at a fresh temp dir lets these tests do REAL fs
 // round-trips — the honest I/O boundary — instead of mocking node:fs globally.
 //
@@ -17,9 +17,9 @@ import path from "node:path";
 export interface TmpWorkspace {
   /** The active temp workspace dir (valid between setup() and cleanup()). */
   readonly dir: string;
-  /** Create a fresh temp dir and point ACCOUNTANT24_HOME at it. */
+  /** Create a fresh temp dir and point ACCOUNTANT24_WORKSPACE at it. */
   setup(): string;
-  /** Remove the temp dir and restore the previous ACCOUNTANT24_HOME. */
+  /** Remove the temp dir and restore the previous ACCOUNTANT24_WORKSPACE. */
   cleanup(): void;
   /** Join segments into the current workspace dir. */
   path(...segments: string[]): string;
@@ -34,16 +34,16 @@ export function makeTmpWorkspace(): TmpWorkspace {
       return dir;
     },
     setup() {
-      prev = process.env.ACCOUNTANT24_HOME;
+      prev = process.env.ACCOUNTANT24_WORKSPACE;
       dir = mkdtempSync(path.join(tmpdir(), "a24-test-"));
-      process.env.ACCOUNTANT24_HOME = dir;
+      process.env.ACCOUNTANT24_WORKSPACE = dir;
       return dir;
     },
     cleanup() {
       if (dir) rmSync(dir, { recursive: true, force: true });
       dir = "";
-      if (prev === undefined) delete process.env.ACCOUNTANT24_HOME;
-      else process.env.ACCOUNTANT24_HOME = prev;
+      if (prev === undefined) delete process.env.ACCOUNTANT24_WORKSPACE;
+      else process.env.ACCOUNTANT24_WORKSPACE = prev;
     },
     path(...segments) {
       return path.join(dir, ...segments);

--- a/packages/desktop/src/main/__tests__/workspace.test.ts
+++ b/packages/desktop/src/main/__tests__/workspace.test.ts
@@ -1,16 +1,24 @@
-// The fs and git are real (a temp ACCOUNTANT24_HOME via makeTmpWorkspace) — what
+// The fs and git are real (a temp ACCOUNTANT24_WORKSPACE via makeTmpWorkspace) — what
 // the module leaves on disk is the whole point of it. Electron is the only faked
-// boundary, for the app metadata env.ts reads.
+// boundary: the app metadata env.ts reads, and ipcMain/shell for the IPC.
 
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { ensureWorkspace } from "../workspace";
+import { ensureWorkspace, registerWorkspaceIpc } from "../workspace";
 import { makeTmpWorkspace } from "./tmpWorkspace";
+
+type Handler = (event: unknown, payload?: unknown) => unknown;
+const h = vi.hoisted(() => ({
+  handlers: new Map<string, (event: unknown, payload?: unknown) => unknown>(),
+  openPath: vi.fn(() => Promise.resolve("")),
+}));
 
 vi.mock("electron", () => ({
   app: { isPackaged: false, getAppPath: () => "/app" },
+  ipcMain: { handle: (channel: string, fn: Handler) => h.handlers.set(channel, fn) },
+  shell: { openPath: h.openPath },
 }));
 
 const ws = makeTmpWorkspace();
@@ -242,11 +250,35 @@ describe("ensureWorkspace()", () => {
   });
 
   test("should create the workspace root when it does not exist yet", async () => {
-    const nested = join(BASE, "nested", "Accountant24");
-    process.env.ACCOUNTANT24_HOME = nested;
+    const nested = join(BASE, "nested", ".accountant24");
+    process.env.ACCOUNTANT24_WORKSPACE = nested;
 
     await ensureWorkspace();
 
     expect(existsSync(join(nested, "ledger", "main.journal"))).toBe(true);
+  });
+});
+
+describe("registerWorkspaceIpc()", () => {
+  beforeEach(() => {
+    h.handlers.clear();
+    h.openPath.mockReset();
+    h.openPath.mockResolvedValue("");
+    registerWorkspaceIpc();
+  });
+
+  test("should answer workspace_dir with the active workspace path", async () => {
+    expect(await h.handlers.get("workspace_dir")?.({})).toBe(BASE);
+  });
+
+  test("should open the workspace folder in the file manager on workspace_open", async () => {
+    await h.handlers.get("workspace_open")?.({});
+    expect(h.openPath).toHaveBeenCalledTimes(1);
+    expect(h.openPath).toHaveBeenCalledWith(BASE);
+  });
+
+  test("should reject workspace_open when the file manager reports an error", async () => {
+    h.openPath.mockResolvedValue("No application can open this folder");
+    await expect(h.handlers.get("workspace_open")?.({})).rejects.toThrow("No application can open this folder");
   });
 });

--- a/packages/desktop/src/main/agent/__tests__/router.test.ts
+++ b/packages/desktop/src/main/agent/__tests__/router.test.ts
@@ -50,7 +50,7 @@ vi.mock("../../analytics", () => ({ trackAgentFailed: h.trackAgentFailed }));
 vi.mock("../../env", () => ({
   workspaceDir: () => "/ws",
   sessionsDir: () => "/ws/sessions",
-  agentEnv: () => ({ PATH: "/vendored/bin", ACCOUNTANT24_HOME: "/ws", DROPPED: undefined }),
+  agentEnv: () => ({ PATH: "/vendored/bin", ACCOUNTANT24_WORKSPACE: "/ws", DROPPED: undefined }),
   agentHostEntryPath: () => "/out/main/agent-host.js",
   agentHostConfig: () => ({ workspaceDir: "/ws", sessionsDir: "/ws/sessions" }),
 }));
@@ -123,7 +123,7 @@ describe("agent_send", () => {
     expect(opts.stdio).toEqual(["ignore", "pipe", "pipe"]);
     // Undefined env values are filtered; the Dock-icon-era ELECTRON_RUN_AS_NODE
     // must be gone.
-    expect(opts.env).toEqual({ PATH: "/vendored/bin", ACCOUNTANT24_HOME: "/ws" });
+    expect(opts.env).toEqual({ PATH: "/vendored/bin", ACCOUNTANT24_WORKSPACE: "/ws" });
   });
 
   it("should post the command to the host tagged with its session path", async () => {

--- a/packages/desktop/src/main/agent/skills-store.ts
+++ b/packages/desktop/src/main/agent/skills-store.ts
@@ -1,4 +1,4 @@
-// The on-disk skills store: ~/Accountant24/skills, one self-contained folder per
+// The on-disk skills store: <workspace>/skills, one self-contained folder per
 // skill (Agent Skills standard — a directory holding SKILL.md). This module owns
 // the folder-level logic shared by the agent spawn (which passes each enabled
 // skill via `--skill`) and the skills IPC module; it deliberately has no

--- a/packages/desktop/src/main/agent/skills.ts
+++ b/packages/desktop/src/main/agent/skills.ts
@@ -1,4 +1,4 @@
-// Skills — manage the Agent Skills store (~/Accountant24/skills) over IPC.
+// Skills — manage the Agent Skills store (<workspace>/skills) over IPC.
 //
 // Add = fetch the repo tarball from the GitHub API over plain HTTPS (no git
 // or npm on the user's machine) → extract into a temp dir → locate + validate

--- a/packages/desktop/src/main/analytics.ts
+++ b/packages/desktop/src/main/analytics.ts
@@ -2,7 +2,7 @@
 // (one event per launch, no renderer SDK, no extra IPC channel). Aptabase is
 // privacy-first by design: no cookies, no persistent device id, IP only used as
 // an ephemeral daily-rotated hash and never stored. Everything here is gated on
-// the user's opt-out (`analyticsEnabled: false` in ~/Accountant24/app-settings.json).
+// the user's opt-out (`analyticsEnabled: false` in <workspace>/app-settings.json).
 
 import { initialize, trackEvent } from "@aptabase/electron/main";
 import { ipcMain } from "electron";

--- a/packages/desktop/src/main/cli.ts
+++ b/packages/desktop/src/main/cli.ts
@@ -1,0 +1,66 @@
+// The command-line flags the app accepts. Today that is one: `--workspace`.
+//
+// Which folder is the workspace is decided once per launch, in this order: the
+// `--workspace <path>` flag, then the ACCOUNTANT24_WORKSPACE env var, then the
+// default (~/.accountant24, see env.ts). The flag is exported into
+// ACCOUNTANT24_WORKSPACE so that one env var stays the single channel every
+// consumer reads. Parsing scans process.argv itself: Electron's
+// app.commandLine only understands the `--flag=value` form and is documented
+// as not meant for application flags.
+
+import { existsSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+export type WorkspaceSource = "flag" | "env" | "default";
+
+const WORKSPACE_FLAG = "--workspace";
+
+/** Find `--workspace <path>` / `--workspace=<path>` in argv. The last
+ *  occurrence wins; every other switch (Electron's, Chromium's) is ignored. A
+ *  flag without a usable value is an error, never a silent fallback to another
+ *  folder: this is a finance app, opening the wrong workspace is worse than
+ *  not opening. */
+export function parseWorkspaceFlag(argv: readonly string[]): { path: string } | { error: string } | undefined {
+  const missing = { error: `${WORKSPACE_FLAG} needs a folder path, e.g. ${WORKSPACE_FLAG} ~/Demo` };
+  let result: { path: string } | { error: string } | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === WORKSPACE_FLAG) {
+      const value = argv[i + 1];
+      if (value === undefined || value === "" || value.startsWith("-")) {
+        result = missing;
+      } else {
+        result = { path: value };
+        i++;
+      }
+    } else if (arg.startsWith(`${WORKSPACE_FLAG}=`)) {
+      const value = arg.slice(WORKSPACE_FLAG.length + 1);
+      result = value === "" ? missing : { path: value };
+    }
+  }
+  return result;
+}
+
+/** Apply the `--workspace` flag to this process: expand `~`, make the path
+ *  absolute, and export it as ACCOUNTANT24_WORKSPACE so workspaceDir() and every
+ *  child process agree. Returns where the workspace comes from. Throws a
+ *  user-facing Error for a malformed flag or a path that exists but is not a
+ *  directory; a folder that does not exist yet is fine (workspace setup
+ *  creates it). */
+export function applyWorkspaceFlag(argv: readonly string[] = process.argv): WorkspaceSource {
+  const flag = parseWorkspaceFlag(argv);
+  if (flag === undefined) {
+    const env = process.env.ACCOUNTANT24_WORKSPACE;
+    return env && env.length > 0 ? "env" : "default";
+  }
+  if ("error" in flag) throw new Error(flag.error);
+  const expanded =
+    flag.path === "~" || flag.path.startsWith("~/") ? path.join(homedir(), flag.path.slice(1)) : flag.path;
+  const resolved = path.resolve(expanded);
+  if (existsSync(resolved) && !statSync(resolved).isDirectory()) {
+    throw new Error(`${WORKSPACE_FLAG} must point to a folder, but ${resolved} is a file`);
+  }
+  process.env.ACCOUNTANT24_WORKSPACE = resolved;
+  return "flag";
+}

--- a/packages/desktop/src/main/env.ts
+++ b/packages/desktop/src/main/env.ts
@@ -1,8 +1,14 @@
 // Resource paths + the environment passed to the agent-host utilityProcess.
 //
-// The workspace (~/Accountant24) holds the ledger + auth.json + models.json;
-// PATH exposes the vendored native tools (hledger/pdftotext/tesseract) to the
-// agent's bash/tool subprocesses; TESSDATA_PREFIX points at the OCR data.
+// The workspace (~/.accountant24 by default) holds the ledger + auth.json +
+// models.json; PATH exposes the vendored native tools (hledger/pdftotext/
+// tesseract) to the agent's bash/tool subprocesses; TESSDATA_PREFIX points at
+// the OCR data.
+//
+// ACCOUNTANT24_WORKSPACE is the single channel that names the workspace: set
+// by the `--workspace` launch flag (cli.ts) or by the caller's environment, read
+// by workspaceDir() here and inherited by the agent host (agentEnv), the bundled
+// extension, hledger subprocesses, and the test helpers.
 
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
@@ -11,40 +17,42 @@ import { fileURLToPath } from "node:url";
 import { app } from "electron";
 import type { AgentHostConfig } from "../shared/agentHost";
 
-/** ~/Accountant24 — the agent's cwd and the home of the ledger/auth/models. */
-export function workspaceDir(): string {
-  const env = process.env.ACCOUNTANT24_HOME;
-  return env && env.length > 0 ? env : path.join(homedir(), "Accountant24");
+/** ~/.accountant24 — the workspace when neither --workspace nor
+ *  ACCOUNTANT24_WORKSPACE is set. */
+export function defaultWorkspaceDir(): string {
+  return path.join(homedir(), ".accountant24");
 }
 
-/** ~/Accountant24/skills — one self-contained folder per installed skill
+/** The workspace: the agent's cwd and the home of the ledger/auth/models.
+ *  ACCOUNTANT24_WORKSPACE when set and non-empty, else the default. */
+export function workspaceDir(): string {
+  const env = process.env.ACCOUNTANT24_WORKSPACE;
+  return env && env.length > 0 ? env : defaultWorkspaceDir();
+}
+
+/** <workspace>/skills — one self-contained folder per installed skill
  *  (Agent Skills standard: a dir with SKILL.md). Each enabled skill is passed
  *  to the agent child via a `--skill` flag. */
 export function skillsDir(): string {
   return path.join(workspaceDir(), "skills");
 }
 
-/** ~/Accountant24/sessions — pi's session files, one JSONL per chat thread.
+/** <workspace>/sessions — pi's session files, one JSONL per chat thread.
  *  Passed to the agent child via `--session-dir`. */
 export function sessionsDir(): string {
   return path.join(workspaceDir(), "sessions");
 }
 
-/** ~/Accountant24/ledger/main.journal — the ledger's entry point (includes the
+/** <workspace>/ledger/main.journal — the ledger's entry point (includes the
  *  other journal files). */
 export function mainJournalPath(): string {
   return path.join(workspaceDir(), "ledger", "main.journal");
 }
 
-/** ~/Accountant24/app-settings.json — app-owned settings (distinct from pi's). */
+/** <workspace>/app-settings.json — app-owned settings (distinct from pi's
+ *  own settings.json in the same folder). */
 export function appSettingsPath(): string {
   return path.join(workspaceDir(), "app-settings.json");
-}
-
-/** ~/Accountant24/settings.json — pi's settings file, which earlier app
- *  versions shared; read once as a migration source. */
-export function legacySettingsPath(): string {
-  return path.join(workspaceDir(), "settings.json");
 }
 
 /** Dir holding vendored bin/ + tessdata/ + the extension bundle.
@@ -111,7 +119,7 @@ export function agentEnv(): NodeJS.ProcessEnv {
   const workspace = workspaceDir();
   const env: NodeJS.ProcessEnv = {
     ...process.env,
-    ACCOUNTANT24_HOME: workspace,
+    ACCOUNTANT24_WORKSPACE: workspace,
     PI_CODING_AGENT_DIR: workspace,
   };
   const res = resourceDir();

--- a/packages/desktop/src/main/files.ts
+++ b/packages/desktop/src/main/files.ts
@@ -1,5 +1,5 @@
 // Archives every user-attached file into the workspace (files/YYYY/MM, timestamped
-// + deduplicated, relative to ACCOUNTANT24_HOME) and returns its workspace-relative
+// + deduplicated, relative to ACCOUNTANT24_WORKSPACE) and returns its workspace-relative
 // path. The renderer sends the file bytes (base64) rather than a source path, so
 // this works for picked, dropped, and pasted files alike. The agent then receives
 // a ready workspace path — pi-supported types (images) also ride along as native

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -2,20 +2,23 @@
 // auth/sessions, all exposed to the renderer over IPC. Replaces src-tauri.
 
 import { join } from "node:path";
-import { app, BrowserWindow, ipcMain, nativeImage } from "electron";
+import { app, BrowserWindow, dialog, ipcMain, nativeImage } from "electron";
 import { killAllAgents, registerAgentIpc } from "./agent/router";
 import { registerSessionsIpc } from "./agent/sessions";
 import { registerSkillsIpc } from "./agent/skills";
 import { initAnalytics, registerAnalyticsIpc, trackLaunch, trackQuit } from "./analytics";
+import { applyWorkspaceFlag } from "./cli";
+import { workspaceDir } from "./env";
 import { registerFilesIpc } from "./files";
 import { registerLedgerIpc } from "./ledger";
 import { registerAuthIpc } from "./llm-providers/auth";
 import { registerOauthIpc } from "./llm-providers/oauth";
 import { registerOllamaIpc } from "./llm-providers/ollama";
+import { runPendingMigrations } from "./migrations";
 import { registerSettingsIpc } from "./settings";
 import { initAutoUpdater } from "./updater";
 import { createWindow } from "./window";
-import { ensureWorkspace } from "./workspace";
+import { ensureWorkspace, registerWorkspaceIpc } from "./workspace";
 
 // Dev only: expose a local CDP endpoint so tooling (visual-measurement and
 // driver scripts) can attach to the RUNNING dev app instead of launching a
@@ -25,6 +28,28 @@ if (!app.isPackaged && !app.commandLine.hasSwitch("remote-debugging-port")) {
   app.commandLine.appendSwitch("remote-debugging-port", "9223");
 }
 
+/** Refuse to start: a native error box (safe before `ready`, modal) and a
+ *  non-zero exit. Used when continuing could open or create the wrong
+ *  workspace. app.exit() tears the process down asynchronously, so the
+ *  startup path below also checks `startupFailed` and stops. */
+let startupFailed = false;
+function failStartup(message: string): void {
+  startupFailed = true;
+  console.error(`[workspace] ${message}`);
+  dialog.showErrorBox("Accountant24 can't start", message);
+  app.exit(1);
+}
+
+// Pin the workspace for this launch before anything reads it: `--workspace`
+// beats ACCOUNTANT24_WORKSPACE beats ~/.accountant24 (see cli.ts). A malformed
+// flag is fatal rather than a silent fallback to another folder.
+try {
+  const source = applyWorkspaceFlag(process.argv);
+  console.log(`[workspace] using ${workspaceDir()} (${source})`);
+} catch (err) {
+  failStartup(err instanceof Error ? err.message : String(err));
+}
+
 let mainWindow: BrowserWindow | null = null;
 const getWin = (): BrowserWindow | null => mainWindow;
 
@@ -32,7 +57,20 @@ const getWin = (): BrowserWindow | null => mainWindow;
 initAnalytics();
 
 app.whenReady().then(async () => {
-  // Seed ~/Accountant24 (dirs, starter journals, git repo) before anything can
+  if (startupFailed) return;
+
+  // Bring an existing workspace up to date first (e.g. move a pre-0.3
+  // ~/Accountant24 into place). A failed migration is fatal: scaffolding a
+  // fresh workspace next to un-migrated data would hide the user's ledger.
+  try {
+    await runPendingMigrations();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    failStartup(`Updating the workspace failed:\n\n${msg}\n\nWorkspace: ${workspaceDir()}`);
+    return;
+  }
+
+  // Seed the workspace (dirs, starter journals, git repo) before anything can
   // read or write it — the ledger views and settings must not race a fresh
   // install, and the workspace is the agent's cwd. A failure here (an
   // unwritable home) must not cost the user their window: log it and open
@@ -67,6 +105,7 @@ app.whenReady().then(async () => {
   registerFilesIpc();
   registerLedgerIpc();
   registerAnalyticsIpc();
+  registerWorkspaceIpc();
 
   // Count this launch (and a one-time install), respecting the opt-out.
   trackLaunch();

--- a/packages/desktop/src/main/migrations/0001-relocate-legacy-home.ts
+++ b/packages/desktop/src/main/migrations/0001-relocate-legacy-home.ts
@@ -1,0 +1,22 @@
+// Versions before 0.3 kept the default workspace at ~/Accountant24, in plain
+// sight in the home folder. The default is now the hidden ~/.accountant24;
+// this moves an existing folder there once, so upgraded installs keep their
+// ledger, settings, sessions and git history without noticing.
+
+import { existsSync, renameSync } from "node:fs";
+import path from "node:path";
+import type { Migration } from "./runner";
+
+export const relocateLegacyHome: Migration = {
+  id: "0001-relocate-legacy-home",
+  run({ workspaceDir, homeDir }) {
+    // Only the default location is ours to move; a --workspace /
+    // ACCOUNTANT24_WORKSPACE folder is whatever the user pointed at.
+    if (workspaceDir !== path.join(homeDir, ".accountant24")) return;
+    const legacy = path.join(homeDir, "Accountant24");
+    // Already moved (or a fresh workspace was created meanwhile): a leftover
+    // legacy folder is left alone rather than merged or deleted.
+    if (existsSync(workspaceDir) || !existsSync(legacy)) return;
+    renameSync(legacy, workspaceDir);
+  },
+};

--- a/packages/desktop/src/main/migrations/__tests__/0001-relocate-legacy-home.test.ts
+++ b/packages/desktop/src/main/migrations/__tests__/0001-relocate-legacy-home.test.ts
@@ -1,0 +1,69 @@
+// 0001 over a REAL temp "home": the old ~/Accountant24 is moved to the new
+// hidden default exactly once, and only for the default workspace location.
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { relocateLegacyHome } from "../0001-relocate-legacy-home";
+
+let home: string;
+const legacy = () => path.join(home, "Accountant24");
+const target = () => path.join(home, ".accountant24");
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(tmpdir(), "a24-home-"));
+});
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+function seedLegacy(): void {
+  mkdirSync(path.join(legacy(), "ledger", "2026"), { recursive: true });
+  mkdirSync(path.join(legacy(), ".git"), { recursive: true });
+  writeFileSync(path.join(legacy(), "ledger", "main.journal"), "; main\n");
+  writeFileSync(path.join(legacy(), "ledger", "2026", "01.journal"), "2026-01-01 x\n");
+  writeFileSync(path.join(legacy(), "app-settings.json"), '{"defaultModel":"a/1"}\n');
+  writeFileSync(path.join(legacy(), ".git", "HEAD"), "ref: refs/heads/main\n");
+}
+
+describe("0001-relocate-legacy-home", () => {
+  it("should carry the id the runner records", () => {
+    expect(relocateLegacyHome.id).toBe("0001-relocate-legacy-home");
+  });
+
+  it("should move ~/Accountant24 to ~/.accountant24 with everything inside when only the old folder exists", async () => {
+    seedLegacy();
+    await relocateLegacyHome.run({ workspaceDir: target(), homeDir: home });
+    expect(existsSync(legacy())).toBe(false);
+    expect(readFileSync(path.join(target(), "ledger", "main.journal"), "utf8")).toBe("; main\n");
+    expect(readFileSync(path.join(target(), "ledger", "2026", "01.journal"), "utf8")).toBe("2026-01-01 x\n");
+    expect(readFileSync(path.join(target(), "app-settings.json"), "utf8")).toBe('{"defaultModel":"a/1"}\n');
+    expect(readFileSync(path.join(target(), ".git", "HEAD"), "utf8")).toBe("ref: refs/heads/main\n");
+  });
+
+  it("should do nothing on a fresh install where neither folder exists", async () => {
+    await relocateLegacyHome.run({ workspaceDir: target(), homeDir: home });
+    expect(existsSync(legacy())).toBe(false);
+    expect(existsSync(target())).toBe(false);
+  });
+
+  it("should leave both folders untouched when ~/.accountant24 already exists", async () => {
+    seedLegacy();
+    mkdirSync(target());
+    writeFileSync(path.join(target(), "memory.md"), "new\n");
+    await relocateLegacyHome.run({ workspaceDir: target(), homeDir: home });
+    expect(existsSync(path.join(legacy(), "ledger", "main.journal"))).toBe(true);
+    expect(readFileSync(path.join(target(), "memory.md"), "utf8")).toBe("new\n");
+    expect(existsSync(path.join(target(), "ledger"))).toBe(false);
+  });
+
+  it("should do nothing when the workspace is a custom folder, even if the old default exists", async () => {
+    seedLegacy();
+    const custom = path.join(home, "Demo");
+    await relocateLegacyHome.run({ workspaceDir: custom, homeDir: home });
+    expect(existsSync(path.join(legacy(), "ledger", "main.journal"))).toBe(true);
+    expect(existsSync(custom)).toBe(false);
+    expect(existsSync(target())).toBe(false);
+  });
+});

--- a/packages/desktop/src/main/migrations/__tests__/runner.test.ts
+++ b/packages/desktop/src/main/migrations/__tests__/runner.test.ts
@@ -1,0 +1,210 @@
+// The migration runner over a REAL temp directory: the filesystem is the one
+// I/O boundary, and the state file's exact contents are the contract.
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  MIGRATIONS_STATE_FILE,
+  type Migration,
+  readMigrationState,
+  runMigrations,
+  writeMigrationState,
+} from "../runner";
+
+let root: string;
+let ws: string;
+const ctx = () => ({ workspaceDir: ws, homeDir: root });
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "a24-mig-"));
+  ws = path.join(root, ".accountant24");
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+const readState = () => JSON.parse(readFileSync(path.join(ws, MIGRATIONS_STATE_FILE), "utf8"));
+const seedState = (content: string) => {
+  mkdirSync(ws, { recursive: true });
+  writeFileSync(path.join(ws, MIGRATIONS_STATE_FILE), content);
+};
+const noop = (id: string): Migration => ({ id, run: vi.fn() });
+
+describe("readMigrationState()", () => {
+  it("should read nothing applied when the workspace does not exist", () => {
+    expect(readMigrationState(ws)).toEqual({ applied: [] });
+    expect(existsSync(ws)).toBe(false);
+  });
+
+  it("should read the applied ids back from the state file", () => {
+    seedState(JSON.stringify({ applied: ["0001-a", "0002-b"] }));
+    expect(readMigrationState(ws)).toEqual({ applied: ["0001-a", "0002-b"] });
+  });
+
+  it("should treat a corrupt state file as nothing applied", () => {
+    seedState("{not json");
+    expect(readMigrationState(ws)).toEqual({ applied: [] });
+  });
+
+  it("should treat a state file without an applied array as nothing applied", () => {
+    seedState(JSON.stringify({ applied: "0001-a" }));
+    expect(readMigrationState(ws)).toEqual({ applied: [] });
+  });
+
+  it("should treat a state file that is valid JSON but not an object as nothing applied", () => {
+    seedState("null");
+    expect(readMigrationState(ws)).toEqual({ applied: [] });
+    seedState('"0001-a"');
+    expect(readMigrationState(ws)).toEqual({ applied: [] });
+  });
+
+  it("should drop non-string entries from the applied list", () => {
+    seedState(JSON.stringify({ applied: ["0001-a", 7, null] }));
+    expect(readMigrationState(ws)).toEqual({ applied: ["0001-a"] });
+  });
+});
+
+describe("writeMigrationState()", () => {
+  it("should create the workspace dir and write pretty JSON with a trailing newline", () => {
+    writeMigrationState(ws, { applied: ["0001-a"] });
+    expect(readFileSync(path.join(ws, MIGRATIONS_STATE_FILE), "utf8")).toBe(
+      '{\n  "applied": [\n    "0001-a"\n  ]\n}\n',
+    );
+  });
+});
+
+describe("runMigrations()", () => {
+  it("should run every migration in order and record each id when nothing was applied yet", async () => {
+    const order: string[] = [];
+    const a: Migration = { id: "0001-a", run: () => void order.push("a") };
+    const b: Migration = { id: "0002-b", run: () => void order.push("b") };
+    await expect(runMigrations([a, b], ctx())).resolves.toEqual(["0001-a", "0002-b"]);
+    expect(order).toEqual(["a", "b"]);
+    expect(readState()).toEqual({ applied: ["0001-a", "0002-b"] });
+  });
+
+  it("should pass the context through to each migration", async () => {
+    const m = noop("0001-a");
+    await runMigrations([m], ctx());
+    expect(m.run).toHaveBeenCalledWith({ workspaceDir: ws, homeDir: root });
+  });
+
+  it("should skip migrations already recorded and run only the pending ones", async () => {
+    seedState(JSON.stringify({ applied: ["0001-a"] }));
+    const a = noop("0001-a");
+    const b = noop("0002-b");
+    await expect(runMigrations([a, b], ctx())).resolves.toEqual(["0002-b"]);
+    expect(a.run).not.toHaveBeenCalled();
+    expect(b.run).toHaveBeenCalledTimes(1);
+    expect(readState()).toEqual({ applied: ["0001-a", "0002-b"] });
+  });
+
+  it("should re-run everything when the state file is corrupt", async () => {
+    seedState("{not json");
+    const a = noop("0001-a");
+    await expect(runMigrations([a], ctx())).resolves.toEqual(["0001-a"]);
+    expect(readState()).toEqual({ applied: ["0001-a"] });
+  });
+
+  it("should stop at the first failing migration, record only the ones before it, and rethrow with the id", async () => {
+    const a = noop("0001-a");
+    const boom: Migration = {
+      id: "0002-boom",
+      run: () => {
+        throw new Error("disk full");
+      },
+    };
+    const c = noop("0003-c");
+    await expect(runMigrations([a, boom, c], ctx())).rejects.toThrow("migration 0002-boom failed: disk full");
+    expect(c.run).not.toHaveBeenCalled();
+    expect(readState()).toEqual({ applied: ["0001-a"] });
+  });
+
+  it("should wrap a non-Error throw with the migration id too", async () => {
+    const weird: Migration = {
+      id: "0001-weird",
+      run: () => {
+        throw "plain string";
+      },
+    };
+    await expect(runMigrations([weird], ctx())).rejects.toThrow("migration 0001-weird failed: plain string");
+  });
+
+  it("should keep a failed migration pending so the next launch retries it", async () => {
+    let attempts = 0;
+    const flaky: Migration = {
+      id: "0001-flaky",
+      run: () => {
+        attempts++;
+        if (attempts === 1) throw new Error("first try");
+      },
+    };
+    await expect(runMigrations([flaky], ctx())).rejects.toThrow();
+    await expect(runMigrations([flaky], ctx())).resolves.toEqual(["0001-flaky"]);
+    expect(attempts).toBe(2);
+  });
+
+  it("should await async migrations", async () => {
+    let done = false;
+    const slow: Migration = {
+      id: "0001-slow",
+      run: async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        done = true;
+      },
+    };
+    await runMigrations([slow], ctx());
+    expect(done).toBe(true);
+    expect(readState()).toEqual({ applied: ["0001-slow"] });
+  });
+
+  it("should pick up a state file that a migration moved into place and not re-run what it lists", async () => {
+    // Like 0001: the workspace does not exist, the migration renames a folder
+    // (that already has a state file) to become the workspace.
+    const old = path.join(root, "Old");
+    mkdirSync(old);
+    writeFileSync(path.join(old, MIGRATIONS_STATE_FILE), JSON.stringify({ applied: ["0002-b"] }));
+    const mover: Migration = { id: "0001-move", run: () => renameSync(old, ws) };
+    const b = noop("0002-b");
+    const c = noop("0003-c");
+    await expect(runMigrations([mover, b, c], ctx())).resolves.toEqual(["0001-move", "0003-c"]);
+    expect(b.run).not.toHaveBeenCalled();
+    expect(readState()).toEqual({ applied: ["0002-b", "0001-move", "0003-c"] });
+  });
+
+  it("should not duplicate an id that a migration itself recorded", async () => {
+    const self: Migration = {
+      id: "0001-self",
+      run: ({ workspaceDir }) => writeMigrationState(workspaceDir, { applied: ["0001-self"] }),
+    };
+    await runMigrations([self], ctx());
+    expect(readState()).toEqual({ applied: ["0001-self"] });
+  });
+
+  it("should create the workspace dir when recording into one that does not exist yet", async () => {
+    await runMigrations([noop("0001-a")], ctx());
+    expect(existsSync(ws)).toBe(true);
+  });
+
+  it("should write nothing when there is nothing to run", async () => {
+    await expect(runMigrations([], ctx())).resolves.toEqual([]);
+    expect(existsSync(ws)).toBe(false);
+  });
+
+  it("should write nothing when every migration is already recorded", async () => {
+    seedState(JSON.stringify({ applied: ["0001-a"] }));
+    const before = readFileSync(path.join(ws, MIGRATIONS_STATE_FILE), "utf8");
+    await expect(runMigrations([noop("0001-a")], ctx())).resolves.toEqual([]);
+    expect(readFileSync(path.join(ws, MIGRATIONS_STATE_FILE), "utf8")).toBe(before);
+  });
+
+  it("should refuse a list with duplicate ids before running anything", async () => {
+    const a = noop("0001-a");
+    const dup = noop("0001-a");
+    await expect(runMigrations([a, dup], ctx())).rejects.toThrow("duplicate migration id: 0001-a");
+    expect(a.run).not.toHaveBeenCalled();
+    expect(existsSync(ws)).toBe(false);
+  });
+});

--- a/packages/desktop/src/main/migrations/index.ts
+++ b/packages/desktop/src/main/migrations/index.ts
@@ -1,0 +1,14 @@
+// The ordered list of workspace migrations (see runner.ts for the rules) and
+// the launch-time entry point. Append new migrations at the end.
+
+import { homedir } from "node:os";
+import { workspaceDir } from "../env";
+import { relocateLegacyHome } from "./0001-relocate-legacy-home";
+import { type Migration, runMigrations } from "./runner";
+
+export const MIGRATIONS: readonly Migration[] = [relocateLegacyHome];
+
+/** Run the migrations the active workspace has not seen yet. */
+export function runPendingMigrations(): Promise<string[]> {
+  return runMigrations(MIGRATIONS, { workspaceDir: workspaceDir(), homeDir: homedir() });
+}

--- a/packages/desktop/src/main/migrations/runner.ts
+++ b/packages/desktop/src/main/migrations/runner.ts
@@ -1,0 +1,97 @@
+// Workspace migrations: one-off, versioned changes to the layout or contents
+// of an existing workspace, run at launch before the workspace scaffold
+// (workspace.ts) and before anything reads the folder.
+//
+// Adding a migration (conventions: AGENTS.md, "Workspace" → "Migrations"):
+//   1. Create `NNNN-short-name.ts` next to this file with the next 4-digit
+//      number and export a `Migration` whose `id` is the file name.
+//   2. Append it to MIGRATIONS in ./index.ts (order = run order).
+//   3. Cover it with a test over a temp directory (see __tests__).
+// Rules: a migration must be idempotent (a crash between `run` and the
+// record write re-runs it), must only touch the workspace it is given, and is
+// never edited once shipped — add a new one instead.
+//
+// Applied ids are recorded in <workspace>/.migrations.json, so each runs at
+// most once per workspace; the file travels with the workspace (git, backups).
+// This module is Electron-free on purpose: tests run it over real temp dirs.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+export const MIGRATIONS_STATE_FILE = ".migrations.json";
+
+export interface MigrationContext {
+  /** The resolved workspace dir. May not exist yet (fresh install). */
+  workspaceDir: string;
+  /** The user's home dir — injected so migrations (and tests) never reach for
+   *  the real one. */
+  homeDir: string;
+}
+
+export interface Migration {
+  /** Stable id, `NNNN-short-name`; this is what gets recorded. */
+  id: string;
+  run(ctx: MigrationContext): void | Promise<void>;
+}
+
+export interface MigrationState {
+  applied: string[];
+}
+
+function stateFile(workspaceDir: string): string {
+  return path.join(workspaceDir, MIGRATIONS_STATE_FILE);
+}
+
+/** The recorded state. A missing, unreadable, or malformed file reads as
+ *  "nothing applied": every migration is idempotent, so re-running is safe
+ *  and self-heals the file. Never creates anything. */
+export function readMigrationState(workspaceDir: string): MigrationState {
+  const file = stateFile(workspaceDir);
+  if (!existsSync(file)) return { applied: [] };
+  try {
+    const raw = JSON.parse(readFileSync(file, "utf8")) as unknown;
+    const applied = raw && typeof raw === "object" ? (raw as { applied?: unknown }).applied : undefined;
+    if (!Array.isArray(applied)) return { applied: [] };
+    return { applied: applied.filter((id): id is string => typeof id === "string") };
+  } catch {
+    return { applied: [] };
+  }
+}
+
+/** Persist the state, creating the workspace dir if a migration has not. */
+export function writeMigrationState(workspaceDir: string, state: MigrationState): void {
+  mkdirSync(workspaceDir, { recursive: true });
+  writeFileSync(stateFile(workspaceDir), `${JSON.stringify(state, null, 2)}\n`);
+}
+
+/** Run every migration not yet recorded for this workspace, in order, and
+ *  record each one right after it succeeds. Resolves with the ids applied in
+ *  this run. The state is re-read before each migration and before each
+ *  record, because a migration may itself move a folder into place that
+ *  already carries a state file. A failing migration stops the run unrecorded
+ *  and the error propagates, so the caller can refuse to start rather than
+ *  open a half-migrated workspace. */
+export async function runMigrations(migrations: readonly Migration[], ctx: MigrationContext): Promise<string[]> {
+  const ids = new Set<string>();
+  for (const m of migrations) {
+    if (ids.has(m.id)) throw new Error(`duplicate migration id: ${m.id}`);
+    ids.add(m.id);
+  }
+
+  const appliedNow: string[] = [];
+  for (const migration of migrations) {
+    if (readMigrationState(ctx.workspaceDir).applied.includes(migration.id)) continue;
+    try {
+      await migration.run(ctx);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`migration ${migration.id} failed: ${msg}`, { cause: err });
+    }
+    const current = readMigrationState(ctx.workspaceDir).applied;
+    if (!current.includes(migration.id)) {
+      writeMigrationState(ctx.workspaceDir, { applied: [...current, migration.id] });
+    }
+    appliedNow.push(migration.id);
+  }
+  return appliedNow;
+}

--- a/packages/desktop/src/main/settings.ts
+++ b/packages/desktop/src/main/settings.ts
@@ -1,15 +1,15 @@
 // App settings — the app's OWN config, the single source of truth the Settings
-// UI reads/writes. Stored as ~/Accountant24/app-settings.json.
+// UI reads/writes. Stored as <workspace>/app-settings.json.
 //
 // It must NOT share pi's settings.json: pi reads/writes its own settings.json in
-// the same workspace (PI_CODING_AGENT_DIR), so sharing the file mixed pi's keys
-// (e.g. defaultProvider) into ours and risked clobbering. We keep a separate file
-// and only ever persist our own keys.
+// the same workspace (PI_CODING_AGENT_DIR), so sharing the file would mix pi's
+// keys (e.g. defaultProvider) into ours and risk clobbering. We keep a separate
+// file and only ever persist our own keys.
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { ipcMain } from "electron";
 import type { AppSettings } from "../shared/types";
-import { appSettingsPath, legacySettingsPath, workspaceDir } from "./env";
+import { appSettingsPath, workspaceDir } from "./env";
 
 function parseFile(path: string): Record<string, unknown> | undefined {
   if (!existsSync(path)) return undefined;
@@ -41,30 +41,9 @@ function pickAppKeys(raw: Record<string, unknown>): AppSettings {
   return out;
 }
 
-/** One-time move of app keys out of the shared settings.json into app-settings.json,
- *  leaving pi's own keys behind in settings.json. Best-effort. */
-function migrateFromLegacy(): AppSettings {
-  const legacy = parseFile(legacySettingsPath());
-  if (!legacy) return {};
-  const app = pickAppKeys(legacy);
-  try {
-    mkdirSync(workspaceDir(), { recursive: true });
-    writeFileSync(appSettingsPath(), `${JSON.stringify(app, null, 2)}\n`);
-    // Strip our keys from pi's file so it's no longer a mix of both.
-    const cleaned = { ...legacy };
-    delete cleaned.defaultModel;
-    delete cleaned.enabledModels;
-    if (Object.keys(cleaned).length > 0) writeFileSync(legacySettingsPath(), `${JSON.stringify(cleaned, null, 2)}\n`);
-  } catch {
-    // Best-effort; the in-memory `app` is still correct for this session.
-  }
-  return app;
-}
-
 function readSettings(): AppSettings {
   const own = parseFile(appSettingsPath());
-  if (own) return pickAppKeys(own);
-  return migrateFromLegacy();
+  return own ? pickAppKeys(own) : {};
 }
 
 /** Merge-patch the settings file and return the merged result. */

--- a/packages/desktop/src/main/workspace.ts
+++ b/packages/desktop/src/main/workspace.ts
@@ -1,9 +1,12 @@
-// First-run workspace setup: the app seeds ~/Accountant24 with its directories,
-// the starter journal + memory files, and a git repo at launch — before any chat
-// exists, so the ledger views, settings, and skills all work on a fresh install.
+// First-run workspace setup: the app seeds the workspace (~/.accountant24 by
+// default) with its directories, the starter journal + memory files, and a git
+// repo at launch — before any chat exists, so the ledger views, settings, and
+// skills all work on a fresh install. Also the IPC that tells the renderer where
+// the workspace is and opens it in the Finder.
 
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { ipcMain, shell } from "electron";
 import { workspaceDir } from "./env";
 import { commitAll, initRepo } from "./git";
 // `?raw` text imports so vite inlines the template files into the main bundle.
@@ -46,4 +49,15 @@ export async function ensureWorkspace(): Promise<void> {
   if (freshRepo) {
     await commitAll(home, "Initial Accountant24 setup");
   }
+}
+
+/** Register workspace IPC handlers: the active workspace path (Settings →
+ *  About) and opening that folder in the system file manager. */
+export function registerWorkspaceIpc(): void {
+  ipcMain.handle("workspace_dir", () => workspaceDir());
+  ipcMain.handle("workspace_open", async () => {
+    // shell.openPath resolves with an error message (not a rejection) on failure.
+    const error = await shell.openPath(workspaceDir());
+    if (error) throw new Error(error);
+  });
 }

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -36,6 +36,8 @@ const INVOKE_CHANNELS = new Set([
   "analytics_track",
   "update_pending",
   "update_install",
+  "workspace_dir",
+  "workspace_open",
 ]);
 
 const EVENT_CHANNELS = new Set([

--- a/packages/desktop/src/renderer/components/accountant24/settings/__tests__/about-settings.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/settings/__tests__/about-settings.test.tsx
@@ -5,17 +5,21 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { installJsdomPolyfills } from "@/test/jsdomPolyfills";
 
-// IPC boundary: version for the info row, updateApi for the staged-update row.
+// IPC boundary: version for the info row, updateApi for the staged-update row,
+// workspaceApi for the workspace row.
 const h = vi.hoisted(() => ({
   version: vi.fn(),
   pending: vi.fn(),
   install: vi.fn(),
   onDownloaded: vi.fn(),
+  workspaceDir: vi.fn(),
+  openWorkspace: vi.fn(),
 }));
 
 vi.mock("@/rpc/api", () => ({
   appApi: { version: h.version },
   updateApi: { pending: h.pending, install: h.install, onDownloaded: h.onDownloaded },
+  workspaceApi: { dir: h.workspaceDir, open: h.openWorkspace },
 }));
 
 import { AboutSettings } from "../about-settings";
@@ -29,6 +33,8 @@ beforeEach(() => {
   h.pending.mockResolvedValue(null);
   h.install.mockResolvedValue(undefined);
   h.onDownloaded.mockReturnValue(() => {});
+  h.workspaceDir.mockResolvedValue("/home/user/.accountant24");
+  h.openWorkspace.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -109,5 +115,32 @@ describe("AboutSettings", () => {
     render(<AboutSettings />);
     await userEvent.click(await screen.findByRole("button", { name: "Relaunch to update" }));
     expect(h.install).toHaveBeenCalledTimes(1);
+  });
+
+  it("should show the workspace path once it resolves", async () => {
+    render(<AboutSettings />);
+    expect(await screen.findByText("/home/user/.accountant24")).toBeInTheDocument();
+  });
+
+  it("should open the workspace folder when the Workspace row is clicked", async () => {
+    render(<AboutSettings />);
+    await userEvent.click(await screen.findByRole("button", { name: "Workspace /home/user/.accountant24" }));
+    expect(h.openWorkspace).toHaveBeenCalledTimes(1);
+  });
+
+  it("should keep the Workspace row usable when opening the folder fails", async () => {
+    h.openWorkspace.mockRejectedValue(new Error("no finder"));
+    render(<AboutSettings />);
+    const row = await screen.findByRole("button", { name: "Workspace /home/user/.accountant24" });
+    await userEvent.click(row);
+    expect(h.openWorkspace).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "Workspace /home/user/.accountant24" })).toBeInTheDocument();
+  });
+
+  it("should still render the Workspace row when the path lookup fails", async () => {
+    h.workspaceDir.mockRejectedValue(new Error("no workspace"));
+    render(<AboutSettings />);
+    await screen.findByText("v1.2.3");
+    expect(screen.getByRole("button", { name: "Workspace" })).toBeInTheDocument();
   });
 });

--- a/packages/desktop/src/renderer/components/accountant24/settings/__tests__/settings.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/settings/__tests__/settings.test.tsx
@@ -23,6 +23,7 @@ const h = vi.hoisted(() => ({
 vi.mock("@/rpc/api", () => ({
   appApi: { version: h.version },
   updateApi: { pending: h.updatePending, install: vi.fn(), onDownloaded: vi.fn(() => () => {}) },
+  workspaceApi: { dir: vi.fn(async () => "/home/user/.accountant24"), open: vi.fn() },
   authApi: {
     status: h.status,
     detectOllama: h.detectOllama,

--- a/packages/desktop/src/renderer/components/accountant24/settings/about-settings.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/settings/about-settings.tsx
@@ -1,14 +1,14 @@
 // About — read-only app info: version (with the staged-update state when one
-// is pending) and links to the docs and project resources. Nothing here
-// persists settings; links open in the system browser via the window-open
-// handler.
+// is pending), the workspace folder (click opens it in the Finder), and links
+// to the docs and project resources. Nothing here persists settings; links open
+// in the system browser via the window-open handler.
 
-import { ExternalLinkIcon } from "lucide-react";
+import { ExternalLinkIcon, FolderOpenIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/shadcn/button";
 import { ItemActions, ItemContent, ItemTitle } from "@/components/shadcn/item";
 import { useUpdateStatus } from "@/hooks/use-update-status";
-import { appApi, updateApi } from "@/rpc/api";
+import { appApi, updateApi, workspaceApi } from "@/rpc/api";
 import { Section, SettingsRow, SettingsRows } from "./parts";
 
 const RESOURCES = [
@@ -42,12 +42,17 @@ function LinkRow({ label, href }: { label: string; href: string }) {
 
 export function AboutSettings() {
   const [version, setVersion] = useState<string>();
+  const [workspace, setWorkspace] = useState<string>();
   const pendingUpdate = useUpdateStatus();
 
   useEffect(() => {
     appApi
       .version()
       .then(setVersion)
+      .catch(() => undefined);
+    workspaceApi
+      .dir()
+      .then(setWorkspace)
       .catch(() => undefined);
   }, []);
 
@@ -89,6 +94,22 @@ export function AboutSettings() {
               </ItemActions>
             </SettingsRow>
           )}
+          {/* The folder is hidden (~/.accountant24), so this row is how users
+              find it: the whole row is a button that opens it in the Finder.
+              Same layout idiom as LinkRow; `hover:bg-muted` is explicit because
+              the stock Item only styles the hover of anchor rows. */}
+          <SettingsRow
+            className="-mx-2 w-auto rounded-xl px-2 hover:bg-muted"
+            render={<button type="button" onClick={() => void workspaceApi.open().catch(() => undefined)} />}
+          >
+            <ItemContent>
+              <ItemTitle>Workspace</ItemTitle>
+            </ItemContent>
+            <ItemActions className="min-w-0">
+              <span className="text-muted-foreground truncate text-sm">{workspace}</span>
+              <FolderOpenIcon className="text-muted-foreground size-4 shrink-0" />
+            </ItemActions>
+          </SettingsRow>
         </SettingsRows>
       </Section>
 

--- a/packages/desktop/src/renderer/components/accountant24/settings/skills-settings.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/settings/skills-settings.tsx
@@ -1,6 +1,6 @@
 // Skills — what the chat agent can do. Two kinds: native skills embedded in
 // the app bundle (always on, no controls) and custom skills added as
-// folders in the workspace (~/Accountant24/skills), which can be toggled,
+// folders in the workspace (<workspace>/skills), which can be toggled,
 // removed, or added from a public GitHub repo. The agent child is restarted
 // after any change so its --skill flags reflect the store. Mirrors the
 // Providers/Models pages: same sections, rows, badges, and busy patterns.

--- a/packages/desktop/src/renderer/rpc/__tests__/api.test.ts
+++ b/packages/desktop/src/renderer/rpc/__tests__/api.test.ts
@@ -21,6 +21,7 @@ const {
   settingsApi,
   skillsApi,
   updateApi,
+  workspaceApi,
 } = await import("../api");
 
 /** The only I/O boundary is `window.api`; reset it between tests. */
@@ -163,6 +164,29 @@ describe("appApi", () => {
 
       expect(result).toBe("0.2.7");
       expect(bridge.callsFor("app_version")).toEqual([undefined]);
+    });
+  });
+});
+
+describe("workspaceApi", () => {
+  describe("dir()", () => {
+    it("should invoke 'workspace_dir' with no payload and resolve the path", async () => {
+      bridge.setHandler("workspace_dir", () => "/home/user/.accountant24");
+
+      const result = await workspaceApi.dir();
+
+      expect(result).toBe("/home/user/.accountant24");
+      expect(bridge.callsFor("workspace_dir")).toEqual([undefined]);
+    });
+  });
+
+  describe("open()", () => {
+    it("should invoke 'workspace_open' with no payload", async () => {
+      bridge.setHandler("workspace_open", () => undefined);
+
+      await workspaceApi.open();
+
+      expect(bridge.callsFor("workspace_open")).toEqual([undefined]);
     });
   });
 });

--- a/packages/desktop/src/renderer/rpc/api.ts
+++ b/packages/desktop/src/renderer/rpc/api.ts
@@ -81,6 +81,13 @@ export const appApi = {
   version: () => api.invoke<string>("app_version"),
 };
 
+export const workspaceApi = {
+  /** Absolute path of the active workspace folder. */
+  dir: () => api.invoke<string>("workspace_dir"),
+  /** Open the workspace folder in the system file manager (Finder). */
+  open: () => api.invoke<void>("workspace_open"),
+};
+
 export const updateApi = {
   /** The version staged and ready to install, or null if none is pending. Read
    *  on mount since the download may have completed before we subscribed. */
@@ -110,7 +117,7 @@ export const filesApi = {
 const SETTINGS_CHANGED = "a24:settings-changed";
 
 export const settingsApi = {
-  /** Read the app's own settings (~/Accountant24/settings.json). */
+  /** Read the app's own settings (<workspace>/app-settings.json). */
   get: () => api.invoke<AppSettings>("settings_get"),
   /** Merge-patch the app settings; resolves with the merged result. */
   async set(patch: Partial<AppSettings>): Promise<AppSettings> {

--- a/packages/desktop/src/renderer/rpc/types.ts
+++ b/packages/desktop/src/renderer/rpc/types.ts
@@ -34,7 +34,7 @@ export interface ModelInfo {
 /** provider id -> pi's default model id for it. */
 export type ProviderDefaults = Record<string, string>;
 
-// ---- App settings (app-owned config in ~/Accountant24/settings.json) -----
+// ---- App settings (app-owned config in <workspace>/app-settings.json) ---
 
 /** A concrete model pick: provider + the provider's model id. */
 export interface ModelRef {

--- a/packages/desktop/src/shared/types.ts
+++ b/packages/desktop/src/shared/types.ts
@@ -109,7 +109,7 @@ export interface LedgerTransaction {
   postings: LedgerPosting[];
 }
 
-// ---- App settings (app-owned config in ~/Accountant24/app-settings.json) ---
+// ---- App settings (app-owned config in <workspace>/app-settings.json) -----
 
 /** The app's own settings schema (app-owned keys, distinct from pi's config,
  *  which we don't write). */
@@ -129,7 +129,7 @@ export interface AppSettings {
 // ---- Skills (Settings → Skills) --------------------------------------------
 
 /** A skill the agent can use: native (embedded in the app bundle) or
- *  third-party (a folder in ~/Accountant24/skills). */
+ *  third-party (a folder in <workspace>/skills). */
 export interface SkillInfo {
   /** Skill identity: the store folder name for third-party skills, the
    *  frontmatter name for native ones. */

--- a/packages/pi-extension/src/__tests__/config.test.ts
+++ b/packages/pi-extension/src/__tests__/config.test.ts
@@ -1,58 +1,58 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { ACCOUNTANT24_HOME, LEDGER_DIR, MEMORY_PATH, setBaseDir } from "../config";
+import { ACCOUNTANT24_WORKSPACE, LEDGER_DIR, MEMORY_PATH, setBaseDir } from "../config";
 
-const originalHome = join(homedir(), "Accountant24");
+const originalHome = join(homedir(), ".accountant24");
 
 afterEach(() => {
   setBaseDir(originalHome);
 });
 
 describe("config defaults", () => {
-  test("should set ACCOUNTANT24_HOME to ~/Accountant24", () => {
+  test("should set ACCOUNTANT24_WORKSPACE to ~/.accountant24", () => {
     setBaseDir(originalHome);
-    expect(ACCOUNTANT24_HOME).toBe(join(homedir(), "Accountant24"));
+    expect(ACCOUNTANT24_WORKSPACE).toBe(join(homedir(), ".accountant24"));
   });
 
-  test("should set MEMORY_PATH to ~/Accountant24/memory.md", () => {
+  test("should set MEMORY_PATH to ~/.accountant24/memory.md", () => {
     setBaseDir(originalHome);
-    expect(MEMORY_PATH).toBe(join(homedir(), "Accountant24", "memory.md"));
+    expect(MEMORY_PATH).toBe(join(homedir(), ".accountant24", "memory.md"));
   });
 
-  test("should set LEDGER_DIR to ~/Accountant24/ledger", () => {
+  test("should set LEDGER_DIR to ~/.accountant24/ledger", () => {
     setBaseDir(originalHome);
-    expect(LEDGER_DIR).toBe(join(homedir(), "Accountant24", "ledger"));
+    expect(LEDGER_DIR).toBe(join(homedir(), ".accountant24", "ledger"));
   });
 });
 
-describe("ACCOUNTANT24_HOME env var (module eval)", () => {
+describe("ACCOUNTANT24_WORKSPACE env var (module eval)", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.resetModules();
   });
 
-  test("should use ACCOUNTANT24_HOME when set and non-empty", async () => {
-    vi.stubEnv("ACCOUNTANT24_HOME", "/tmp/env-home");
+  test("should use ACCOUNTANT24_WORKSPACE when set and non-empty", async () => {
+    vi.stubEnv("ACCOUNTANT24_WORKSPACE", "/tmp/env-home");
     vi.resetModules();
     const config = await import("../config.js");
-    expect(config.ACCOUNTANT24_HOME).toBe("/tmp/env-home");
+    expect(config.ACCOUNTANT24_WORKSPACE).toBe("/tmp/env-home");
     expect(config.MEMORY_PATH).toBe(join("/tmp/env-home", "memory.md"));
     expect(config.LEDGER_DIR).toBe(join("/tmp/env-home", "ledger"));
   });
 
-  test("should fall back to ~/Accountant24 when ACCOUNTANT24_HOME is empty", async () => {
-    vi.stubEnv("ACCOUNTANT24_HOME", "");
+  test("should fall back to ~/.accountant24 when ACCOUNTANT24_WORKSPACE is empty", async () => {
+    vi.stubEnv("ACCOUNTANT24_WORKSPACE", "");
     vi.resetModules();
     const config = await import("../config.js");
-    expect(config.ACCOUNTANT24_HOME).toBe(join(homedir(), "Accountant24"));
+    expect(config.ACCOUNTANT24_WORKSPACE).toBe(join(homedir(), ".accountant24"));
   });
 });
 
 describe("setBaseDir()", () => {
-  test("should update ACCOUNTANT24_HOME to given dir", () => {
+  test("should update ACCOUNTANT24_WORKSPACE to given dir", () => {
     setBaseDir("/tmp/test-dir");
-    expect(ACCOUNTANT24_HOME).toBe("/tmp/test-dir");
+    expect(ACCOUNTANT24_WORKSPACE).toBe("/tmp/test-dir");
   });
 
   test("should update MEMORY_PATH to dir/memory.md", () => {

--- a/packages/pi-extension/src/config.ts
+++ b/packages/pi-extension/src/config.ts
@@ -1,16 +1,16 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-// Resolved at module-eval time. The desktop app sets ACCOUNTANT24_HOME in the
+// Resolved at module-eval time. The desktop app sets ACCOUNTANT24_WORKSPACE in the
 // agent host's env before forking it, so the bundled extension picks up the
-// right workspace dir; standalone/dev falls back to ~/Accountant24.
-const envHome = process.env.ACCOUNTANT24_HOME;
-export let ACCOUNTANT24_HOME = envHome && envHome.length > 0 ? envHome : join(homedir(), "Accountant24");
-export let MEMORY_PATH = join(ACCOUNTANT24_HOME, "memory.md");
-export let LEDGER_DIR = join(ACCOUNTANT24_HOME, "ledger");
+// right workspace dir; standalone/dev falls back to ~/.accountant24.
+const envHome = process.env.ACCOUNTANT24_WORKSPACE;
+export let ACCOUNTANT24_WORKSPACE = envHome && envHome.length > 0 ? envHome : join(homedir(), ".accountant24");
+export let MEMORY_PATH = join(ACCOUNTANT24_WORKSPACE, "memory.md");
+export let LEDGER_DIR = join(ACCOUNTANT24_WORKSPACE, "ledger");
 
 export function setBaseDir(dir: string): void {
-  ACCOUNTANT24_HOME = dir;
+  ACCOUNTANT24_WORKSPACE = dir;
   MEMORY_PATH = join(dir, "memory.md");
   LEDGER_DIR = join(dir, "ledger");
 }

--- a/packages/pi-extension/src/entry.ts
+++ b/packages/pi-extension/src/entry.ts
@@ -5,7 +5,7 @@
 // desktop app loads via `pi -e <path>`.
 // pi's extension loader calls the default export as `factory(api)`.
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-// Importing config first resolves ACCOUNTANT24_HOME from the env at module-eval time.
+// Importing config first resolves ACCOUNTANT24_WORKSPACE from the env at module-eval time.
 import "./config";
 import { createAccountantExtension } from "./extension";
 

--- a/packages/pi-extension/src/files/__tests__/extract.test.ts
+++ b/packages/pi-extension/src/files/__tests__/extract.test.ts
@@ -8,7 +8,7 @@ const BASE = mkdtempSync(join(tmpdir(), "accountant24-file-extract-"));
 import { vi } from "vitest";
 
 vi.mock("../../config.js", () => ({
-  ACCOUNTANT24_HOME: BASE,
+  ACCOUNTANT24_WORKSPACE: BASE,
   MEMORY_PATH: join(BASE, "memory.md"),
   LEDGER_DIR: join(BASE, "ledger"),
   setBaseDir: () => {},

--- a/packages/pi-extension/src/files/__tests__/paths.test.ts
+++ b/packages/pi-extension/src/files/__tests__/paths.test.ts
@@ -8,7 +8,7 @@ const BASE = mkdtempSync(join(tmpdir(), "accountant24-file-paths-"));
 import { vi } from "vitest";
 
 vi.mock("../../config.js", () => ({
-  ACCOUNTANT24_HOME: BASE,
+  ACCOUNTANT24_WORKSPACE: BASE,
   MEMORY_PATH: join(BASE, "memory.md"),
   LEDGER_DIR: join(BASE, "ledger"),
   setBaseDir: () => {},

--- a/packages/pi-extension/src/files/paths.ts
+++ b/packages/pi-extension/src/files/paths.ts
@@ -1,5 +1,5 @@
 import { isAbsolute } from "node:path";
-import { ACCOUNTANT24_HOME } from "../config";
+import { ACCOUNTANT24_WORKSPACE } from "../config";
 import { resolveSafePath } from "../ledger/paths";
 
 export function resolveWorkspacePath(relativePath: string): string {
@@ -14,5 +14,5 @@ export function resolveWorkspacePath(relativePath: string): string {
     );
   }
 
-  return resolveSafePath(relativePath, ACCOUNTANT24_HOME);
+  return resolveSafePath(relativePath, ACCOUNTANT24_WORKSPACE);
 }

--- a/packages/pi-extension/src/git/commit-push.ts
+++ b/packages/pi-extension/src/git/commit-push.ts
@@ -1,4 +1,4 @@
-import { ACCOUNTANT24_HOME } from "../config";
+import { ACCOUNTANT24_WORKSPACE } from "../config";
 import { commitAll, diffStat, hasRemotes, push } from "./git";
 
 export interface CommitAndPushResult {
@@ -9,7 +9,7 @@ export interface CommitAndPushResult {
   pushed: boolean;
 }
 
-export async function commitAndPush(message: string, cwd = ACCOUNTANT24_HOME): Promise<CommitAndPushResult> {
+export async function commitAndPush(message: string, cwd = ACCOUNTANT24_WORKSPACE): Promise<CommitAndPushResult> {
   const files = await diffStat(cwd);
   const meaningful = files.filter((f) => !f.startsWith("sessions/"));
   if (meaningful.length === 0) return { status: "no_changes", committedFiles: [], commitMessage: "", pushed: false };

--- a/packages/pi-extension/src/ledger/__tests__/accounts.test.ts
+++ b/packages/pi-extension/src/ledger/__tests__/accounts.test.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 
 const BASE = mkdtempSync(join(tmpdir(), "accountant24-accounts-"));
 vi.mock("../../config.js", () => ({
-  ACCOUNTANT24_HOME: BASE,
+  ACCOUNTANT24_WORKSPACE: BASE,
   LEDGER_DIR: join(BASE, "ledger"),
   MEMORY_PATH: join(BASE, "memory.md"),
   setBaseDir: () => {},

--- a/packages/pi-extension/src/ledger/__tests__/payees.test.ts
+++ b/packages/pi-extension/src/ledger/__tests__/payees.test.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 
 const BASE = mkdtempSync(join(tmpdir(), "accountant24-payees-"));
 vi.mock("../../config.js", () => ({
-  ACCOUNTANT24_HOME: BASE,
+  ACCOUNTANT24_WORKSPACE: BASE,
   LEDGER_DIR: join(BASE, "ledger"),
   MEMORY_PATH: join(BASE, "memory.md"),
   setBaseDir: () => {},

--- a/packages/pi-extension/src/ledger/__tests__/query.test.ts
+++ b/packages/pi-extension/src/ledger/__tests__/query.test.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 
 const BASE = mkdtempSync(join(tmpdir(), "accountant24-ledger-"));
 vi.mock("../../config.js", () => ({
-  ACCOUNTANT24_HOME: BASE,
+  ACCOUNTANT24_WORKSPACE: BASE,
   MEMORY_PATH: join(BASE, "memory.md"),
   LEDGER_DIR: join(BASE, "ledger"),
   setBaseDir: () => {},

--- a/packages/pi-extension/src/ledger/__tests__/tags.test.ts
+++ b/packages/pi-extension/src/ledger/__tests__/tags.test.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 
 const BASE = mkdtempSync(join(tmpdir(), "accountant24-tags-"));
 vi.mock("../../config.js", () => ({
-  ACCOUNTANT24_HOME: BASE,
+  ACCOUNTANT24_WORKSPACE: BASE,
   LEDGER_DIR: join(BASE, "ledger"),
   MEMORY_PATH: join(BASE, "memory.md"),
   setBaseDir: () => {},

--- a/packages/pi-extension/src/ledger/__tests__/transactions.test.ts
+++ b/packages/pi-extension/src/ledger/__tests__/transactions.test.ts
@@ -11,7 +11,7 @@ const BASE = mkdtempSync(join(tmpdir(), "accountant24-transactions-"));
 const LEDGER = join(BASE, "ledger");
 
 vi.mock("../../config.js", () => ({
-  ACCOUNTANT24_HOME: BASE,
+  ACCOUNTANT24_WORKSPACE: BASE,
   LEDGER_DIR: LEDGER,
   MEMORY_PATH: join(BASE, "memory.md"),
   setBaseDir: () => {},

--- a/packages/pi-extension/src/ledger/__tests__/validate.test.ts
+++ b/packages/pi-extension/src/ledger/__tests__/validate.test.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 
 const BASE = mkdtempSync(join(tmpdir(), "accountant24-validate-"));
 vi.mock("../../config.js", () => ({
-  ACCOUNTANT24_HOME: BASE,
+  ACCOUNTANT24_WORKSPACE: BASE,
   LEDGER_DIR: join(BASE, "ledger"),
   MEMORY_PATH: join(BASE, "memory.md"),
   setBaseDir: () => {},

--- a/packages/pi-extension/src/ledger/bulk-edit.ts
+++ b/packages/pi-extension/src/ledger/bulk-edit.ts
@@ -1,5 +1,5 @@
 import { isAbsolute, relative, resolve } from "node:path";
-import { ACCOUNTANT24_HOME, LEDGER_DIR } from "../config";
+import { ACCOUNTANT24_WORKSPACE, LEDGER_DIR } from "../config";
 import { JournalEditSession } from "./edit-session";
 import { HledgerCommandError, hledgerCheck, runHledger } from "./hledger";
 import { resolveSafePath } from "./paths";
@@ -116,7 +116,7 @@ export async function bulkEditTransactions(
   let ledgerIsValid = true;
   let validationError: string | undefined;
   try {
-    await hledgerCheck(mainPath, { cwd: ACCOUNTANT24_HOME, signal });
+    await hledgerCheck(mainPath, { cwd: ACCOUNTANT24_WORKSPACE, signal });
   } catch (e) {
     if (e instanceof HledgerCommandError) {
       ledgerIsValid = false;
@@ -215,7 +215,7 @@ async function discover(
 ): Promise<Match[]> {
   // Each query element is one argv token — spaces inside a term are preserved by spawn.
   const stdout = await runHledger(["print", "-f", mainPath, ...query, "-O", "json"], {
-    cwd: ACCOUNTANT24_HOME,
+    cwd: ACCOUNTANT24_WORKSPACE,
     signal,
   });
 
@@ -256,7 +256,7 @@ function parseSourcePos(tsourcepos: unknown): { sourceName: string; sourceLine: 
 
 /** Resolve an hledger source path to an absolute path, confirming it lives inside the ledger dir. */
 function resolveSourceFile(sourceName: string): string | null {
-  const abs = isAbsolute(sourceName) ? sourceName : resolve(ACCOUNTANT24_HOME, sourceName);
+  const abs = isAbsolute(sourceName) ? sourceName : resolve(ACCOUNTANT24_WORKSPACE, sourceName);
   try {
     resolveSafePath(relative(LEDGER_DIR, abs), LEDGER_DIR);
   } catch {

--- a/packages/pi-extension/src/ledger/query.ts
+++ b/packages/pi-extension/src/ledger/query.ts
@@ -1,4 +1,4 @@
-import { ACCOUNTANT24_HOME } from "../config";
+import { ACCOUNTANT24_WORKSPACE } from "../config";
 import { runHledger } from "./hledger";
 import { resolveSafePath } from "./paths";
 
@@ -20,7 +20,7 @@ export interface QueryLedgerResult {
 
 export async function queryLedger(params: any, signal?: AbortSignal): Promise<QueryLedgerResult> {
   const file = params.file ?? "ledger/main.journal";
-  const resolved = resolveSafePath(file, ACCOUNTANT24_HOME);
+  const resolved = resolveSafePath(file, ACCOUNTANT24_WORKSPACE);
   const args = buildQueryArgs(params, resolved);
   const raw = await runHledger(args, { signal });
   const command = ["hledger", ...args].join(" ");

--- a/packages/pi-extension/src/ledger/transactions.ts
+++ b/packages/pi-extension/src/ledger/transactions.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { generateDiffString } from "@earendil-works/pi-coding-agent";
-import { ACCOUNTANT24_HOME, LEDGER_DIR } from "../config";
+import { ACCOUNTANT24_WORKSPACE, LEDGER_DIR } from "../config";
 import { HledgerCommandError, hledgerCheck } from "./hledger";
 import { resolveSafePath } from "./paths";
 
@@ -223,7 +223,7 @@ function declareMissingCommodities(currencies: string[]): void {
 async function validateLedger(formatted: FormattedEntry[], signal?: AbortSignal): Promise<void> {
   const mainPath = resolveSafePath("main.journal", LEDGER_DIR);
   try {
-    await hledgerCheck(mainPath, { cwd: ACCOUNTANT24_HOME, signal });
+    await hledgerCheck(mainPath, { cwd: ACCOUNTANT24_WORKSPACE, signal });
   } catch (e) {
     if (e instanceof HledgerCommandError) {
       const filePaths = [...new Set(formatted.map((f) => f.fullFilePath))].join(", ");

--- a/packages/pi-extension/src/memory/__tests__/guard.test.ts
+++ b/packages/pi-extension/src/memory/__tests__/guard.test.ts
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 const BASE = mkdtempSync(join(tmpdir(), "accountant24-guard-"));
 
 vi.mock("../../config.js", () => ({
-  ACCOUNTANT24_HOME: BASE,
+  ACCOUNTANT24_WORKSPACE: BASE,
   LEDGER_DIR: join(BASE, "ledger"),
   MEMORY_PATH: join(BASE, "memory.md"),
   setBaseDir: () => {},

--- a/packages/pi-extension/src/memory/__tests__/memory.test.ts
+++ b/packages/pi-extension/src/memory/__tests__/memory.test.ts
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 const BASE = mkdtempSync(join(tmpdir(), "accountant24-memory-"));
 
 vi.mock("../../config.js", () => ({
-  ACCOUNTANT24_HOME: BASE,
+  ACCOUNTANT24_WORKSPACE: BASE,
   LEDGER_DIR: join(BASE, "ledger"),
   MEMORY_PATH: join(BASE, "memory.md"),
   setBaseDir: () => {},

--- a/packages/pi-extension/src/memory/__tests__/paths.test.ts
+++ b/packages/pi-extension/src/memory/__tests__/paths.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, test, vi } from "vitest";
 const WORKSPACE = join(homedir(), "Accountant 24");
 
 vi.mock("../../config.js", () => ({
-  ACCOUNTANT24_HOME: WORKSPACE,
+  ACCOUNTANT24_WORKSPACE: WORKSPACE,
   LEDGER_DIR: join(WORKSPACE, "ledger"),
   MEMORY_PATH: join(WORKSPACE, "memory.md"),
   setBaseDir: () => {},

--- a/packages/pi-extension/src/system-prompt/system.md
+++ b/packages/pi-extension/src/system-prompt/system.md
@@ -19,7 +19,7 @@ You are Accountant24 — a personal finance assistant. You help people manage th
 
 # Workspace
 
-Your workspace is `~/Accountant24`. All file operations stay within this directory.
+Your workspace is the current working directory. All file operations stay within it.
 
 - `ledger/main.journal` — Entry point (includes other files via include directives)
 - `ledger/accounts.journal` — Chart of accounts

--- a/packages/pi-extension/src/tools/__tests__/add-balance-assertions.test.ts
+++ b/packages/pi-extension/src/tools/__tests__/add-balance-assertions.test.ts
@@ -11,7 +11,7 @@ const BASE = mkdtempSync(join(tmpdir(), "accountant24-add-ba-"));
 const LEDGER = join(BASE, "ledger");
 
 vi.mock("../../config.js", () => ({
-  ACCOUNTANT24_HOME: BASE,
+  ACCOUNTANT24_WORKSPACE: BASE,
   LEDGER_DIR: LEDGER,
   MEMORY_PATH: join(BASE, "memory.md"),
   setBaseDir: () => {},

--- a/packages/pi-extension/src/tools/__tests__/add-prices.test.ts
+++ b/packages/pi-extension/src/tools/__tests__/add-prices.test.ts
@@ -11,7 +11,7 @@ const BASE = mkdtempSync(join(tmpdir(), "accountant24-add-prices-"));
 const LEDGER = join(BASE, "ledger");
 
 vi.mock("../../config.js", () => ({
-  ACCOUNTANT24_HOME: BASE,
+  ACCOUNTANT24_WORKSPACE: BASE,
   LEDGER_DIR: LEDGER,
   MEMORY_PATH: join(BASE, "memory.md"),
   setBaseDir: () => {},

--- a/packages/pi-extension/src/tools/__tests__/add-transactions.test.ts
+++ b/packages/pi-extension/src/tools/__tests__/add-transactions.test.ts
@@ -11,7 +11,7 @@ const BASE = mkdtempSync(join(tmpdir(), "accountant24-add-tx-"));
 const LEDGER = join(BASE, "ledger");
 
 vi.mock("../../config.js", () => ({
-  ACCOUNTANT24_HOME: BASE,
+  ACCOUNTANT24_WORKSPACE: BASE,
   LEDGER_DIR: LEDGER,
   MEMORY_PATH: join(BASE, "memory.md"),
   setBaseDir: () => {},

--- a/packages/pi-extension/src/tools/__tests__/bulk-edit-transactions.test.ts
+++ b/packages/pi-extension/src/tools/__tests__/bulk-edit-transactions.test.ts
@@ -11,7 +11,7 @@ const BASE = mkdtempSync(join(tmpdir(), "accountant24-bulk-edit-"));
 const LEDGER = join(BASE, "ledger");
 
 vi.mock("../../config.js", () => ({
-  ACCOUNTANT24_HOME: BASE,
+  ACCOUNTANT24_WORKSPACE: BASE,
   LEDGER_DIR: LEDGER,
   MEMORY_PATH: join(BASE, "memory.md"),
   FILES_DIR: join(BASE, "files"),

--- a/packages/pi-extension/src/tools/__tests__/commit-and-push.test.ts
+++ b/packages/pi-extension/src/tools/__tests__/commit-and-push.test.ts
@@ -7,7 +7,7 @@ import { spawnText } from "../../spawn";
 const BASE = mkdtempSync(join(tmpdir(), "accountant24-commit-tool-"));
 
 vi.mock("../../config.js", () => ({
-  ACCOUNTANT24_HOME: BASE,
+  ACCOUNTANT24_WORKSPACE: BASE,
   MEMORY_PATH: join(BASE, "memory.md"),
   LEDGER_DIR: join(BASE, "ledger"),
   setBaseDir: () => {},

--- a/packages/pi-extension/src/tools/__tests__/query.test.ts
+++ b/packages/pi-extension/src/tools/__tests__/query.test.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 
 const BASE = mkdtempSync(join(tmpdir(), "accountant24-query-"));
 vi.mock("../../config.js", () => ({
-  ACCOUNTANT24_HOME: BASE,
+  ACCOUNTANT24_WORKSPACE: BASE,
   MEMORY_PATH: join(BASE, "memory.md"),
   LEDGER_DIR: join(BASE, "ledger"),
   setBaseDir: () => {},

--- a/packages/pi-extension/src/tools/__tests__/validate.test.ts
+++ b/packages/pi-extension/src/tools/__tests__/validate.test.ts
@@ -11,7 +11,7 @@ const BASE = mkdtempSync(join(tmpdir(), "accountant24-validate-"));
 const LEDGER = join(BASE, "ledger");
 
 vi.mock("../../config.js", () => ({
-  ACCOUNTANT24_HOME: BASE,
+  ACCOUNTANT24_WORKSPACE: BASE,
   MEMORY_PATH: join(BASE, "memory.md"),
   LEDGER_DIR: LEDGER,
   setBaseDir: () => {},


### PR DESCRIPTION
- Move the default workspace from `~/Accountant24` to the hidden `~/.accountant24`; an existing `~/Accountant24` is moved there on the first launch.
- Add a versioned workspace migration runner in `src/main/migrations/` (one file per migration, applied ids recorded in `<workspace>/.migrations.json`, a failed migration aborts startup with an error box); `0001-relocate-legacy-home` is the first migration.
- Add the `--workspace <path>` launch flag (`src/main/cli.ts`); precedence is the flag, then `ACCOUNTANT24_WORKSPACE`, then the default. A flag without a path or pointing at a file refuses to start.
- Rename the `ACCOUNTANT24_HOME` env var to `ACCOUNTANT24_WORKSPACE` (app, pi extension, tests, e2e).
- Log `[workspace] using <dir> (flag|env|default)` at startup.
- Show the workspace path in Settings → About; clicking the row opens the folder in the Finder (`workspace_dir` / `workspace_open` IPC).
- Remove the legacy `settings.json` → `app-settings.json` migration from `settings.ts`; pi's `settings.json` is never read or written by the app.
- Replace the hardcoded workspace path in the system prompt with "the current working directory".
- Document the workspace folder and the `--workspace` flag in the docs (Settings, FAQ, Skills), and the workspace, migrations, and "never run against the real workspace" rules in `AGENTS.md` and the verify skill.
- Cover the flag parsing, the runner, the migration, the IPC, and the About row with unit, component, and E2E tests.


BREAKING CHANGE:

- The default workspace is now `~/.accountant24`; an existing `~/Accountant24` is moved there on the first launch. Anything outside the app that pointed at the old path (scripts, `hledger -f`, sync or backup selections, Finder favorites) needs the new one. An older build launched afterwards starts from an empty `~/Accountant24`.
- The `ACCOUNTANT24_HOME` env var is renamed to `ACCOUNTANT24_WORKSPACE`; the old name is ignored.

