### PR TITLE
feat: pick up new and changed plugins without an app restart

### DIFF
--- a/docs/docs/create-a-plugin.mdx
+++ b/docs/docs/create-a-plugin.mdx
@@ -20,7 +20,7 @@ monthly-review/
         └── references/          optional reference material
 ```
 
-Put the folder at `~/.accountant24/plugins/<plugin-name>`. It appears under **Settings → Plugins**. Restart the app to make its skills available in chat.
+Put the folder at `~/.accountant24/plugins/<plugin-name>`. The app picks it up within a few seconds. It appears under **Settings → Plugins**, and its skills are ready to use in chat.
 
 The folder name must match the `name` in `plugin.json`.
 

--- a/docs/docs/plugins.mdx
+++ b/docs/docs/plugins.mdx
@@ -14,7 +14,7 @@ The [marketplace](/docs/marketplace) lists plugins published by the community.
 
 ## Your own plugins
 
-Ask the agent to create a skill in chat, or write a plugin manually. See [Create a plugin](/docs/create-a-plugin) for more details.
+Ask the agent to create a skill in chat, or write a plugin manually. The app picks up a new or changed plugin automatically, and its skills are ready to use in chat. See [Create a plugin](/docs/create-a-plugin) for more details.
 
 ## Manage plugins
 

--- a/packages/desktop/src/main/agent/__tests__/plugins-watch.test.ts
+++ b/packages/desktop/src/main/agent/__tests__/plugins-watch.test.ts
@@ -1,0 +1,178 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// plugins-watch.ts turns raw fs events on the workspace plugins folder into
+// the app's "plugins changed" pipeline: one debounced notification to the
+// renderer plus an agent recycle, suppressed while an install holds the lock.
+// The watch itself is the faked I/O boundary (injected); the debounce, lock
+// and notify logic run for real.
+
+const h = vi.hoisted(() => ({
+  ws: "",
+  appListeners: new Map<string, () => void>(),
+  sendToWindow: vi.fn(),
+  recycleAgentsWhenIdle: vi.fn(),
+  lockHeld: false,
+  withInstallLock: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  app: {
+    on: (event: string, fn: () => void) => {
+      h.appListeners.set(event, fn);
+    },
+  },
+}));
+vi.mock("../../env", () => ({
+  pluginsDir: () => join(h.ws, "plugins"),
+}));
+vi.mock("../plugins", () => ({ withInstallLock: h.withInstallLock }));
+vi.mock("../router", () => ({ recycleAgentsWhenIdle: h.recycleAgentsWhenIdle }));
+
+const win = { isDestroyed: () => false, webContents: { send: h.sendToWindow } };
+
+/** A fake fs.watch: records the watched path, exposes the change callback. */
+function makeWatch() {
+  const state = {
+    dir: "",
+    options: undefined as unknown,
+    onChange: () => {},
+    onError: undefined as ((error: Error) => void) | undefined,
+    close: vi.fn(),
+  };
+  const watch = ((dir: string, options: unknown, listener: () => void) => {
+    state.dir = dir;
+    state.options = options;
+    state.onChange = listener;
+    return {
+      close: state.close,
+      on: (event: string, fn: (error: Error) => void) => {
+        if (event === "error") state.onError = fn;
+      },
+    };
+  }) as never;
+  return { state, watch };
+}
+
+async function start(getWin: () => unknown = () => win, watch?: unknown) {
+  const fake = makeWatch();
+  const mod = await import("../plugins-watch");
+  mod.startPluginsWatcher(getWin as never, { watch: (watch ?? fake.watch) as never });
+  return { fake, mod };
+}
+
+beforeEach(() => {
+  h.ws = mkdtempSync(join(tmpdir(), "a24-watch-"));
+  h.appListeners.clear();
+  h.lockHeld = false;
+  h.withInstallLock.mockImplementation(async (fn: () => Promise<unknown>) => (h.lockHeld ? undefined : fn()));
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.useFakeTimers();
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  rmSync(h.ws, { recursive: true, force: true });
+});
+
+describe("startPluginsWatcher()", () => {
+  it("should create the plugins folder and watch it recursively", async () => {
+    const { fake } = await start();
+
+    expect(existsSync(join(h.ws, "plugins"))).toBe(true);
+    expect(fake.state.dir).toBe(join(h.ws, "plugins"));
+    expect(fake.state.options).toEqual({ recursive: true });
+  });
+
+  it("should send one changed event and one recycle after a burst of fs events settles", async () => {
+    const { fake } = await start();
+
+    fake.state.onChange();
+    fake.state.onChange();
+    fake.state.onChange();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(h.sendToWindow).toHaveBeenCalledTimes(1);
+    expect(h.sendToWindow).toHaveBeenCalledWith("plugins-event", { type: "changed" });
+    expect(h.recycleAgentsWhenIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it("should hold the fire while events keep arriving inside the debounce window", async () => {
+    const { fake } = await start();
+
+    fake.state.onChange();
+    await vi.advanceTimersByTimeAsync(999);
+    fake.state.onChange();
+    await vi.advanceTimersByTimeAsync(999);
+    expect(h.sendToWindow).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(h.sendToWindow).toHaveBeenCalledTimes(1);
+    expect(h.recycleAgentsWhenIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it("should still recycle the agents when no window is open", async () => {
+    const { fake } = await start(() => null);
+
+    fake.state.onChange();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(h.sendToWindow).not.toHaveBeenCalled();
+    expect(h.recycleAgentsWhenIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it("should neither notify nor recycle while an install holds the lock", async () => {
+    const { fake } = await start();
+    h.lockHeld = true;
+
+    fake.state.onChange();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(h.sendToWindow).not.toHaveBeenCalled();
+    expect(h.recycleAgentsWhenIdle).not.toHaveBeenCalled();
+  });
+
+  it("should warn and keep the app alive when the watch cannot start", async () => {
+    const watch = () => {
+      throw new Error("EMFILE: too many open files");
+    };
+
+    await expect(start(() => win, watch)).resolves.toBeDefined();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("EMFILE"));
+  });
+
+  it("should warn when the running watcher reports an error", async () => {
+    const { fake } = await start();
+
+    fake.state.onError?.(new Error("watch died"));
+
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("watch died"));
+  });
+
+  it("should close the watcher and drop a pending fire on will-quit", async () => {
+    const { fake } = await start();
+
+    fake.state.onChange();
+    h.appListeners.get("will-quit")?.();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(fake.state.close).toHaveBeenCalledTimes(1);
+    expect(h.sendToWindow).not.toHaveBeenCalled();
+    expect(h.recycleAgentsWhenIdle).not.toHaveBeenCalled();
+  });
+
+  it("should not send to a destroyed window", async () => {
+    const { fake } = await start(() => ({ isDestroyed: () => true, webContents: { send: h.sendToWindow } }));
+
+    fake.state.onChange();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(h.sendToWindow).not.toHaveBeenCalled();
+    expect(h.recycleAgentsWhenIdle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/desktop/src/main/agent/__tests__/router.test.ts
+++ b/packages/desktop/src/main/agent/__tests__/router.test.ts
@@ -65,11 +65,13 @@ const B = "/ws/sessions/b.jsonl";
 
 let killSessionAgent: (sessionPath: string) => Promise<void>;
 let killAllAgents: () => void;
+let recycleAgentsWhenIdle: () => void;
 
 async function setup(getWin: () => unknown = () => win) {
   const mod = await import("../router");
   killSessionAgent = mod.killSessionAgent;
   killAllAgents = mod.killAllAgents;
+  recycleAgentsWhenIdle = mod.recycleAgentsWhenIdle;
   mod.registerAgentIpc(getWin as never);
 }
 
@@ -320,6 +322,167 @@ describe("intentional stops", () => {
   it("should do nothing when killAllAgents is called with no host", async () => {
     await setup();
     expect(() => killAllAgents()).not.toThrow();
+  });
+});
+
+describe("recycleAgentsWhenIdle", () => {
+  /** Relay one pi wire event line through the fake host. */
+  const line = (sessionPath: string, event: Record<string, unknown>, procIndex = 0) =>
+    notice({ kind: "event", sessionPath, line: JSON.stringify(event) }, procIndex);
+
+  it("should kill the host immediately when no run is in flight", async () => {
+    await setup();
+    send(A);
+
+    recycleAgentsWhenIdle();
+
+    expect(proc().kill).toHaveBeenCalledTimes(1);
+    proc().emit("exit", 0);
+    expect(sent("agent-terminated")).toEqual([]);
+  });
+
+  it("should defer the kill while a run is in flight and kill once when it ends", async () => {
+    await setup();
+    send(A);
+    line(A, { type: "agent_start" });
+
+    recycleAgentsWhenIdle();
+    expect(proc().kill).not.toHaveBeenCalled();
+
+    line(A, { type: "agent_end" });
+    expect(proc().kill).toHaveBeenCalledTimes(1);
+
+    // A stray later end must not kill the replacement's slot again.
+    line(A, { type: "agent_end" });
+    expect(proc().kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("should treat a prompt send alone as a run in flight before agent_start arrives", async () => {
+    await setup();
+    send(A, { type: "prompt", message: "hi" });
+
+    recycleAgentsWhenIdle();
+    expect(proc().kill).not.toHaveBeenCalled();
+
+    line(A, { type: "agent_end" });
+    expect(proc().kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("should keep deferring across an agent_end that will retry", async () => {
+    await setup();
+    send(A);
+    line(A, { type: "agent_start" });
+    recycleAgentsWhenIdle();
+
+    line(A, { type: "agent_end", willRetry: true });
+    expect(proc().kill).not.toHaveBeenCalled();
+
+    line(A, { type: "agent_end" });
+    expect(proc().kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("should release the deferral when the prompt preflight fails", async () => {
+    await setup();
+    send(A, { type: "prompt", message: "hi" });
+    recycleAgentsWhenIdle();
+
+    line(A, { id: "1", type: "response", command: "prompt", success: false, error: "busy" });
+
+    expect(proc().kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not end the run on a successful prompt preflight response", async () => {
+    await setup();
+    send(A, { type: "prompt", message: "hi" });
+    recycleAgentsWhenIdle();
+
+    line(A, { id: "1", type: "response", command: "prompt", success: true });
+
+    expect(proc().kill).not.toHaveBeenCalled();
+  });
+
+  it("should wait for every running session before killing", async () => {
+    await setup();
+    send(A);
+    send(B);
+    line(A, { type: "agent_start" });
+    line(B, { type: "agent_start" });
+    recycleAgentsWhenIdle();
+
+    line(A, { type: "agent_end" });
+    expect(proc().kill).not.toHaveBeenCalled();
+
+    line(B, { type: "agent_end" });
+    expect(proc().kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("should kill when the last running session closes instead of ending", async () => {
+    await setup();
+    send(A);
+    line(A, { type: "agent_start" });
+    recycleAgentsWhenIdle();
+
+    notice({ kind: "session_closed", sessionPath: A, reason: "disposed" });
+
+    expect(proc().kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("should kill when the last running session errors instead of starting", async () => {
+    await setup();
+    send(A, { type: "prompt", message: "hi" });
+    recycleAgentsWhenIdle();
+
+    notice({ kind: "session_error", sessionPath: A, message: "boom" });
+
+    expect(proc().kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("should drop the pending recycle when the host crashes mid-run", async () => {
+    await setup();
+    send(A);
+    line(A, { type: "agent_start" });
+    recycleAgentsWhenIdle();
+    proc().emit("exit", 1);
+
+    send(A);
+    line(A, { type: "agent_start" }, 1);
+    line(A, { type: "agent_end" }, 1);
+
+    expect(proc(1).kill).not.toHaveBeenCalled();
+  });
+
+  it("should clear the run tracking on killAllAgents so a later recycle is immediate", async () => {
+    await setup();
+    send(A);
+    line(A, { type: "agent_start" });
+    killAllAgents();
+
+    send(A);
+    recycleAgentsWhenIdle();
+
+    expect(proc(1).kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("should ignore a message merely containing the marker text", async () => {
+    await setup();
+    send(A);
+    line(A, { type: "agent_start" });
+    recycleAgentsWhenIdle();
+
+    line(A, { type: "message_update", text: 'the words "agent_end" quoted in a reply' });
+
+    expect(proc().kill).not.toHaveBeenCalled();
+  });
+
+  it("should ignore an unparsable event line", async () => {
+    await setup();
+    send(A);
+    line(A, { type: "agent_start" });
+    recycleAgentsWhenIdle();
+
+    notice({ kind: "event", sessionPath: A, line: 'not json but mentions "agent_end"' });
+
+    expect(proc().kill).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/desktop/src/main/agent/plugins-watch.ts
+++ b/packages/desktop/src/main/agent/plugins-watch.ts
@@ -1,0 +1,67 @@
+// Watches the workspace plugins folder so a plugin written behind the app's
+// back — by the agent (create-plugin skill) or by the user dropping a folder
+// in — goes live without an app restart: the open plugin lists refresh right
+// away, and the agent host is recycled once idle so the next message runs
+// with the current skill set. The marketplace paths fire the same pipeline
+// themselves; the install lock keeps this watcher quiet while they copy files.
+
+import { type FSWatcher, watch as fsWatch, mkdirSync } from "node:fs";
+import { app, type BrowserWindow } from "electron";
+import { pluginsDir } from "../env";
+import { withInstallLock } from "./plugins";
+import { recycleAgentsWhenIdle } from "./router";
+
+// A change arrives as a burst (a folder copy is one event per file); act only
+// once it has settled, so a half-copied plugin is never announced.
+const DEBOUNCE_MS = 1000;
+
+/** Injectable I/O, so tests drive the logic without a real recursive watch
+ *  (unavailable on the Linux CI runners; the shipped app is macOS-only). */
+interface PluginsWatcherDeps {
+  watch?: typeof fsWatch;
+  debounceMs?: number;
+}
+
+let watcher: FSWatcher | null = null;
+let timer: NodeJS.Timeout | undefined;
+
+export function startPluginsWatcher(getWin: () => BrowserWindow | null, deps: PluginsWatcherDeps = {}): void {
+  const { watch = fsWatch, debounceMs = DEBOUNCE_MS } = deps;
+  const fire = () => {
+    // The try-lock skips this while an install is copying files — that path
+    // notifies for itself. The event goes out even when the recycle has to
+    // wait for a run to end, so open lists show the plugin immediately.
+    void withInstallLock(async () => {
+      const win = getWin();
+      if (win && !win.isDestroyed()) win.webContents.send("plugins-event", { type: "changed" });
+      recycleAgentsWhenIdle();
+    });
+  };
+  const dir = pluginsDir();
+  try {
+    // The folder is otherwise created on the first install; having it from
+    // launch also gives hand-dropped plugins a place to land.
+    mkdirSync(dir, { recursive: true });
+    watcher = watch(dir, { recursive: true }, () => {
+      clearTimeout(timer);
+      timer = setTimeout(fire, debounceMs);
+      timer.unref?.();
+    });
+  } catch (error) {
+    // Hot reload is a convenience — never let it break startup.
+    console.warn(`[plugins] watcher failed to start: ${error instanceof Error ? error.message : String(error)}`);
+    return;
+  }
+  watcher.on("error", (error: Error) => {
+    console.warn(`[plugins] watcher stopped: ${error.message}`);
+  });
+  app.on("will-quit", () => stopPluginsWatcher());
+}
+
+/** Close the watcher and drop any pending fire (quit, and a test seam). */
+export function stopPluginsWatcher(): void {
+  clearTimeout(timer);
+  timer = undefined;
+  watcher?.close();
+  watcher = null;
+}

--- a/packages/desktop/src/main/agent/router.ts
+++ b/packages/desktop/src/main/agent/router.ts
@@ -40,6 +40,50 @@ let current: HostHandle | null = null;
 // its exit event while a fresh one is already running.
 const intentionalKills = new Set<UtilityProcess>();
 
+// Sessions with a generation in flight: marked on a prompt send (optimistic,
+// like the renderer's running set) and on agent_start, cleared when the run
+// ends. Lets recycleAgentsWhenIdle wait for a quiet moment — an intentional
+// kill emits no agent-terminated, so killing mid-run would strand the chat
+// visually "running" with its answer cut short. Module-level, not per-handle:
+// it answers "is anything running right now", and every path that takes the
+// host down clears it.
+const runningSessions = new Set<string>();
+// A recycle requested while a run was in flight; honored when the last ends.
+let recyclePending = false;
+
+// The relayed lines that can flip a session's run state. The substring guard
+// keeps the hot relay path parse-free; a hit is confirmed on the parsed
+// object, so a message merely containing the marker text changes nothing.
+const RUN_MARKERS = ['"agent_start"', '"agent_end"', '"command":"prompt"'] as const;
+
+function trackRunSignals(sessionPath: string, line: string): void {
+  if (!RUN_MARKERS.some((marker) => line.includes(marker))) return;
+  let event: { type?: unknown; willRetry?: unknown; command?: unknown; success?: unknown };
+  try {
+    event = JSON.parse(line) as typeof event;
+  } catch {
+    return;
+  }
+  if (event.type === "agent_start") {
+    runningSessions.add(sessionPath);
+    return;
+  }
+  // A retried run keeps going after its agent_end; a failed prompt preflight
+  // means the optimistic mark from agent_send never became a run.
+  const runEnded =
+    (event.type === "agent_end" && event.willRetry !== true) ||
+    (event.type === "response" && event.command === "prompt" && event.success === false);
+  if (!runEnded) return;
+  runningSessions.delete(sessionPath);
+  finishPendingRecycle();
+}
+
+function finishPendingRecycle(): void {
+  if (!recyclePending || runningSessions.size > 0) return;
+  recyclePending = false;
+  killAllAgents();
+}
+
 /** Reject session paths outside the sessions dir — the path becomes the host's
  *  session-file target. */
 function assertSessionPath(sessionPath: unknown): string {
@@ -106,26 +150,38 @@ function ensureHost(getWin: () => BrowserWindow | null): HostHandle {
   proc.on("message", (message: AgentHostNotice) => {
     switch (message.kind) {
       case "event":
+        trackRunSignals(message.sessionPath, message.line);
         emit("agent-event", { sessionPath: message.sessionPath, line: message.line });
         return;
       case "session_error":
         console.error(`[agent] session failed to start: ${message.message}`);
         trackAgentFailed("spawn");
         handle.liveSessions.delete(message.sessionPath);
+        runningSessions.delete(message.sessionPath);
         emit("agent-error", { sessionPath: message.sessionPath, message: message.message });
+        finishPendingRecycle();
         return;
       case "session_closed":
         handle.liveSessions.delete(message.sessionPath);
+        runningSessions.delete(message.sessionPath);
         if (message.requestId !== undefined) {
           handle.pendingDisposes.get(message.requestId)?.();
           handle.pendingDisposes.delete(message.requestId);
         }
+        finishPendingRecycle();
         return;
     }
   });
 
   proc.on("exit", (code) => {
-    if (current === handle) current = null;
+    const wasCurrent = current === handle;
+    if (wasCurrent) {
+      current = null;
+      // The crash took every run with it; a pending recycle is moot — the
+      // next send re-forks with fresh skills anyway.
+      runningSessions.clear();
+      recyclePending = false;
+    }
     const affected = [...handle.liveSessions];
     settleHostState(handle);
     // Kills we initiated (restart / app quit) aren't crashes — don't surface them.
@@ -166,12 +222,27 @@ export async function killSessionAgent(sessionPath: string): Promise<void> {
 
 /** Kill the host (app exit / restart after provider/skills changes). */
 export function killAllAgents(): void {
+  runningSessions.clear();
+  recyclePending = false;
   const handle = current;
   if (!handle) return;
   intentionalKills.add(handle.proc);
   current = null;
   settleHostState(handle);
   handle.proc.kill();
+}
+
+/** Kill the host as soon as no run is in flight, so the next send re-forks
+ *  with the current skill set: immediately when everything is idle, otherwise
+ *  when the last running generation ends. Used by the plugins watcher — unlike
+ *  agent_restart it may fire while the agent is mid-answer (writing a plugin
+ *  is itself agent work), and that answer must finish. */
+export function recycleAgentsWhenIdle(): void {
+  if (runningSessions.size === 0) {
+    killAllAgents();
+    return;
+  }
+  recyclePending = true;
 }
 
 /** Register agent IPC. */
@@ -183,6 +254,9 @@ export function registerAgentIpc(getWin: () => BrowserWindow | null): void {
     if (typeof command !== "object" || command === null) throw new Error("invalid agent command");
     const handle = ensureHost(getWin);
     handle.liveSessions.add(target);
+    // Optimistic run mark (the renderer keeps the same one), closing the gap
+    // between this send and its agent_start; a failed preflight unmarks it.
+    if ((command as Record<string, unknown>).type === "prompt") runningSessions.add(target);
     handle.proc.postMessage({
       kind: "command",
       sessionPath: target,

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -6,6 +6,7 @@ import { app, BrowserWindow, dialog, ipcMain, nativeImage } from "electron";
 import { registerMarketplaceIpc } from "./agent/marketplace";
 import { registerPluginsIpc } from "./agent/plugins";
 import { installDefaultPlugins } from "./agent/plugins-defaults";
+import { startPluginsWatcher } from "./agent/plugins-watch";
 import { killAllAgents, registerAgentIpc } from "./agent/router";
 import { registerSessionsIpc } from "./agent/sessions";
 import { initAnalytics, registerAnalyticsIpc, trackLaunch, trackQuit } from "./analytics";
@@ -109,6 +110,10 @@ app.whenReady().then(async () => {
   registerLedgerIpc();
   registerAnalyticsIpc();
   registerWorkspaceIpc();
+
+  // Pick up plugins written into the workspace behind the app's back (by the
+  // agent, or by hand) without a restart.
+  startPluginsWatcher(getWin);
 
   // The plugins a new workspace starts with are downloaded from their own
   // repositories, like any other. Not awaited: startup never waits on the

--- a/packages/desktop/src/renderer/runtime/__tests__/electronPiClient.test.ts
+++ b/packages/desktop/src/renderer/runtime/__tests__/electronPiClient.test.ts
@@ -52,6 +52,8 @@ const h = vi.hoisted(() => ({
     source?: string;
     skills: { name: string; description: string }[];
   }[],
+  /** plugins-event subscribers the client registered. */
+  pluginsEvents: [] as ((event: { type: string }) => void)[],
   track: vi.fn(),
   trackOnce: vi.fn(),
 }));
@@ -101,7 +103,13 @@ vi.mock("../../rpc/api", () => ({
       return h.settings;
     },
   },
-  pluginsApi: { list: async () => ({ plugins: h.plugins }) },
+  pluginsApi: {
+    list: async () => ({ plugins: h.plugins }),
+    onEvent: async (cb: (event: { type: string }) => void) => {
+      h.pluginsEvents.push(cb);
+      return () => {};
+    },
+  },
   authApi: { models: async () => ({ type: "models", models: h.availableModels }) },
   agentApi: {
     onModelsChanged: () => () => {},
@@ -143,6 +151,7 @@ const requestCmds = () => h.requests.map((r) => r.command);
 beforeEach(() => {
   h.listeners.length = 0;
   h.errorListeners.length = 0;
+  h.pluginsEvents.length = 0;
   h.sent.length = 0;
   h.requests.length = 0;
   h.newSessionPath = "/ws/sessions/new.jsonl";
@@ -274,6 +283,31 @@ describe("createElectronPiClient() analytics", () => {
       const snapshot = await client.createThread({});
       await client.sendMessage(snapshot.metadata.id, message(":skill[health:nutrition-coach] log lunch"));
       expect(h.track).toHaveBeenCalledWith("skill_used", { skill: "custom", kind: "custom", method: "manual" });
+    });
+
+    it("should refresh the official lookup when the plugin store changes", async () => {
+      const officialPlugins = h.plugins;
+      h.plugins = [];
+      const client = createElectronPiClient();
+      await flushLookup();
+      const snapshot = await client.createThread({});
+
+      // Installed after the client came up — a progress event alone must not
+      // refresh the lookup, so the skill still reports as custom.
+      h.plugins = officialPlugins;
+      for (const fn of h.pluginsEvents) fn({ type: "progress" });
+      await flushLookup();
+      await client.sendMessage(snapshot.metadata.id, message(":skill[accountant24:subscription-audit] check"));
+      expect(h.track).toHaveBeenCalledWith("skill_used", { skill: "custom", kind: "custom", method: "manual" });
+
+      for (const fn of h.pluginsEvents) fn({ type: "changed" });
+      await flushLookup();
+      await client.sendMessage(snapshot.metadata.id, message(":skill[accountant24:subscription-audit] check"));
+      expect(h.track).toHaveBeenCalledWith("skill_used", {
+        skill: "accountant24:subscription-audit",
+        kind: "official",
+        method: "manual",
+      });
     });
 
     it("should not track skill_used for a plain message", async () => {

--- a/packages/desktop/src/renderer/runtime/electronPiClient.ts
+++ b/packages/desktop/src/renderer/runtime/electronPiClient.ts
@@ -104,9 +104,10 @@ export function createElectronPiClient(): PiClient {
   // A persistent listener keeps it accurate even between subscriptions.
   const running = new Set<string>();
   // skill_used analytics: resolve a skill to official-or-custom without leaking
-  // custom identities. The lookup refreshes on the same signal as the composer
-  // picker (every plugin mutation restarts the agent). A use landing before
-  // the first fetch resolves reports "custom" — acceptable for analytics.
+  // custom identities. The lookup refreshes on the same signals as the composer
+  // picker (every plugin mutation restarts the agent or fires plugins-event).
+  // A use landing before the first fetch resolves reports "custom" —
+  // acceptable for analytics.
   // Keyed by both names a use can arrive under — the `<plugin>:<skill>` name a
   // manual pick carries, and the bare folder name a SKILL.md read yields — each
   // mapping to the namespaced name the event reports.
@@ -142,6 +143,10 @@ export function createElectronPiClient(): PiClient {
   };
   refreshOfficialSkills();
   agentApi.onModelsChanged(refreshOfficialSkills);
+  // Singleton client, never unmounted — the unsubscribe is deliberately dropped.
+  void pluginsApi.onEvent((event) => {
+    if (event.type === "changed") refreshOfficialSkills();
+  });
   const trackSkillByName = (name: string, method: "manual" | "auto") => {
     const official = officialSkills.get(name);
     trackSkillUsed(official ?? "custom", official ? "official" : "custom", method);


### PR DESCRIPTION
- Watch the workspace `plugins/` folder and fire the existing `plugins-event {type:"changed"}` pipeline on any change, debounced so a half-copied plugin is never announced.
- Stay quiet while a marketplace install holds the install lock.
- Create the `plugins/` folder at launch.
- Add `recycleAgentsWhenIdle` to the agent router: restart the agent host immediately when idle, or after the last running generation ends.
- Track runs in the router via prompt sends and relayed `agent_start`/`agent_end` events, respecting `willRetry` and failed prompt preflights.
- Refresh the `officialSkills` analytics lookup on `plugins-event` in `electronPiClient`.
- Update the plugins and create-a-plugin docs pages to drop the restart instruction.