### PR TITLE
fix: move ~/Accountant24 into place over a leftover ~/.accountant24

### DIFF
--- a/packages/desktop/src/main/migrations/0002-relocate-legacy-home-over-unused.ts
+++ b/packages/desktop/src/main/migrations/0002-relocate-legacy-home-over-unused.ts
@@ -1,0 +1,155 @@
+// Follow-up to 0001. A ~/.accountant24 could already exist before 0.3:
+// v0.1.x (Apr–Jun 2026) used it as pi's config dir (agent/, auth.json,
+// sessions/). 0001 took that leftover for an already-migrated workspace, left
+// ~/Accountant24 where it was, and the launch scaffolded a fresh workspace into
+// the leftovers — onboarding screen, real books out of sight. This moves
+// ~/Accountant24 into place anyway when the folder in the way holds nothing
+// the user made: that folder is renamed to ~/.accountant24.bak first, never
+// deleted. A folder that has been used since (a chat, a ledger edit) is left
+// alone with a warning; the FAQ covers sorting that out by hand.
+
+import { createHash } from "node:crypto";
+import { closeSync, existsSync, openSync, readdirSync, readFileSync, readSync, renameSync, statSync } from "node:fs";
+import path from "node:path";
+import type { Migration } from "./runner";
+
+/** sha256 of src/main/template/ledger/* as shipped in v0.3.0, the only
+ *  version that scaffolds a workspace before this migration exists. Frozen on
+ *  purpose: a shipped migration must not follow later template edits. To
+ *  recompute: `git show v0.3.0:packages/desktop/src/main/template/ledger/<file> | shasum -a 256`. */
+const SCAFFOLD_LEDGER_SHA256: Readonly<Record<string, string>> = {
+  "main.journal": "56040c93a86a88a57c54c9dba9bc083e6d97aadfcfb516ab870e9fca22637941",
+  "accounts.journal": "59ee1bb8579117febaa432fa9b7b7e8e2540f2d2d06fb2fc93840dee8b05297e",
+  "commodities.journal": "eaff9c2fa05ed6de0f983fc5433ab4f65dbdb27a0f606b1de8e4937826e9c12b",
+};
+
+/** How much of a session file to read for its header line. pi's own header
+ *  scan is bounded the same way; a header that long is not one of ours. */
+const HEADER_SCAN_BYTES = 64 * 1024;
+
+const BACKUP_SUFFIX = ".bak";
+
+function isDirectory(p: string): boolean {
+  return existsSync(p) && statSync(p).isDirectory();
+}
+
+/** True when there is no regular file anywhere under `dir` (a missing dir
+ *  counts; empty subfolders are fine). */
+function hasNoFiles(dir: string): boolean {
+  if (!existsSync(dir)) return true;
+  if (!statSync(dir).isDirectory()) return false;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) return false;
+    if (!hasNoFiles(path.join(dir, entry.name))) return false;
+  }
+  return true;
+}
+
+/** True when `ledger/` is missing or holds exactly what the 0.3.0 scaffold
+ *  wrote: a subset of the three template files, each byte-identical. */
+function isScaffoldLedger(ledgerDir: string): boolean {
+  if (!existsSync(ledgerDir)) return true;
+  if (!statSync(ledgerDir).isDirectory()) return false;
+  for (const entry of readdirSync(ledgerDir, { withFileTypes: true })) {
+    const expected = SCAFFOLD_LEDGER_SHA256[entry.name];
+    if (expected === undefined || !entry.isFile()) return false;
+    const actual = createHash("sha256")
+      .update(readFileSync(path.join(ledgerDir, entry.name)))
+      .digest("hex");
+    if (actual !== expected) return false;
+  }
+  return true;
+}
+
+/** The `cwd` of a pi session file's header line, or undefined when the first
+ *  line is not a JSON object with one (or is longer than the bounded scan). */
+function sessionHeaderCwd(file: string): string | undefined {
+  const fd = openSync(file, "r");
+  try {
+    const buf = Buffer.alloc(HEADER_SCAN_BYTES);
+    const n = readSync(fd, buf, 0, HEADER_SCAN_BYTES, 0);
+    const text = buf.subarray(0, n).toString("utf8");
+    const newline = text.indexOf("\n");
+    if (newline === -1) return undefined;
+    const header = JSON.parse(text.slice(0, newline)) as unknown;
+    if (!header || typeof header !== "object") return undefined;
+    const cwd = (header as { cwd?: unknown }).cwd;
+    return typeof cwd === "string" ? cwd : undefined;
+  } catch {
+    return undefined;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/** Every `*.jsonl` under `dir`, recursively. */
+function sessionFiles(dir: string): string[] {
+  if (!isDirectory(dir)) return [];
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...sessionFiles(p));
+    else if (entry.isFile() && entry.name.endsWith(".jsonl")) files.push(p);
+  }
+  return files;
+}
+
+/** True when no chat was ever recorded in this workspace. pi lists a session
+ *  for a workspace only when its header cwd is that folder, and writes the
+ *  file only once an assistant reply exists; a session recorded under another
+ *  cwd (v0.1.x pi leftovers) is invisible to the app and ignored here too.
+ *  A `.jsonl` without a readable header is taken as a chat: when in doubt,
+ *  leave the folder alone. */
+function hasNoChats(sessionsDir: string, workspaceDir: string): boolean {
+  return sessionFiles(sessionsDir).every((file) => {
+    const cwd = sessionHeaderCwd(file);
+    return cwd !== undefined && path.resolve(cwd) !== workspaceDir;
+  });
+}
+
+/** True when the folder holds nothing the user made: no chats of its own, an
+ *  untouched (or absent) template ledger, an empty memory, no documents.
+ *  Anything else in it (.git, .gitignore, .migrations.json, app-settings.json,
+ *  plugins/, auth.json, models.json, settings.json, pi's agent/) carries no
+ *  ledger data; the legacy workspace brings its own. */
+function isUnused(workspaceDir: string): boolean {
+  const memory = path.join(workspaceDir, "memory.md");
+  return (
+    hasNoChats(path.join(workspaceDir, "sessions"), workspaceDir) &&
+    isScaffoldLedger(path.join(workspaceDir, "ledger")) &&
+    (!existsSync(memory) || (statSync(memory).isFile() && statSync(memory).size === 0)) &&
+    hasNoFiles(path.join(workspaceDir, "files"))
+  );
+}
+
+export const relocateLegacyHomeOverUnused: Migration = {
+  id: "0002-relocate-legacy-home-over-unused",
+  run({ workspaceDir, homeDir }) {
+    // Only the default location is ours to move (same rule as 0001).
+    if (workspaceDir !== path.join(homeDir, ".accountant24")) return;
+    // Stricter than 0001 about what counts as the legacy workspace: 0001 only
+    // moved a folder, this one displaces one.
+    const legacy = path.join(homeDir, "Accountant24");
+    if (!isDirectory(legacy) || !existsSync(path.join(legacy, "ledger", "main.journal"))) return;
+
+    if (existsSync(workspaceDir)) {
+      if (!statSync(workspaceDir).isDirectory()) {
+        throw new Error(`${workspaceDir} exists but is not a folder`);
+      }
+      if (!isUnused(workspaceDir)) {
+        console.warn(
+          `[workspace] ${workspaceDir} is in use, so the previous workspace at ${legacy} was left where it is`,
+        );
+        return;
+      }
+      const backup = workspaceDir + BACKUP_SUFFIX;
+      if (existsSync(backup)) {
+        throw new Error(`${backup} already exists. Move it somewhere else, then open the app again.`);
+      }
+      renameSync(workspaceDir, backup);
+    }
+    // Reached with no workspace folder either when this run just moved it
+    // aside or when an earlier run crashed between the two renames.
+    renameSync(legacy, workspaceDir);
+  },
+};

