### PR TITLE
feat: reword the composer hint to "Type / to use skills"

### DIFF
--- a/packages/desktop/src/renderer/components/accountant24/__tests__/rotating-placeholder.test.ts
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/rotating-placeholder.test.ts
@@ -8,7 +8,7 @@ import { useRotatingPlaceholder } from "../rotating-placeholder";
 // for 100ms, then shows the next tip (mentions, then skills, then wraps).
 const PLAIN_PROMPT = "Write a message...";
 const MENTION_TIP = "Type @ to mention accounts, payees, tags";
-const SKILL_TIP = "Type / to use a skill";
+const SKILL_TIP = "Type / to use skills";
 const ROTATE_MS = 5_000;
 const SWAP_MS = 100;
 

--- a/packages/desktop/src/renderer/components/accountant24/rotating-placeholder.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/rotating-placeholder.tsx
@@ -11,7 +11,7 @@ import { useSteerEnter } from "@/hooks/use-steer-enter";
 const COMPOSER_PLACEHOLDERS = [
   "Write a message...",
   "Type @ to mention accounts, payees, tags",
-  "Type / to use a skill",
+  "Type / to use skills",
 ];
 const PLACEHOLDER_ROTATE_MS = 5000;
 // Must match the .aui-lexical-placeholder transition duration in index.css.


### PR DESCRIPTION
- Change the rotating composer placeholder from `Type / to use a skill` to `Type / to use skills`
- Update the matching `SKILL_TIP` constant in the placeholder test