### PR TITLE
feat!: require a description in plugin manifests

### DIFF
--- a/docs/docs/create-a-plugin.mdx
+++ b/docs/docs/create-a-plugin.mdx
@@ -33,7 +33,8 @@ A minimal example:
 ```json
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
-  "name": "monthly-review"
+  "name": "monthly-review",
+  "description": "A monthly review of your spending."
 }
 ```
 
@@ -43,8 +44,8 @@ A minimal example:
 | --------------------------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------------- |
 | `$schema`                                     | string   | Yes      | The manifest format the file follows. Editors use it for autocomplete.                         |
 | `name`                                        | string   | Yes      | The plugin's identity, used as the folder name and the namespace for its skills. Up to 64 characters. |
+| `description`                                 | string   | Yes      | Shown in the plugin list and the install confirmation. Clipped at 1024 characters.             |
 | `version`                                     | string   | No       | Shown next to the name. Up to 64 characters.                                                   |
-| `description`                                 | string   | No       | Shown in the plugin list and the install confirmation. Clipped at 1024 characters.             |
 | `author.name`                                 | string   | No       | Matched by the marketplace search. Up to 128 characters.                                       |
 | `author.email`                                | string   | No       | Contact address. Up to 254 characters.                                                         |
 | `author.url`                                  | string   | No       | The author's page. Up to 512 characters.                                                       |