--- a/packages/desktop/src/main/migrations/__tests__/0002-relocate-legacy-home-over-unused.test.ts
+++ b/packages/desktop/src/main/migrations/__tests__/0002-relocate-legacy-home-over-unused.test.ts
@@ -1,0 +1,373 @@
+// 0002 over a REAL temp "home": ~/Accountant24 is moved into place even when
+// ~/.accountant24 already exists, as long as that folder holds nothing the
+// user made; it is set aside as ~/.accountant24.bak first, never deleted. A
+// folder with a chat, a ledger edit, a memory or a document of its own keeps
+// both folders where they are.
+
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { relocateLegacyHome } from "../0001-relocate-legacy-home";
+import { relocateLegacyHomeOverUnused } from "../0002-relocate-legacy-home-over-unused";
+import { MIGRATIONS_STATE_FILE, runMigrations } from "../runner";
+
+/** The ledger files exactly as the v0.3.0 scaffold wrote them. */
+const SCAFFOLD_LEDGER = path.join(path.dirname(fileURLToPath(import.meta.url)), "fixtures", "scaffold-0.3.0", "ledger");
+
+let home: string;
+const legacy = () => path.join(home, "Accountant24");
+const target = () => path.join(home, ".accountant24");
+const backup = () => path.join(home, ".accountant24.bak");
+const ctx = () => ({ workspaceDir: target(), homeDir: home });
+const run = () => relocateLegacyHomeOverUnused.run(ctx());
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(tmpdir(), "a24-home-"));
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function write(file: string, content: string): void {
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, content);
+}
+
+/** A pi session file: the header line plus one exchange. */
+function writeSession(file: string, cwd: string): void {
+  write(
+    file,
+    `${JSON.stringify({ type: "session", version: 3, id: "s", timestamp: "2026-06-01T10:00:00.000Z", cwd })}\n` +
+      `${JSON.stringify({ type: "message", id: "m1", parentId: null, message: { role: "user", content: "hi" } })}\n`,
+  );
+}
+
+/** The pre-0.3 workspace: real books, chats, memory, logins, git history. */
+function seedLegacy(): void {
+  write(path.join(legacy(), "ledger", "main.journal"), "; main\ninclude 2026/01.journal\n");
+  write(path.join(legacy(), "ledger", "2026", "01.journal"), "2026-01-01 x\n");
+  write(path.join(legacy(), "memory.md"), "# Memory\n");
+  write(path.join(legacy(), "auth.json"), '{"anthropic":{"type":"api_key","key":"k"}}\n');
+  write(path.join(legacy(), "app-settings.json"), '{"defaultModel":"a/1"}\n');
+  write(path.join(legacy(), ".git", "HEAD"), "ref: refs/heads/main\n");
+  writeSession(path.join(legacy(), "sessions", "2026-06-01T10-00-00-000Z_old.jsonl"), legacy());
+}
+
+/** What v0.1.x pi left in ~/.accountant24: its config dir, no ledger. */
+function seedStale(): void {
+  write(path.join(target(), "agent", "bin", "fd"), "binary\n");
+  writeSession(
+    path.join(target(), "agent", "sessions", "--Users-x-repo--", "2026-05-01T10-00-00-000Z_s.jsonl"),
+    "/Users/x/repo",
+  );
+  write(path.join(target(), "agent", "auth.json"), "{}");
+  write(path.join(target(), "auth.json"), "{}");
+  mkdirSync(path.join(target(), "sessions"), { recursive: true });
+}
+
+/** What a 0.3.0 launch scaffolded into ~/.accountant24 (0001 recorded). */
+function seedScaffold(): void {
+  cpSync(SCAFFOLD_LEDGER, path.join(target(), "ledger"), { recursive: true });
+  write(path.join(target(), "memory.md"), "");
+  write(path.join(target(), ".gitignore"), "auth.json\nsessions/\n");
+  write(path.join(target(), ".git", "HEAD"), "ref: refs/heads/main\n");
+  write(path.join(target(), MIGRATIONS_STATE_FILE), '{\n  "applied": [\n    "0001-relocate-legacy-home"\n  ]\n}\n');
+  write(path.join(target(), "app-settings.json"), '{"onceEvents":["app_installed"]}\n');
+  write(path.join(target(), "plugins", "accountant24-skills", "plugin.json"), '{"name":"accountant24-skills"}\n');
+  mkdirSync(path.join(target(), "files"), { recursive: true });
+  mkdirSync(path.join(target(), "sessions"), { recursive: true });
+}
+
+function expectLegacyInPlace(): void {
+  expect(existsSync(legacy())).toBe(false);
+  expect(readFileSync(path.join(target(), "ledger", "2026", "01.journal"), "utf8")).toBe("2026-01-01 x\n");
+  expect(readFileSync(path.join(target(), "memory.md"), "utf8")).toBe("# Memory\n");
+  expect(readFileSync(path.join(target(), ".git", "HEAD"), "utf8")).toBe("ref: refs/heads/main\n");
+  expect(existsSync(path.join(target(), "sessions", "2026-06-01T10-00-00-000Z_old.jsonl"))).toBe(true);
+}
+
+function expectNothingMoved(): void {
+  expect(readFileSync(path.join(legacy(), "ledger", "2026", "01.journal"), "utf8")).toBe("2026-01-01 x\n");
+  expect(existsSync(backup())).toBe(false);
+  expect(existsSync(path.join(target(), "ledger", "2026", "01.journal"))).toBe(false);
+}
+
+describe("0002-relocate-legacy-home-over-unused", () => {
+  it("should carry the id the runner records", () => {
+    expect(relocateLegacyHomeOverUnused.id).toBe("0002-relocate-legacy-home-over-unused");
+  });
+
+  describe("no legacy workspace to move", () => {
+    it("should create nothing on a fresh install where neither folder exists", async () => {
+      await run();
+      expect(readdirSync(home)).toEqual([]);
+    });
+
+    it("should leave a ~/Accountant24 without a ledger alone, and not set the workspace aside for it", async () => {
+      write(path.join(legacy(), "notes.txt"), "not a workspace\n");
+      seedScaffold();
+      await run();
+      expect(existsSync(path.join(legacy(), "notes.txt"))).toBe(true);
+      expect(existsSync(backup())).toBe(false);
+      expect(existsSync(path.join(target(), "ledger", "main.journal"))).toBe(true);
+    });
+
+    it("should do nothing for a custom workspace, even with both default folders present", async () => {
+      seedLegacy();
+      seedStale();
+      const custom = path.join(home, "Demo");
+      await relocateLegacyHomeOverUnused.run({ workspaceDir: custom, homeDir: home });
+      expectNothingMoved();
+      expect(existsSync(custom)).toBe(false);
+    });
+  });
+
+  describe("moving ~/Accountant24 into place", () => {
+    it("should move it when ~/.accountant24 does not exist", async () => {
+      seedLegacy();
+      await run();
+      expectLegacyInPlace();
+      expect(existsSync(backup())).toBe(false);
+    });
+
+    it("should set aside a v0.1.x pi config dir as ~/.accountant24.bak and move the legacy workspace in", async () => {
+      seedLegacy();
+      seedStale();
+      await run();
+      expectLegacyInPlace();
+      expect(readFileSync(path.join(backup(), "agent", "bin", "fd"), "utf8")).toBe("binary\n");
+      expect(readFileSync(path.join(backup(), "auth.json"), "utf8")).toBe("{}");
+      expect(readFileSync(path.join(target(), "auth.json"), "utf8")).toBe(
+        '{"anthropic":{"type":"api_key","key":"k"}}\n',
+      );
+    });
+
+    it("should set aside an untouched 0.3.0 scaffold, plugins and 0001 record included", async () => {
+      seedLegacy();
+      seedScaffold();
+      await run();
+      expectLegacyInPlace();
+      expect(readFileSync(path.join(backup(), "ledger", "accounts.journal"))).toEqual(
+        readFileSync(path.join(SCAFFOLD_LEDGER, "accounts.journal")),
+      );
+      expect(existsSync(path.join(backup(), "plugins", "accountant24-skills", "plugin.json"))).toBe(true);
+      expect(JSON.parse(readFileSync(path.join(backup(), MIGRATIONS_STATE_FILE), "utf8"))).toEqual({
+        applied: ["0001-relocate-legacy-home"],
+      });
+      expect(existsSync(path.join(target(), MIGRATIONS_STATE_FILE))).toBe(false);
+    });
+
+    it("should set aside the reported case: v0.1.x leftovers with a 0.3.0 scaffold on top", async () => {
+      seedLegacy();
+      seedStale();
+      seedScaffold();
+      await run();
+      expectLegacyInPlace();
+      expect(existsSync(path.join(backup(), "agent", "bin", "fd"))).toBe(true);
+      expect(existsSync(path.join(backup(), "ledger", "main.journal"))).toBe(true);
+    });
+
+    it("should ignore a session recorded under another folder, as the app does", async () => {
+      seedLegacy();
+      seedScaffold();
+      writeSession(path.join(target(), "sessions", "2026-04-20T10-00-00-000Z_tui.jsonl"), "/Users/x/Accountant24");
+      await run();
+      expectLegacyInPlace();
+      expect(existsSync(path.join(backup(), "sessions", "2026-04-20T10-00-00-000Z_tui.jsonl"))).toBe(true);
+    });
+
+    it("should ignore files in sessions/ that are not session files", async () => {
+      seedLegacy();
+      seedScaffold();
+      write(path.join(target(), "sessions", ".DS_Store"), "junk");
+      await run();
+      expectLegacyInPlace();
+    });
+
+    it("should accept a ledger holding only some of the template files", async () => {
+      seedLegacy();
+      seedScaffold();
+      rmSync(path.join(target(), "ledger", "commodities.journal"));
+      await run();
+      expectLegacyInPlace();
+    });
+
+    it("should accept empty subfolders under files/", async () => {
+      seedLegacy();
+      seedScaffold();
+      mkdirSync(path.join(target(), "files", "2026", "08"), { recursive: true });
+      await run();
+      expectLegacyInPlace();
+    });
+
+    it("should finish a run that crashed between the two renames", async () => {
+      // The previous run set the scaffold aside and died before moving the
+      // legacy folder: the backup exists, ~/.accountant24 does not.
+      seedLegacy();
+      write(path.join(backup(), "ledger", "main.journal"), "; scaffold\n");
+      await run();
+      expectLegacyInPlace();
+      expect(readFileSync(path.join(backup(), "ledger", "main.journal"), "utf8")).toBe("; scaffold\n");
+    });
+
+    it("should do nothing on a second run", async () => {
+      seedLegacy();
+      seedScaffold();
+      await run();
+      const before = readdirSync(home).sort();
+      await run();
+      expect(readdirSync(home).sort()).toEqual(before);
+      expectLegacyInPlace();
+    });
+  });
+
+  describe("~/.accountant24 in use", () => {
+    const seedUsed = () => {
+      seedLegacy();
+      seedScaffold();
+    };
+
+    function expectLeftAlone(): void {
+      expectNothingMoved();
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining(target()));
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining(legacy()));
+    }
+
+    it("should leave both folders and warn when a chat was recorded in it", async () => {
+      seedUsed();
+      writeSession(path.join(target(), "sessions", "2026-08-27T10-00-00-000Z_new.jsonl"), target());
+      await run();
+      expectLeftAlone();
+      expect(existsSync(path.join(target(), "sessions", "2026-08-27T10-00-00-000Z_new.jsonl"))).toBe(true);
+    });
+
+    it("should count a session whose cwd resolves to the workspace through a trailing slash", async () => {
+      seedUsed();
+      writeSession(path.join(target(), "sessions", "s.jsonl"), `${target()}/`);
+      await run();
+      expectLeftAlone();
+    });
+
+    it("should count a session file with an unreadable header as a chat", async () => {
+      seedUsed();
+      write(path.join(target(), "sessions", "s.jsonl"), "not json\n");
+      await run();
+      expectLeftAlone();
+    });
+
+    it("should count a session file whose header has no cwd as a chat", async () => {
+      seedUsed();
+      write(path.join(target(), "sessions", "s.jsonl"), '{"type":"session"}\n');
+      await run();
+      expectLeftAlone();
+    });
+
+    it("should count an empty session file as a chat", async () => {
+      seedUsed();
+      write(path.join(target(), "sessions", "s.jsonl"), "");
+      await run();
+      expectLeftAlone();
+    });
+
+    it("should count a non-empty memory", async () => {
+      seedUsed();
+      write(path.join(target(), "memory.md"), "Prefers EUR.\n");
+      await run();
+      expectLeftAlone();
+    });
+
+    it("should count a memory.md that is not a file", async () => {
+      seedUsed();
+      rmSync(path.join(target(), "memory.md"));
+      mkdirSync(path.join(target(), "memory.md"));
+      await run();
+      expectLeftAlone();
+    });
+
+    it("should count a stored document", async () => {
+      seedUsed();
+      write(path.join(target(), "files", "2026", "receipt.pdf"), "%PDF");
+      await run();
+      expectLeftAlone();
+    });
+
+    it("should count a files entry that is not a folder", async () => {
+      seedUsed();
+      rmSync(path.join(target(), "files"), { recursive: true });
+      write(path.join(target(), "files"), "");
+      await run();
+      expectLeftAlone();
+    });
+
+    it("should count an edited template journal", async () => {
+      seedUsed();
+      write(path.join(target(), "ledger", "accounts.journal"), "account Assets:Bank\n");
+      await run();
+      expectLeftAlone();
+    });
+
+    it("should count an extra entry in ledger/", async () => {
+      seedUsed();
+      write(path.join(target(), "ledger", "2026", "08.journal"), "2026-08-01 x\n");
+      await run();
+      expectLeftAlone();
+    });
+
+    it("should count a ledger that is not a folder", async () => {
+      seedUsed();
+      rmSync(path.join(target(), "ledger"), { recursive: true });
+      write(path.join(target(), "ledger"), "");
+      await run();
+      expectLeftAlone();
+    });
+  });
+
+  describe("unexpected state", () => {
+    it("should refuse to move anything when ~/.accountant24.bak already exists", async () => {
+      seedLegacy();
+      seedStale();
+      write(path.join(backup(), "keep.txt"), "mine\n");
+      await expect(async () => run()).rejects.toThrow(`${backup()} already exists`);
+      expect(readFileSync(path.join(legacy(), "ledger", "2026", "01.journal"), "utf8")).toBe("2026-01-01 x\n");
+      expect(readFileSync(path.join(target(), "auth.json"), "utf8")).toBe("{}");
+      expect(readFileSync(path.join(backup(), "keep.txt"), "utf8")).toBe("mine\n");
+    });
+
+    it("should refuse when ~/.accountant24 is a file", async () => {
+      seedLegacy();
+      write(target(), "");
+      await expect(async () => run()).rejects.toThrow(`${target()} exists but is not a folder`);
+      expectNothingMoved();
+    });
+  });
+
+  describe("through the runner, after 0001 was recorded in the scaffold", () => {
+    const migrations = [relocateLegacyHome, relocateLegacyHomeOverUnused];
+    const readState = () => JSON.parse(readFileSync(path.join(target(), MIGRATIONS_STATE_FILE), "utf8"));
+
+    it("should skip 0001, move the legacy workspace in, and record 0002 in it", async () => {
+      seedLegacy();
+      seedStale();
+      seedScaffold();
+      await expect(runMigrations(migrations, ctx())).resolves.toEqual(["0002-relocate-legacy-home-over-unused"]);
+      expectLegacyInPlace();
+      expect(readState()).toEqual({ applied: ["0002-relocate-legacy-home-over-unused"] });
+    });
+
+    it("should record 0001 as a no-op on the next launch and touch nothing else", async () => {
+      seedLegacy();
+      seedScaffold();
+      await runMigrations(migrations, ctx());
+      await expect(runMigrations(migrations, ctx())).resolves.toEqual(["0001-relocate-legacy-home"]);
+      expectLegacyInPlace();
+      expect(readState()).toEqual({
+        applied: ["0002-relocate-legacy-home-over-unused", "0001-relocate-legacy-home"],
+      });
+      expect(existsSync(path.join(backup(), "ledger", "main.journal"))).toBe(true);
+    });
+  });
+});

