### PR TITLE
fix: show previous chats after the workspace moved

### DIFF
--- a/packages/desktop/src/main/agent/__tests__/runtime.test.ts
+++ b/packages/desktop/src/main/agent/__tests__/runtime.test.ts
@@ -101,9 +101,11 @@ describe("createRuntimeFactory()", () => {
     expect("modelsStorePath" in options).toBe(false);
   });
 
-  it("should open the session at its minted path with the sessions dir (fresh AND reopen contract)", async () => {
+  it("should open the session at its minted path with the sessions dir and the workspace as cwd (fresh AND reopen contract)", async () => {
     await createRuntimeForSession();
-    expect(h.sessionOpen).toHaveBeenCalledWith(A, "/ws/sessions");
+    // The cwd override keeps a reopened session in the workspace even when the
+    // file was recorded under another path (a moved workspace folder).
+    expect(h.sessionOpen).toHaveBeenCalledWith(A, "/ws/sessions", "/ws");
     expect(h.createRuntime).toHaveBeenCalledWith(expect.any(Function), {
       cwd: "/ws",
       agentDir: "/ws",

--- a/packages/desktop/src/main/agent/__tests__/sessions.integration.test.ts
+++ b/packages/desktop/src/main/agent/__tests__/sessions.integration.test.ts
@@ -1,0 +1,86 @@
+// The sessions list over a REAL temp workspace with the REAL pi SessionManager:
+// the sidebar must show every chat stored in the workspace's own sessions dir,
+// including ones recorded while the workspace folder lived at another path
+// (pre-0.3 ~/Accountant24, a --workspace folder that was moved, a restored
+// backup). Only Electron and the router are faked.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeTmpWorkspace } from "../../__tests__/tmpWorkspace";
+
+type Handler = (event: unknown, payload?: unknown) => unknown;
+const h = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  killSessionAgent: vi.fn(async () => {}),
+}));
+
+vi.mock("electron", () => ({
+  app: { isPackaged: false, getAppPath: () => "/app" },
+  ipcMain: {
+    handle: (channel: string, fn: Handler) => {
+      h.handlers.set(channel, fn);
+    },
+  },
+}));
+vi.mock("../router", () => ({ killSessionAgent: h.killSessionAgent }));
+
+const ws = makeTmpWorkspace();
+
+beforeEach(() => {
+  ws.setup();
+  h.handlers.clear();
+  vi.resetModules();
+});
+afterEach(() => ws.cleanup());
+
+/** A minimal pi session file: the header line plus one user message. */
+function writeSession(name: string, id: string, cwd: string, text: string): string {
+  const file = ws.path("sessions", name);
+  mkdirSync(ws.path("sessions"), { recursive: true });
+  const header = { type: "session", version: 3, id, timestamp: "2026-08-01T10:00:00.000Z", cwd };
+  const message = {
+    type: "message",
+    id: `${id}-m1`,
+    parentId: null,
+    timestamp: "2026-08-01T10:00:01.000Z",
+    message: { role: "user", content: [{ type: "text", text }], timestamp: 1785578401000 },
+  };
+  writeFileSync(file, `${JSON.stringify(header)}\n${JSON.stringify(message)}\n`);
+  return file;
+}
+
+async function listSessions(): Promise<{ id: string; path: string; firstMessage: string; messageCount: number }[]> {
+  const { registerSessionsIpc } = await import("../sessions");
+  registerSessionsIpc();
+  const handler = h.handlers.get("sessions_list");
+  if (!handler) throw new Error("no handler for sessions_list");
+  const result = (await handler(null)) as { type: string; sessions: never[] };
+  expect(result.type).toBe("sessions");
+  return result.sessions;
+}
+
+describe("sessions_list (real workspace, real pi)", () => {
+  it("should list a chat recorded in another workspace path next to one recorded here", async () => {
+    const here = writeSession("2026-08-20T10-00-00-000Z_here.jsonl", "here", ws.dir, "groceries this month");
+    const moved = writeSession(
+      "2026-06-01T10-00-00-000Z_old.jsonl",
+      "old",
+      "/Users/someone/Accountant24",
+      "salary in june",
+    );
+
+    const sessions = await listSessions();
+
+    expect(sessions.map((s) => s.id).sort()).toEqual(["here", "old"]);
+    expect(sessions.find((s) => s.id === "old")).toMatchObject({
+      path: moved,
+      firstMessage: "salary in june",
+      messageCount: 1,
+    });
+    expect(sessions.find((s) => s.id === "here")).toMatchObject({ path: here, firstMessage: "groceries this month" });
+  });
+
+  it("should return an empty list when the sessions dir does not exist yet", async () => {
+    await expect(listSessions()).resolves.toEqual([]);
+  });
+});

--- a/packages/desktop/src/main/agent/__tests__/sessions.test.ts
+++ b/packages/desktop/src/main/agent/__tests__/sessions.test.ts
@@ -19,10 +19,10 @@ vi.mock("electron", () => ({
     },
   },
 }));
-vi.mock("../../env", () => ({ workspaceDir: () => "/ws", sessionsDir: () => "/ws/sessions" }));
+vi.mock("../../env", () => ({ sessionsDir: () => "/ws/sessions" }));
 vi.mock("../router", () => ({ killSessionAgent: h.killSessionAgent }));
 vi.mock("@earendil-works/pi-coding-agent", () => ({
-  SessionManager: { list: (...args: unknown[]) => h.sessionList(...args) },
+  SessionManager: { listAll: (...args: unknown[]) => h.sessionList(...args) },
 }));
 vi.mock("node:fs", () => ({ rmSync: h.rmSync }));
 
@@ -71,7 +71,8 @@ describe("sessions_list", () => {
         },
       ],
     });
