### PR TITLE
feat: drop the Official and Community labels from the skills selector

### DIFF
--- a/packages/desktop/src/renderer/components/accountant24/__tests__/composer-skills-popover.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/composer-skills-popover.test.tsx
@@ -1,10 +1,7 @@
 // @vitest-environment jsdom
 
 // Spec for the `/` skills popover UI: a flat, keyboard-navigable list that opens
-// only for a *leading* slash, renders Official/Custom section labels on group
-// boundaries, and shows an empty label when nothing matches. The grouping helper
-// (groupSkillRows) is unit-tested in composer-skills.test.tsx; this file covers
-// the rendered popover itself.
+// only for a *leading* slash and shows an empty label when nothing matches.
 
 import {
   AssistantRuntimeProvider,
@@ -31,8 +28,8 @@ afterEach(() => {
 });
 
 const MIXED_SKILLS: Unstable_TriggerItem[] = [
-  { id: "pdf", type: "skill", label: "pdf", description: "Read PDF files.", metadata: { official: true } },
-  { id: "invoices", type: "skill", label: "invoices", description: "Draft invoices.", metadata: { official: false } },
+  { id: "pdf", type: "skill", label: "pdf", description: "Read PDF files." },
+  { id: "invoices", type: "skill", label: "invoices", description: "Draft invoices." },
 ];
 
 /** A flat skills adapter: no categories, a search that filters on the label
@@ -102,25 +99,6 @@ describe("ComposerSkillsPopover", () => {
     type(input, "/");
     await waitFor(() => expect(screen.getByText("Read PDF files.")).toBeInTheDocument());
     expect(screen.getByText("Draft invoices.")).toBeInTheDocument();
-  });
-
-  it("should label the Official and Custom groups when both are present", async () => {
-    const input = renderPicker();
-    type(input, "/");
-    await waitFor(() => expect(screen.getByText("Official")).toBeInTheDocument());
-    expect(screen.getByText("Community")).toBeInTheDocument();
-  });
-
-  it("should not draw group labels for a homogeneous list", async () => {
-    const input = renderPicker(
-      makeAdapter([
-        { id: "pdf", type: "skill", label: "pdf", description: "Read PDFs.", metadata: { official: true } },
-      ]),
-    );
-    type(input, "/");
-    await waitFor(() => expect(screen.getByText("pdf")).toBeInTheDocument());
-    expect(screen.queryByText("Official")).toBeNull();
-    expect(screen.queryByText("Community")).toBeNull();
   });
 
   it("should show the empty label when the query matches no skill", async () => {

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/composer-skills.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/composer-skills.test.tsx
@@ -36,7 +36,6 @@ import {
   AssistantRuntimeProvider,
   ComposerPrimitive,
   type ExternalStoreAdapter,
-  type Unstable_TriggerItem,
   useExternalStoreRuntime,
 } from "@assistant-ui/react";
 import type { ReactNode } from "react";
@@ -47,7 +46,7 @@ import {
   pickerSkills,
   useEnabledSkills,
 } from "../composer-skills";
-import { ComposerSkillsPopover, groupSkillRows } from "../composer-skills-popover";
+import { ComposerSkillsPopover } from "../composer-skills-popover";
 
 beforeAll(() => {
   installJsdomPolyfills();
@@ -55,11 +54,6 @@ beforeAll(() => {
   Element.prototype.setPointerCapture ??= () => {};
   Element.prototype.releasePointerCapture ??= () => {};
 });
-
-/** Minimal trigger item for grouping specs. */
-function triggerItem(id: string, official: boolean): Unstable_TriggerItem {
-  return { id, type: "skill", label: id, metadata: { official } };
-}
 
 /** Probe rendering the hook's result as text. */
 function Probe() {
@@ -228,15 +222,6 @@ describe("createSkillsAdapter()", () => {
     expect(adapter.search?.("")?.map((i) => i.id)).toEqual(["official-b", "official-d", "custom-a", "custom-c"]);
   });
 
-  it("should carry the group on item metadata", () => {
-    const adapter = createSkillsAdapter([
-      { name: "official-b", description: "B.", official: true },
-      { name: "custom-a", description: "A.", official: false },
-    ]);
-    const items = adapter.search?.("") ?? [];
-    expect(items.map((i) => i.metadata)).toEqual([{ official: true }, { official: false }]);
-  });
-
   it("should expose no categories (skills are one flat list)", () => {
     const adapter = createSkillsAdapter(skills);
     expect(adapter.categories()).toEqual([]);
@@ -351,46 +336,6 @@ describe("createSkillsAdapter()", () => {
   });
 });
 
-describe("groupSkillRows()", () => {
-  it("should put a header on the first row of each group when both groups are present", () => {
-    const rows = groupSkillRows([
-      triggerItem("official-a", true),
-      triggerItem("official-b", true),
-      triggerItem("custom-c", false),
-      triggerItem("custom-d", false),
-    ]);
-    expect(rows.map((r) => r.header)).toEqual(["Official", undefined, "Community", undefined]);
-  });
-
-  it("should keep flat indices in item order (the keyboard-nav contract)", () => {
-    const rows = groupSkillRows([triggerItem("a", true), triggerItem("b", false), triggerItem("c", false)]);
-    expect(rows.map((r) => r.index)).toEqual([0, 1, 2]);
-    expect(rows.map((r) => r.item.id)).toEqual(["a", "b", "c"]);
-  });
-
-  it("should render no headers when only official skills match", () => {
-    const rows = groupSkillRows([triggerItem("a", true), triggerItem("b", true)]);
-    expect(rows.every((r) => r.header === undefined)).toBe(true);
-  });
-
-  it("should render no headers when only community skills match", () => {
-    const rows = groupSkillRows([triggerItem("a", false), triggerItem("b", false)]);
-    expect(rows.every((r) => r.header === undefined)).toBe(true);
-  });
-
-  it("should treat items without metadata as custom", () => {
-    const rows = groupSkillRows([
-      triggerItem("official-a", true),
-      { id: "bare", type: "skill", label: "bare" } as Unstable_TriggerItem,
-    ]);
-    expect(rows.map((r) => r.header)).toEqual(["Official", "Community"]);
-  });
-
-  it("should return an empty list for no items", () => {
-    expect(groupSkillRows([])).toEqual([]);
-  });
-});
-
 describe("<ComposerSkillsPopover />", () => {
   const SKILLS: PickerSkill[] = [
     { name: "docs:pdf", description: "Read and split PDFs.", official: true },
@@ -449,14 +394,6 @@ describe("<ComposerSkillsPopover />", () => {
     await waitFor(() => expect(getSkillRow("docs:pdf")).toBeInTheDocument());
     expect(getSkillRow("money:budget")).toBeInTheDocument();
     expect(screen.getByText("Read and split PDFs.")).toBeInTheDocument();
-  });
-
-  it("should show inline Official and Custom section headers when both groups are present", async () => {
-    const input = renderPicker();
-    type(input, "/");
-    await waitFor(() => expect(getSkillRow("docs:pdf")).toBeInTheDocument());
-    expect(screen.getByText("Official")).toBeInTheDocument();
-    expect(screen.getByText("Community")).toBeInTheDocument();
   });
 
   it("should narrow the list to the matching skill as the query is typed", async () => {

--- a/packages/desktop/src/renderer/components/accountant24/composer-skills-popover.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/composer-skills-popover.tsx
@@ -3,8 +3,7 @@
 // The `/` skills popover — a dedicated, skills-shaped sibling of the mentions
 // popover (composer-mentions-popover.tsx), split off so skill business logic
 // can evolve independently of mentions. Skills are one flat keyboard-navigable
-// list with inline Built-in/Custom section labels on the group boundaries;
-// selecting one replaces the typed `/…` trigger with a `:skill[name]` directive
+// list; selecting one replaces the typed `/…` trigger with a `:skill[name]` directive
 // chip (mention-style — no raw `/skill:` text in the composer). The outgoing
 // message is rewritten to pi's `/skill:name` wire form at send time
 // (hoistSkillDirective in electronPiClient). Rows always carry the skill glyph
@@ -17,13 +16,12 @@
 
 import {
   ComposerPrimitive,
-  type Unstable_TriggerItem,
   unstable_defaultDirectiveFormatter,
   unstable_useTriggerPopoverScopeContext,
   useAuiState,
 } from "@assistant-ui/react";
 import { ZapIcon } from "lucide-react";
-import { type ComponentPropsWithoutRef, type FC, Fragment, useEffect, useLayoutEffect, useRef } from "react";
+import { type ComponentPropsWithoutRef, type FC, useEffect, useLayoutEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { COMPOSER_POPOVER_CHROME, POPOVER_ROW, POPOVER_WIDTH } from "./popover";
 
@@ -40,29 +38,6 @@ type ComposerSkillsPopoverProps = {
   emptyLabel: string;
   className?: string;
 };
-
-type SkillRowEntry = {
-  item: Unstable_TriggerItem;
-  /** Flat index into the items array — the keyboard-nav/highlight contract. */
-  index: number;
-  /** Section label rendered above this row, on group boundaries only. */
-  header?: "Official" | "Community";
-};
-
-/** Mark group boundaries in the (already official-first) item list. Headers
- *  appear only when BOTH groups are present: a lone label over a homogeneous
- *  list is noise. Exported for tests. */
-export function groupSkillRows(items: readonly Unstable_TriggerItem[]): SkillRowEntry[] {
-  const isOfficialItem = (item: Unstable_TriggerItem) => item.metadata?.official === true;
-  const mixed = items.some(isOfficialItem) && items.some((item) => !isOfficialItem(item));
-  let prev: boolean | null = null;
-  return items.map((item, index) => {
-    const official = isOfficialItem(item);
-    const header = mixed && official !== prev ? (official ? ("Official" as const) : ("Community" as const)) : undefined;
-    prev = official;
-    return header ? { item, index, header } : { item, index };
-  });
-}
 
 /** A skill's full name, `plugin:skill`, with the plugin part played down.
  *  Every skill from one plugin starts with the same prefix, so the eye that is
@@ -120,35 +95,27 @@ const SkillRows: FC<{ emptyLabel: string }> = ({ emptyLabel }) => {
           className="scroll-fade no-scrollbar max-h-[15.75rem] overflow-y-auto p-1.5"
         >
           <div className="flex flex-col">
-            {groupSkillRows(items).map(({ item, index, header }) => (
-              <Fragment key={item.id}>
-                {header && (
-                  // Non-interactive section label; recipe adapted from the
-                  // stock dropdown-menu label, sized for this dense list.
-                  <div className={cn("text-muted-foreground px-3 pb-1 text-xs font-medium", index > 0 && "pt-2")}>
-                    {header}
-                  </div>
-                )}
-                <ComposerPrimitive.Unstable_TriggerPopoverItem
-                  item={item}
-                  index={index}
-                  className={cn(POPOVER_ROW, "flex w-full flex-col items-start gap-0.5 text-start")}
-                >
-                  <span className="flex w-full min-w-0 items-center gap-2 text-sm font-medium">
-                    <ZapIcon className="text-muted-foreground size-4 shrink-0" />
-                    <SkillName name={item.label} />
+            {items.map((item, index) => (
+              <ComposerPrimitive.Unstable_TriggerPopoverItem
+                key={item.id}
+                item={item}
+                index={index}
+                className={cn(POPOVER_ROW, "flex w-full flex-col items-start gap-0.5 text-start")}
+              >
+                <span className="flex w-full min-w-0 items-center gap-2 text-sm font-medium">
+                  <ZapIcon className="text-muted-foreground size-4 shrink-0" />
+                  <SkillName name={item.label} />
+                </span>
+                {item.description && (
+                  // Skill descriptions are long by design (they steer the model);
+                  // show up to three lines and let the clamp ellipsize the rest.
+                  // ps-6 (not ms-6): the icon-width indent must live INSIDE the
+                  // w-full box — margin + w-full overflows the row by the margin.
+                  <span className="text-muted-foreground line-clamp-3 w-full min-w-0 ps-6 text-xs leading-tight">
+                    {item.description}
                   </span>
-                  {item.description && (
-                    // Skill descriptions are long by design (they steer the model);
-                    // show up to three lines and let the clamp ellipsize the rest.
-                    // ps-6 (not ms-6): the icon-width indent must live INSIDE the
-                    // w-full box — margin + w-full overflows the row by the margin.
-                    <span className="text-muted-foreground line-clamp-3 w-full min-w-0 ps-6 text-xs leading-tight">
-                      {item.description}
-                    </span>
-                  )}
-                </ComposerPrimitive.Unstable_TriggerPopoverItem>
-              </Fragment>
+                )}
+              </ComposerPrimitive.Unstable_TriggerPopoverItem>
             ))}
             {items.length === 0 && (
               <div className="text-muted-foreground w-full py-6 text-center text-sm">{emptyLabel}</div>

--- a/packages/desktop/src/renderer/components/accountant24/composer-skills.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/composer-skills.tsx
@@ -44,9 +44,8 @@ export function pickerSkills(plugins: PluginInfo[]): PickerSkill[] {
 /** Shape the skills into a flat trigger adapter: no categories, and a search
  *  that narrows by name first (empty query lists everything). The full
  *  description travels on the item — the popover clamps it visually. Official
- *  skills sort before community ones (the popover draws the group boundary
- *  from `metadata.official`); the sort is an explicit contract here, not an
- *  accident of the IPC payload order. */
+ *  skills sort before community ones; the sort is an explicit contract here,
+ *  not an accident of the IPC payload order. */
 export function createSkillsAdapter(skills: PickerSkill[]): SkillsTriggerAdapter {
   const items: Unstable_TriggerItem[] = [...skills]
     .sort((a, b) => Number(b.official) - Number(a.official))
@@ -55,7 +54,6 @@ export function createSkillsAdapter(skills: PickerSkill[]): SkillsTriggerAdapter
       type: "skill",
       label: skill.name,
       description: skill.description,
-      metadata: { official: skill.official },
     }));
   return {
     categories: () => [],


### PR DESCRIPTION
- Render the `/` skills popover as one flat list without section labels
- Remove `groupSkillRows()` and the `official` item metadata it read
- Keep official skills sorted ahead of community ones