--- a/packages/desktop/src/main/migrations/__tests__/fixtures/scaffold-0.3.0/ledger/accounts.journal
+++ b/packages/desktop/src/main/migrations/__tests__/fixtures/scaffold-0.3.0/ledger/accounts.journal
@@ -1,0 +1,56 @@
+; Chart of accounts — every account used in the ledger must be declared here.
+;
+; Account types:
+;   ASSETS       — things you own (cash, bank accounts, investments, property)
+;   LIABILITIES  — things you owe (credit cards, loans, mortgages)
+;   EQUITY       — technical balancing entries, not real money flows (opening balances, currency conversion)
+;   INCOME       — inflows of money (salary, business, investments)
+;   EXPENSES     — outflows of money (rent, groceries, subscriptions)
+
+; ====================================================================
+; ASSETS — things you own (cash, bank accounts, investments, property)
+; ====================================================================
+
+account Assets:Cash  ; physical cash
+
+; ====================================================================
+; LIABILITIES — things you owe (credit cards, loans, mortgages)
+; ====================================================================
+
+account Liabilities:Loan  ; personal loans
+
+; ====================================================================
+; EQUITY — technical balancing entries, not real money flows (opening balances, currency conversion)
+; ====================================================================
+
+account Equity:Opening Balances  ; counterpart for initial account balances
+
+; ====================================================================
+; INCOME — inflows of money (salary, business, investments)
+; ====================================================================
+
+account Income:Salary      ; wages, bonuses, employer benefits
+account Income:Business    ; self-employment, freelance, side gigs
+account Income:Investment  ; dividends, capital gains, interest
+account Income:Other       ; gifts, tax refunds, government benefits
+
+; ====================================================================
+; EXPENSES — outflows of money (rent, groceries, subscriptions)
+; ====================================================================
+
+account Expenses:Housing                ; rent, home insurance, maintenance and repairs
+account Expenses:Utilities              ; electricity, gas, water, internet, phone, sewage and waste
+account Expenses:Food                   ; groceries, dining out, delivery, coffee shops
+account Expenses:Transport              ; fuel, public transit, taxi, parking, car insurance and maintenance
+account Expenses:Shopping               ; clothing, electronics, home goods and furniture
+account Expenses:Entertainment          ; events, activities, video games, hobbies
+account Expenses:Travel                 ; transportation, accommodation, food while traveling
+account Expenses:Health                 ; health insurance, doctors, hospitals, pharmacy, medications
+account Expenses:Personal Care          ; hair, beauty, gym and fitness
+account Expenses:Education              ; tuition, courses, books
+account Expenses:Children               ; childcare, kids' activities
+account Expenses:Financial              ; bank fees, interest, legal and accounting services
+account Expenses:Taxes                  ; income tax, property tax
+account Expenses:Gifts & Donations      ; gifts, charity
+account Expenses:Subscriptions          ; streaming, software and apps, memberships
+account Expenses:Uncategorized          ; transactions pending categorization

