### PR TITLE
chore: skip the verify stop hook when the working tree is unchanged

### DIFF
--- a/.claude/hooks/verify-stop.sh
+++ b/.claude/hooks/verify-stop.sh
@@ -8,6 +8,25 @@ if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
   exit 0
 fi
 
+# Fingerprint = HEAD commit + status + tracked diffs + untracked file contents
+tree_hash() {
+  {
+    git rev-parse HEAD
+    git status --porcelain
+    git diff HEAD
+    git ls-files --others --exclude-standard -z | xargs -0 cat 2>/dev/null
+  } | shasum -a 256 | cut -d' ' -f1
+}
+
+# Skip verify when the tree matches the last state that passed verification.
+# State lives in the OS temp dir keyed by project path, so each worktree gets
+# its own cache and nothing is written into the repo.
+STATE_FILE="${TMPDIR:-/tmp}/claude-verify-$(echo "${CLAUDE_PROJECT_DIR:-$PWD}" | shasum | cut -d' ' -f1)"
+
+if [ -f "$STATE_FILE" ] && [ "$(cat "$STATE_FILE")" = "$(tree_hash)" ]; then
+  exit 0
+fi
+
 # Run verification; exit 2 blocks the stop and feeds stderr back to Claude
 OUTPUT=$(npm run verify 2>&1)
 STATUS=$?
@@ -17,4 +36,6 @@ if [ $STATUS -ne 0 ]; then
   exit 2
 fi
 
+# Hash after verify ran — biome check --write may have auto-fixed files
+tree_hash > "$STATE_FILE"
 exit 0


### PR DESCRIPTION
- Fingerprint the git working tree (HEAD, status, tracked diffs, untracked file contents) in `verify-stop.sh`
- Skip `npm run verify` when the fingerprint matches the last state that passed verification
- Save the fingerprint only after a successful verify, computed after `biome check --write` may have auto-fixed files
- Keep the fingerprint cache in the OS temp dir keyed by project path, one per worktree