@@ -71,6 +72,7 @@ Anything specific to Accountant24 lives under the app's own namespace:
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "monthly-review",
+  "description": "A monthly review of your spending.",
   "extensions": {
     "ai.accountant24": {
       "minAppVersion": "0.3.0"
@@ -165,7 +167,7 @@ The app installs the tip of your default branch, so what you push is what the ne
 | ----------------------------------------- | ------------------------------------------ |
 | Public repository                         | Private repositories are not indexed       |
 | Topic `accountant24-plugin`               | The only way in                            |
-| `plugin.json` at the repository root      | With `$schema` and a `name` that passes the naming rules |
+| `plugin.json` at the repository root      | With `$schema`, a `name` that passes the naming rules, and a `description` |
 | Not a fork                                | Publish from a repository of its own       |
 | Not archived                              | Unarchive it to be indexed                 |
 | At least one commit on the default branch | The index reads that branch's tip          |
@@ -186,7 +188,7 @@ curl -fsSL https://raw.githubusercontent.com/accountant24/marketplace/main/scrip
 
 ## Publishing checklist
 
-- `plugin.json` at the root, with a `name` that matches the folder and follows the naming rules.
+- `plugin.json` at the root, with a `name` that matches the folder and follows the naming rules, and a `description` of what the plugin does.
 - At least one `skills/<name>/SKILL.md`, its frontmatter `name` matching its folder, with a description written for matching.
 - No unknown fields in the manifest.
 - Tested in the app, both from the `/` picker and by asking in your own words.
@@ -210,6 +212,7 @@ The app shows these messages in the install dialog when an install fails. A brok
 | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | "No plugin found in …: a plugin needs a plugin.json file" | The repository has no `plugin.json` at its root.                                                                                         |
 | "plugin.json: $schema is required."                       | The manifest is missing `$schema`. Copy the line from the example above.                                                                 |
+| "plugin.json: description is required."                   | The manifest is missing `description`. Add one sentence on what the plugin does.                                                         |
 | "plugin.json: unknown field …"                            | A key the format doesn't define, usually a typo. The manifest is validated strictly so a misspelled field can't be silently ignored.     |
 | "Plugin has no skills."                                   | No usable skill under `skills/`. Every skill needs `skills/<name>/SKILL.md` with a `name` matching its folder and a `description`.       |
 | "… needs Accountant24 vx.y.z or newer"                    | The plugin declares a minimum app version. Update the app.                                                                               |

--- a/packages/desktop/src/main/agent/__tests__/plugin-manifest.test.ts
+++ b/packages/desktop/src/main/agent/__tests__/plugin-manifest.test.ts
@@ -9,8 +9,10 @@ import { checkMinAppVersion, parsePluginManifest, pluginNameError } from "../plu
 /** Serialize an object literal the way a plugin.json on disk would read. */
 const SCHEMA_URL = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json";
 
-/** A manifest with the required $schema filled in, unless the case overrides it. */
-const manifest = (value: Record<string, unknown>): string => JSON.stringify({ $schema: SCHEMA_URL, ...value });
+/** A manifest with the required $schema and description filled in, unless the
+ *  case overrides them. */
+const manifest = (value: Record<string, unknown>): string =>
+  JSON.stringify({ $schema: SCHEMA_URL, description: "Budget reviews.", ...value });
 
 describe("pluginNameError()", () => {
   it("should accept a lowercase name with interior hyphens", () => {
@@ -116,9 +118,30 @@ describe("parsePluginManifest()", () => {
     });
   });
 
-  it("should accept a manifest with only $schema and a name", () => {
+  it("should accept a manifest with only $schema, a name and a description", () => {
     const result = parsePluginManifest(manifest({ name: "budget" }));
-    expect(result).toEqual({ ok: true, manifest: { name: "budget" } });
+    expect(result).toEqual({ ok: true, manifest: { name: "budget", description: "Budget reviews." } });
+  });
+
+  it("should refuse a manifest without a description", () => {
+    expect(parsePluginManifest(JSON.stringify({ $schema: SCHEMA_URL, name: "budget" }))).toEqual({
+      ok: false,
+      error: "plugin.json: description is required.",
+    });
+  });
+
+  it("should refuse a description that is not a string", () => {
+    expect(parsePluginManifest(manifest({ name: "budget", description: 7 }))).toEqual({
+      ok: false,
+      error: "plugin.json: description is required.",
+    });
+  });
+
+  it("should refuse an empty description", () => {
+    expect(parsePluginManifest(manifest({ name: "budget", description: "" }))).toEqual({
+      ok: false,
+      error: "plugin.json: description is empty.",
+    });
   });
 
   it("should keep every metadata field the format defines", () => {
@@ -218,7 +241,7 @@ describe("parsePluginManifest()", () => {
   it("should accept an empty author object", () => {
     expect(parsePluginManifest(manifest({ name: "budget", author: {} }))).toEqual({
       ok: true,
-      manifest: { name: "budget", author: {} },
+      manifest: { name: "budget", description: "Budget reviews.", author: {} },
     });
   });
 
@@ -237,20 +260,23 @@ describe("parsePluginManifest()", () => {
     const result = parsePluginManifest(
       manifest({ name: "budget", extensions: { "ai.accountant24": { minAppVersion: "1.4.0" } } }),
     );
-    expect(result).toEqual({ ok: true, manifest: { name: "budget", minAppVersion: "1.4.0" } });
+    expect(result).toEqual({
+      ok: true,
+      manifest: { name: "budget", description: "Budget reviews.", minAppVersion: "1.4.0" },
+    });
   });
 
   it("should ignore another client's extension namespace", () => {
     const result = parsePluginManifest(
       manifest({ name: "budget", extensions: { "com.example.client": { anything: [1, 2] } } }),
     );
-    expect(result).toEqual({ ok: true, manifest: { name: "budget" } });
+    expect(result).toEqual({ ok: true, manifest: { name: "budget", description: "Budget reviews." } });
   });
 
   it("should accept a manifest whose extensions omit the app's namespace", () => {
     expect(parsePluginManifest(manifest({ name: "budget", extensions: {} }))).toEqual({
       ok: true,
-      manifest: { name: "budget" },
+      manifest: { name: "budget", description: "Budget reviews." },
     });
   });
 
@@ -280,7 +306,7 @@ describe("parsePluginManifest()", () => {
   it("should accept a namespace entry without a minAppVersion", () => {
     expect(parsePluginManifest(manifest({ name: "budget", extensions: { "ai.accountant24": {} } }))).toEqual({
       ok: true,
-      manifest: { name: "budget" },
+      manifest: { name: "budget", description: "Budget reviews." },
     });
   });
 });

--- a/packages/desktop/src/main/agent/__tests__/plugins-defaults.test.ts
+++ b/packages/desktop/src/main/agent/__tests__/plugins-defaults.test.ts
@@ -381,6 +381,7 @@ describe("installDefaultPlugins(), when the download fails", () => {
   it("should try again when the plugin needs a newer app", async () => {
     await serve({
       manifest: {
+        $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
         name: "accountant24-skills",
         description: "Newer.",
         extensions: { "ai.accountant24": { minAppVersion: "99.0.0" } },

--- a/packages/desktop/src/main/agent/__tests__/plugins-store.test.ts
+++ b/packages/desktop/src/main/agent/__tests__/plugins-store.test.ts
@@ -44,7 +44,7 @@ function writePlugin(
     JSON.stringify({
       $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
       name: options.name ?? folder,
-      ...(options.description ? { description: options.description } : {}),
+      description: options.description ?? "Does plugin things.",
     });
   writeFileSync(join(dir, "plugin.json"), manifest);
   for (const skill of options.skills ?? []) {
@@ -147,6 +147,7 @@ describe("readPluginDir()", () => {
       JSON.stringify({
         $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
         name: "budget",
+        description: "Budget reviews.",
         version: "2.0.0",
         author: { name: "Ada" },
         repository: "https://github.com/acme/budget",
@@ -169,6 +170,7 @@ describe("readPluginDir()", () => {
       manifest: JSON.stringify({
         $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
         name: "budget",
+        description: "Budget reviews.",
         extensions: { "ai.accountant24": { minAppVersion: "9.9.9" } },
       }),
       skills: [{ name: "review" }],
@@ -204,9 +206,15 @@ describe("readPluginDir()", () => {
     expect(readPluginDir(dir).skills.map((s) => s.rawName)).toEqual(["good"]);
   });
 
-  it("should default the description to empty when the manifest omits one", () => {
-    const dir = writePlugin("budget", { skills: [{ name: "review" }] });
-    expect(readPluginDir(dir).description).toBe("");
+  it("should report a plugin whose manifest omits the description", () => {
+    const dir = writePlugin("budget", {
+      manifest: JSON.stringify({
+        $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+        name: "budget",
+      }),
+      skills: [{ name: "review" }],
+    });
+    expect(readPluginDir(dir).error).toBe("plugin.json: description is required.");
   });
 });
 

--- a/packages/desktop/src/main/agent/__tests__/plugins.test.ts
+++ b/packages/desktop/src/main/agent/__tests__/plugins.test.ts
@@ -237,6 +237,7 @@ describe("plugins_list", () => {
       JSON.stringify({
         $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
         name: "budget",
+        description: "Budget reviews.",
         repository: "https://github.com/acme/budget",
       }),
     );
@@ -456,7 +457,11 @@ describe("plugins_inspect", () => {
 
   it("should reject a plugin with no skills", async () => {
     await serve({
-      manifest: { $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json", name: "budget" },
+      manifest: {
+        $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+        name: "budget",
+        description: "Budget reviews.",
+      },
     });
     const result = (await invoke("plugins_inspect", { source: "owner/repo" })) as Result;
     expect(result).toEqual({ type: "error", message: "Plugin has no skills." });
@@ -468,6 +473,7 @@ describe("plugins_inspect", () => {
       manifest: {
         $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
         name: "budget",
+        description: "Budget reviews.",
         extensions: { "ai.accountant24": { minAppVersion: "2.0.0" } },
       },
       skills: [{ name: "review" }],
@@ -486,6 +492,7 @@ describe("plugins_inspect", () => {
       manifest: {
         $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
         name: "budget",
+        description: "Budget reviews.",
         extensions: { "ai.accountant24": { minAppVersion: "2.0.0" } },
       },
       skills: [{ name: "review" }],
@@ -622,7 +629,11 @@ describe("plugins_inspect", () => {
     await serve(BUDGET);
     await install();
     await serve({
-      manifest: { $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json", name: "budget" },
+      manifest: {
+        $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+        name: "budget",
+        description: "Budget reviews.",
+      },
       skills: [{ name: "monthly-review" }],
     });
     expect(await install()).toEqual({ type: "done", name: "budget" });
@@ -671,7 +682,11 @@ describe("plugins_inspect", () => {
 
   it("should keep other plugins' registry entries when one is installed", async () => {
     await serve({
-      manifest: { $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json", name: "taxes" },
+      manifest: {
+        $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+        name: "taxes",
+        description: "Tax estimates.",
+      },
       skills: [{ name: "estimate" }],
     });
     await install("owner/taxes");
@@ -752,7 +767,11 @@ describe("plugins_remove", () => {
 
   it("should keep other plugins' registry entries", async () => {
     await serve({
-      manifest: { $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json", name: "taxes" },
+      manifest: {
+        $schema: "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+        name: "taxes",
+        description: "Tax estimates.",
+      },
       skills: [{ name: "estimate" }],
     });
     await install("owner/taxes");

--- a/packages/desktop/src/main/agent/plugin-manifest.ts
+++ b/packages/desktop/src/main/agent/plugin-manifest.ts
@@ -19,7 +19,7 @@ export interface PluginAuthor {
 export interface PluginManifest {
   name: string;
   version?: string;
-  description?: string;
+  description: string;
   author?: PluginAuthor;
   homepage?: string;
   repository?: string;
@@ -144,9 +144,14 @@ export function parsePluginManifest(text: string): ParsedManifest {
   // installs by hand publishable as it is.
   if (typeof raw.$schema !== "string") return { ok: false, error: "plugin.json: $schema is required." };
 
-  const manifest: PluginManifest = { name: raw.name };
+  // The description is what the plugin row and the install dialog show, and
+  // the marketplace requires it too — same reasoning as $schema.
+  if (typeof raw.description !== "string") return { ok: false, error: "plugin.json: description is required." };
+  if (raw.description.length === 0) return { ok: false, error: "plugin.json: description is empty." };
 
-  for (const key of ["version", "description", "homepage", "repository", "license"] as const) {
+  const manifest: PluginManifest = { name: raw.name, description: raw.description };
+
+  for (const key of ["version", "homepage", "repository", "license"] as const) {
     const parsed = optionalString(raw, key);
     if (!parsed.ok) return { ok: false, error: `plugin.json: ${key} must be a string.` };
     if (parsed.value !== undefined) manifest[key] = parsed.value;

--- a/packages/desktop/src/main/agent/plugins-store.ts
+++ b/packages/desktop/src/main/agent/plugins-store.ts
@@ -104,7 +104,7 @@ export function readPluginDir(dir: string): StoredPlugin {
   const plugin: StoredPlugin = {
     name: manifest.name,
     dir,
-    description: manifest.description ?? "",
+    description: manifest.description,
     skills,
     ...(manifest.version ? { version: manifest.version } : {}),
     ...(manifest.author ? { author: manifest.author } : {}),

--- a/packages/desktop/src/renderer/components/accountant24/settings/plugin-row-parts.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/settings/plugin-row-parts.tsx
@@ -86,9 +86,10 @@ export function ClampedDescription({ text }: { text: string }) {
   );
 }
 
-/** A plugin's own description, falling back to its first skill's when the
- *  manifest omits one (description is optional in the Agent Plugins format,
- *  and a single-skill plugin rarely repeats itself). */
+/** A plugin's own description, falling back to its first skill's when there is
+ *  none. The app requires a description in an installed plugin's manifest, but
+ *  a marketplace entry (whose manifest only the indexer saw) and an invalid
+ *  plugin's row can still arrive without one. */
 export function pluginDescription(plugin: { description: string; skills: PluginSkillInfo[] }): string {
   return plugin.description || plugin.skills[0]?.description || "";
 }


### PR DESCRIPTION
- Reject a `plugin.json` whose `description` is missing, not a string, or empty.
- Show `plugin.json: description is required.` in the install dialog and on the plugin's row.
- Update the create-a-plugin docs page: `description` marked required, both manifest examples carry one, new troubleshooting row.
- Reword the `pluginDescription()` fallback comment in the renderer.

**BREAKING CHANGE**: An installed plugin without a `description` in its `plugin.json` shows an **Invalid** badge after this update. Add a description line to its manifest to fix it.