--- a/packages/desktop/src/main/migrations/__tests__/fixtures/scaffold-0.3.0/ledger/commodities.journal
+++ b/packages/desktop/src/main/migrations/__tests__/fixtures/scaffold-0.3.0/ledger/commodities.journal
@@ -1,0 +1,1 @@
+; Commodity declarations

--- a/packages/desktop/src/main/migrations/__tests__/fixtures/scaffold-0.3.0/ledger/main.journal
+++ b/packages/desktop/src/main/migrations/__tests__/fixtures/scaffold-0.3.0/ledger/main.journal
@@ -1,0 +1,4 @@
+; Accountant24
+
+include commodities.journal
+include accounts.journal

--- a/packages/desktop/src/main/migrations/__tests__/index.test.ts
+++ b/packages/desktop/src/main/migrations/__tests__/index.test.ts
@@ -1,0 +1,14 @@
+// The shipped migration list: order is run order and ids are what gets
+// recorded, so both are part of the contract. env.ts pulls in Electron for
+// unrelated path helpers; it is the only fake here.
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({ app: { isPackaged: false, getAppPath: () => "/app" } }));
+
+describe("MIGRATIONS", () => {
+  it("should list the shipped migrations in order, 0001 then 0002", async () => {
+    const { MIGRATIONS } = await import("../index");
+    expect(MIGRATIONS.map((m) => m.id)).toEqual(["0001-relocate-legacy-home", "0002-relocate-legacy-home-over-unused"]);
+  });
+});