-    expect(h.sessionList).toHaveBeenCalledWith("/ws", "/ws/sessions");
+    // Every file in the workspace's own sessions dir, with no cwd filter.
+    expect(h.sessionList).toHaveBeenCalledWith("/ws/sessions");
   });
 
   it("should stringify a non-Date modified value", async () => {

--- a/packages/desktop/src/main/agent/host/runtime.ts
+++ b/packages/desktop/src/main/agent/host/runtime.ts
@@ -5,7 +5,7 @@
 //   --system-prompt <system.md>                        → resourceLoaderOptions.systemPrompt
 //   --skill <every enabled plugin's skills…>           → additionalSkillPaths
 //   -e <accountant24-extension.js>                     → additionalExtensionPaths
-//   --session <path> --session-dir <sessions>          → SessionManager.open(path, dir)
+//   --session <path> --session-dir <sessions>          → SessionManager.open(path, dir, cwd)
 //   cwd / PI_CODING_AGENT_DIR                          → cwd / agentDir options
 //
 // No model/thinkingLevel is passed: pi restores both from the session file (or
@@ -82,8 +82,11 @@ export function createRuntimeFactory(cfg: AgentHostConfig): RuntimeFactory {
       agentDir: cfg.workspaceDir,
       // open() starts a fresh session at a not-yet-existing path and reopens an
       // existing file (restoring history/model/thinking) — the same contract the
-      // old `--session <path>` spawn relied on.
-      sessionManager: SessionManager.open(sessionPath, cfg.sessionsDir),
+      // old `--session <path>` spawn relied on. The cwd override pins the
+      // session to the workspace: without it a reopened file brings back the
+      // cwd it was recorded under, and pi runs bash/tools there — wrong (or
+      // gone) once the workspace folder has moved.
+      sessionManager: SessionManager.open(sessionPath, cfg.sessionsDir, cfg.workspaceDir),
     });
 
     await runtime.session.bindExtensions({

--- a/packages/desktop/src/main/agent/sessions.ts
+++ b/packages/desktop/src/main/agent/sessions.ts
@@ -6,12 +6,17 @@
 import { rmSync } from "node:fs";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { ipcMain } from "electron";
-import { sessionsDir, workspaceDir } from "../env";
+import { sessionsDir } from "../env";
 import { killSessionAgent } from "./router";
 import { resolveSessionPath } from "./session-paths";
 
 async function sessionsList() {
-  const infos = await SessionManager.list(workspaceDir(), sessionsDir());
+  // listAll, not list(cwd, dir): list() keeps only sessions whose header cwd
+  // is the current workspace, which hides every chat recorded before the
+  // workspace folder moved (0.2's ~/Accountant24, a restored backup, a moved
+  // --workspace folder). The sessions dir is the workspace's own, so every
+  // file in it is this workspace's chat, wherever the folder lived back then.
+  const infos = await SessionManager.listAll(sessionsDir());
   const sessions = infos.map((s) => ({
     path: s.path,
     id: s.id,


### PR DESCRIPTION
- List chats with `SessionManager.listAll(sessionsDir())` instead of `list(workspaceDir(), sessionsDir())`, so every session file in the workspace's own `sessions/` folder is shown regardless of the `cwd` recorded in its header.
- Reopen sessions with `SessionManager.open(path, sessionsDir, workspaceDir)`, pinning a reopened chat's cwd to the current workspace instead of the folder it was recorded under.
- Add `sessions.integration.test.ts`: the real pi `SessionManager` over a temp workspace lists a chat recorded under another path next to one recorded in place.
- Update `sessions.test.ts` and `runtime.test.ts` for the new calls.