--- a/packages/desktop/src/main/migrations/index.ts
+++ b/packages/desktop/src/main/migrations/index.ts
@@ -4,9 +4,10 @@
 import { homedir } from "node:os";
 import { workspaceDir } from "../env";
 import { relocateLegacyHome } from "./0001-relocate-legacy-home";
+import { relocateLegacyHomeOverUnused } from "./0002-relocate-legacy-home-over-unused";
 import { type Migration, runMigrations } from "./runner";
 
-export const MIGRATIONS: readonly Migration[] = [relocateLegacyHome];
+export const MIGRATIONS: readonly Migration[] = [relocateLegacyHome, relocateLegacyHomeOverUnused];
 
 /** Run the migrations the active workspace has not seen yet. */
 export function runPendingMigrations(): Promise<string[]> {


### PR DESCRIPTION
- Add migration `0002-relocate-legacy-home-over-unused`: when the workspace is the default `~/.accountant24`, `~/Accountant24` holds a `ledger/main.journal`, and `~/.accountant24` holds nothing the user made, rename `~/.accountant24` to `~/.accountant24.bak` and move `~/Accountant24` into place.
- Treat `~/.accountant24` as unused when it has no session file whose header `cwd` is the workspace, a `ledger/` that is absent or byte-identical to the v0.3.0 templates (frozen sha256), an absent or empty `memory.md`, and no files under `files/`; ignore everything else in it.
- Leave both folders where they are and log a warning when `~/.accountant24` has been used since; abort startup when `~/.accountant24.bak` already exists or `~/.accountant24` is not a folder.
- Append the migration to `MIGRATIONS` and add `index.test.ts` for the list order.
- Cover the migration over a real temp home, with the v0.3.0 ledger files as fixtures.

If both folders already hold data, quit the app, rename `~/.accountant24` to something else, rename `~/Accountant24` to `~/.accountant24`, and open the app again.