### PR TITLE
feat: name the skill and docs page in the chat's tool steps

### DIFF
--- a/packages/desktop/src/renderer/components/accountant24/__tests__/tool-fallback.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/tool-fallback.test.tsx
@@ -3,7 +3,7 @@
 import type { ToolCallMessagePartStatus } from "@assistant-ui/react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { prettyPrintJson, ToolFallback, toolLabel } from "../tool-fallback";
+import { prettyPrintJson, ToolFallback, toolCallLabel, toolLabel } from "../tool-fallback";
 
 afterEach(cleanup);
 
@@ -266,6 +266,114 @@ describe("ToolFallback memory updates", () => {
     render(<ToolFallback {...partProps({ toolName: "read", args: { path: "ledger/main.journal" } })} />);
     expect(screen.getByText("Read File")).toBeTruthy();
     expect(screen.queryByText("Read Memory")).toBeNull();
+  });
+});
+
+describe("toolCallLabel()", () => {
+  it("should return 'Update Memory' for an edit of memory.md", () => {
+    expect(toolCallLabel("edit", { path: "memory.md", edits: [] })).toBe("Update Memory");
+  });
+
+  it("should return 'Read Memory' for a read of memory.md", () => {
+    expect(toolCallLabel("read", { path: "/ws/memory.md" })).toBe("Read Memory");
+  });
+
+  it("should name the skill for a read of its SKILL.md", () => {
+    expect(toolCallLabel("read", { path: "/ws/plugins/accountant24-skills/skills/docs/SKILL.md" })).toBe(
+      "Use Skill: docs",
+    );
+  });
+
+  it("should return a bare 'Use Skill' for a SKILL.md with no folder", () => {
+    expect(toolCallLabel("read", { path: "SKILL.md" })).toBe("Use Skill");
+  });
+
+  it("should name the page for a read of a bundled documentation page", () => {
+    expect(toolCallLabel("read", { path: "/Applications/Accountant24.app/Contents/Resources/docs/settings.md" })).toBe(
+      "Read Docs: settings",
+    );
+  });
+
+  it("should name the page for a command reading it via $ACCOUNTANT24_DOCS", () => {
+    expect(toolCallLabel("bash", { command: 'cat "$ACCOUNTANT24_DOCS/settings.md"' })).toBe("Read Docs: settings");
+  });
+
+  it("should list every page for a command reading several", () => {
+    expect(toolCallLabel("bash", { command: "cat $ACCOUNTANT24_DOCS/contents.md $ACCOUNTANT24_DOCS/faq.md" })).toBe(
+      "Read Docs: contents, faq",
+    );
+  });
+
+  it("should return a bare 'Read Docs' for a command touching the docs dir without a page", () => {
+    expect(toolCallLabel("bash", { command: "echo $ACCOUNTANT24_DOCS" })).toBe("Read Docs");
+  });
+
+  it("should return the plain tool label for any other file read", () => {
+    expect(toolCallLabel("read", { path: "ledger/main.journal" })).toBe("Read File");
+  });
+
+  it("should return the plain tool label for any other command", () => {
+    expect(toolCallLabel("bash", { command: "hledger bal" })).toBe("Run Command");
+  });
+
+  it("should return the plain tool label while args are still streaming", () => {
+    expect(toolCallLabel("read", undefined)).toBe("Read File");
+    expect(toolCallLabel("bash", {})).toBe("Run Command");
+  });
+
+  it("should return the raw name for unknown tools", () => {
+    expect(toolCallLabel("mystery_tool", { path: "SKILL.md" })).toBe("mystery_tool");
+  });
+});
+
+describe("ToolFallback skill and documentation reads", () => {
+  it("should label a read call on a SKILL.md with the skill name", () => {
+    render(<ToolFallback {...partProps({ toolName: "read", args: { path: "/ws/skills/pdf/SKILL.md" } })} />);
+    expect(screen.getByText("Use Skill: pdf")).toBeTruthy();
+    expect(screen.queryByText("Read File")).toBeNull();
+  });
+
+  it("should label a read call on a bundled documentation page with the page name", () => {
+    render(<ToolFallback {...partProps({ toolName: "read", args: { path: "/app/resources/docs/faq.md" } })} />);
+    expect(screen.getByText("Read Docs: faq")).toBeTruthy();
+    expect(screen.queryByText("Read File")).toBeNull();
+  });
+
+  it("should label a command reading the bundled documentation with the page name", () => {
+    render(
+      <ToolFallback
+        {...partProps({
+          toolName: "bash",
+          args: { command: "echo $ACCOUNTANT24_DOCS; cat $ACCOUNTANT24_DOCS/contents.md" },
+        })}
+      />,
+    );
+    expect(screen.getByText("Read Docs: contents")).toBeTruthy();
+    expect(screen.queryByText("Run Command")).toBeNull();
+  });
+
+  it("should keep the plain command label for other commands", () => {
+    render(<ToolFallback {...partProps({ toolName: "bash", args: { command: "hledger bal" } })} />);
+    expect(screen.getByText("Run Command")).toBeTruthy();
+    expect(screen.queryByText(/Read Docs/)).toBeNull();
+  });
+
+  it("should show the standard input and output like any other tool", () => {
+    render(
+      <ToolFallback
+        {...partProps({
+          toolName: "read",
+          args: { path: "/ws/skills/pdf/SKILL.md" },
+          argsText: '{"path":"/ws/skills/pdf/SKILL.md"}',
+          result: "---\nname: pdf\n---",
+        })}
+      />,
+    );
+    fireEvent.click(screen.getByText("Use Skill: pdf"));
+    expect(screen.getByText("Input:")).toBeTruthy();
+    expect(screen.getByText("Output:")).toBeTruthy();
+    const args = document.querySelector("[data-slot=tool-fallback-args] pre");
+    expect(args?.textContent).toBe(`{\n  "path": "/ws/skills/pdf/SKILL.md"\n}`);
   });
 });
 

--- a/packages/desktop/src/renderer/components/accountant24/tool-fallback.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/tool-fallback.tsx
@@ -18,6 +18,7 @@ import {
 import { Spinner } from "@/components/shadcn/spinner";
 import { formatDuration } from "@/lib/duration";
 import { isMemoryReadCall, isMemoryUpdateCall } from "@/lib/memory-tool";
+import { docsReadPages, skillReadName } from "@/lib/skill-docs-tool";
 import { TOOL_LABELS } from "@/lib/tool-labels";
 import { cn } from "@/lib/utils";
 
@@ -33,6 +34,19 @@ const statusIconMap: Record<ToolStatus, React.ElementType> = {
 // TOOL_LABELS covers the custom tools and pi's built-ins (the event stream
 // only carries tool names). Tools without an entry show their raw name.
 export const toolLabel = (toolName: string) => TOOL_LABELS[toolName] ?? toolName;
+
+// Memory, skills and the bundled documentation ride on the generic file/shell
+// tools; only the step label is specialized so the user can see what is
+// touched, naming the skill or page when the call says which.
+export const toolCallLabel = (toolName: string, args: unknown) => {
+  if (isMemoryUpdateCall(toolName, args)) return "Update Memory";
+  if (isMemoryReadCall(toolName, args)) return "Read Memory";
+  const skill = skillReadName(toolName, args);
+  if (skill !== undefined) return skill ? `Use Skill: ${skill}` : "Use Skill";
+  const pages = docsReadPages(toolName, args);
+  if (pages !== undefined) return pages.length ? `Read Docs: ${pages.join(", ")}` : "Read Docs";
+  return toolLabel(toolName);
+};
 
 function ToolFallbackDuration() {
   const elapsedMs = useToolCallElapsed();
@@ -156,13 +170,7 @@ function ToolFallbackError({ status }: { status?: ToolCallMessagePartStatus }) {
 
 const ToolFallbackImpl: ToolCallMessagePartComponent = ({ toolName, args, argsText, result, isError, status }) => {
   const isCancelled = status?.type === "incomplete" && status.reason === "cancelled";
-  // Memory access rides on the generic file tools; only the step label is
-  // specialized so the user can see when memory is touched.
-  const label = isMemoryUpdateCall(toolName, args)
-    ? "Update Memory"
-    : isMemoryReadCall(toolName, args)
-      ? "Read Memory"
-      : toolLabel(toolName);
+  const label = toolCallLabel(toolName, args);
 
   const [open, setOpen] = useState(false);
 

--- a/packages/desktop/src/renderer/lib/__tests__/skill-docs-tool.test.ts
+++ b/packages/desktop/src/renderer/lib/__tests__/skill-docs-tool.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import { docsReadPages, skillReadName } from "../skill-docs-tool";
+
+describe("skillReadName()", () => {
+  it("should return the skill folder name for a read of its SKILL.md", () => {
+    expect(skillReadName("read", { path: "/ws/plugins/budget-pro/skills/subscription-audit/SKILL.md" })).toBe(
+      "subscription-audit",
+    );
+  });
+
+  it("should return the folder name for a relative path", () => {
+    expect(skillReadName("read", { path: "skills/recurring-spending/SKILL.md" })).toBe("recurring-spending");
+  });
+
+  it("should return the folder name for a backslash path", () => {
+    expect(skillReadName("read", { path: "C:\\ws\\skills\\recurring-spending\\SKILL.md" })).toBe("recurring-spending");
+  });
+
+  it("should return an empty name for a bare SKILL.md with no folder", () => {
+    expect(skillReadName("read", { path: "SKILL.md" })).toBe("");
+  });
+
+  it("should accept the legacy file_path argument name", () => {
+    expect(skillReadName("read", { file_path: "/ws/skills/pdf/SKILL.md" })).toBe("pdf");
+  });
+
+  it("should return undefined for reads of other files", () => {
+    expect(skillReadName("read", { path: "ledger/main.journal" })).toBeUndefined();
+    expect(skillReadName("read", { path: "memory.md" })).toBeUndefined();
+  });
+
+  it("should return undefined for a file whose name merely ends in SKILL.md", () => {
+    expect(skillReadName("read", { path: "skills/pdf/OLD-SKILL.md" })).toBeUndefined();
+  });
+
+  it("should return undefined for a skill's supporting files", () => {
+    expect(skillReadName("read", { path: "skills/pdf/reference.md" })).toBeUndefined();
+  });
+
+  it("should return undefined for non-read tools even when the path matches", () => {
+    expect(skillReadName("edit", { path: "skills/pdf/SKILL.md" })).toBeUndefined();
+    expect(skillReadName("write", { path: "skills/pdf/SKILL.md" })).toBeUndefined();
+    expect(skillReadName("bash", { command: "cat skills/pdf/SKILL.md" })).toBeUndefined();
+  });
+
+  it("should return undefined while args are missing or partial (streaming)", () => {
+    expect(skillReadName("read", undefined)).toBeUndefined();
+    expect(skillReadName("read", null)).toBeUndefined();
+    expect(skillReadName("read", {})).toBeUndefined();
+    expect(skillReadName("read", { path: 42 })).toBeUndefined();
+  });
+});
+
+describe("docsReadPages()", () => {
+  describe("read tool", () => {
+    it("should return the page name for a page under the packaged macOS docs dir", () => {
+      expect(
+        docsReadPages("read", { path: "/Applications/Accountant24.app/Contents/Resources/docs/settings.md" }),
+      ).toEqual(["settings"]);
+    });
+
+    it("should return the page name for a page under the dev docs dir", () => {
+      expect(docsReadPages("read", { path: "/repo/packages/desktop/resources/docs/contents.md" })).toEqual([
+        "contents",
+      ]);
+    });
+
+    it("should return the page name for a backslash path under the docs dir", () => {
+      expect(docsReadPages("read", { path: "C:\\Accountant24\\resources\\docs\\faq.md" })).toEqual(["faq"]);
+    });
+
+    it("should keep a multi-word page name intact", () => {
+      expect(docsReadPages("read", { path: "/app/resources/docs/create-a-plugin.md" })).toEqual(["create-a-plugin"]);
+    });
+
+    it("should keep a file name without the .md extension as is", () => {
+      expect(docsReadPages("read", { path: "/app/resources/docs/README" })).toEqual(["README"]);
+    });
+
+    it("should accept the legacy file_path argument name", () => {
+      expect(docsReadPages("read", { file_path: "/app/resources/docs/faq.md" })).toEqual(["faq"]);
+    });
+
+    it("should return undefined for a skill inside the app resources", () => {
+      expect(
+        docsReadPages("read", { path: "/app/resources/plugins/accountant24/skills/docs/SKILL.md" }),
+      ).toBeUndefined();
+    });
+
+    it("should return undefined for a docs folder outside the app resources", () => {
+      expect(docsReadPages("read", { path: "/ws/docs/notes.md" })).toBeUndefined();
+    });
+
+    it("should return undefined for the docs dir itself with no page", () => {
+      expect(docsReadPages("read", { path: "/app/resources/docs" })).toBeUndefined();
+      expect(docsReadPages("read", { path: "/app/resources/docs/" })).toBeUndefined();
+    });
+
+    it("should return undefined while args are missing or partial (streaming)", () => {
+      expect(docsReadPages("read", undefined)).toBeUndefined();
+      expect(docsReadPages("read", {})).toBeUndefined();
+      expect(docsReadPages("read", { path: 42 })).toBeUndefined();
+    });
+  });
+
+  describe("bash tool", () => {
+    it("should return the page name for a cat of a quoted page via $ACCOUNTANT24_DOCS", () => {
+      expect(docsReadPages("bash", { command: 'cat "$ACCOUNTANT24_DOCS/settings.md"' })).toEqual(["settings"]);
+    });
+
+    it("should return the page name when the env var is referenced with braces", () => {
+      // Assembled so the shell's `${…}` is not read as a template placeholder.
+      const command = ["cat $", "{ACCOUNTANT24_DOCS}/contents.md"].join("");
+      expect(docsReadPages("bash", { command })).toEqual(["contents"]);
+    });
+
+    it("should return the page name for a compound command that also echoes the dir", () => {
+      expect(docsReadPages("bash", { command: "echo $ACCOUNTANT24_DOCS; cat $ACCOUNTANT24_DOCS/contents.md" })).toEqual(
+        ["contents"],
+      );
+    });
+
+    it("should return every distinct page when a command reads several", () => {
+      expect(
+        docsReadPages("bash", {
+          command: "cat $ACCOUNTANT24_DOCS/contents.md $ACCOUNTANT24_DOCS/settings.md $ACCOUNTANT24_DOCS/contents.md",
+        }),
+      ).toEqual(["contents", "settings"]);
+    });
+
+    it("should stop the page name at a pipe", () => {
+      expect(docsReadPages("bash", { command: "cat $ACCOUNTANT24_DOCS/faq.md|head -20" })).toEqual(["faq"]);
+    });
+
+    it("should return an empty list when the docs dir is touched without a page", () => {
+      expect(docsReadPages("bash", { command: "echo $ACCOUNTANT24_DOCS" })).toEqual([]);
+      expect(docsReadPages("bash", { command: 'ls "$ACCOUNTANT24_DOCS"' })).toEqual([]);
+    });
+
+    it("should return undefined when the env var is only mentioned by name", () => {
+      expect(docsReadPages("bash", { command: "env | grep ACCOUNTANT24_DOCS" })).toBeUndefined();
+    });
+
+    it("should return undefined for a different env var with the same prefix", () => {
+      expect(docsReadPages("bash", { command: "echo $ACCOUNTANT24_DOCS_EXTRA" })).toBeUndefined();
+      expect(docsReadPages("bash", { command: "echo $ACCOUNTANT24_WORKSPACE" })).toBeUndefined();
+    });
+
+    it("should return undefined for unrelated commands", () => {
+      expect(docsReadPages("bash", { command: "hledger bal" })).toBeUndefined();
+    });
+
+    it("should return undefined while args are missing or partial (streaming)", () => {
+      expect(docsReadPages("bash", undefined)).toBeUndefined();
+      expect(docsReadPages("bash", {})).toBeUndefined();
+      expect(docsReadPages("bash", { command: 42 })).toBeUndefined();
+    });
+  });
+
+  it("should return undefined for other tools even when the target matches", () => {
+    expect(docsReadPages("edit", { path: "/app/resources/docs/faq.md" })).toBeUndefined();
+    expect(docsReadPages("query", { command: "cat $ACCOUNTANT24_DOCS/faq.md" })).toBeUndefined();
+  });
+});

--- a/packages/desktop/src/renderer/lib/skill-docs-tool.ts
+++ b/packages/desktop/src/renderer/lib/skill-docs-tool.ts
@@ -1,0 +1,48 @@
+// Skills and the app's bundled documentation are read with pi's generic tools:
+// a skill activates by reading its SKILL.md, and the documentation is reached
+// through the ACCOUNTANT24_DOCS env var (a bash `cat "$ACCOUNTANT24_DOCS/<page>.md"`,
+// or a read of the resolved path under the app's resources/docs). The renderer
+// has no paths of its own, so both are recognized from the call's target alone,
+// like memory (memory-tool.ts). A miss is cosmetic (the call keeps its generic
+// Read File / Run Command label), never broken.
+function pathArg(args: unknown): string | undefined {
+  const { path, file_path } = (args ?? {}) as { path?: unknown; file_path?: unknown };
+  const raw = path ?? file_path;
+  return typeof raw === "string" ? raw : undefined;
+}
+
+/** The skill folder name when the call reads a skill's SKILL.md, else undefined. */
+export function skillReadName(toolName: string, args: unknown): string | undefined {
+  if (toolName !== "read") return undefined;
+  const segments = pathArg(args)?.split(/[\\/]/) ?? [];
+  if (segments.at(-1) !== "SKILL.md") return undefined;
+  return segments.at(-2) ?? "";
+}
+
+// Dev: packages/desktop/resources/docs; packaged: <app>/Contents/Resources/docs
+// on macOS, <app>/resources/docs elsewhere.
+const DOCS_DIR_SEGMENT = /\/resources\/docs\/([^/]+)$/i;
+const DOCS_ENV_REFERENCE = /\$\{?ACCOUNTANT24_DOCS\b\}?/;
+// Every page path spelled after the env var in a shell command; a page name
+// ends at whitespace or shell punctuation.
+const DOCS_ENV_PAGE = /\$\{?ACCOUNTANT24_DOCS\}?\/([^\s"'`;|&)<>]+)/g;
+
+/** The documentation page name from a file name: `settings.md` → `settings`. */
+const pageName = (file: string) => file.replace(/\.md$/i, "");
+
+/** The documentation pages a call reads, as bare page names (`settings`), when
+ *  the call targets the bundled docs; undefined when it does not. Empty when
+ *  the docs are touched without a page (`echo $ACCOUNTANT24_DOCS`). */
+export function docsReadPages(toolName: string, args: unknown): string[] | undefined {
+  if (toolName === "read") {
+    const match = pathArg(args)?.replace(/\\/g, "/").match(DOCS_DIR_SEGMENT);
+    return match ? [pageName(match[1])] : undefined;
+  }
+  if (toolName === "bash") {
+    const { command } = (args ?? {}) as { command?: unknown };
+    if (typeof command !== "string" || !DOCS_ENV_REFERENCE.test(command)) return undefined;
+    const pages = [...command.matchAll(DOCS_ENV_PAGE)].map((m) => pageName(m[1].split("/").at(-1) ?? ""));
+    return [...new Set(pages)];
+  }
+  return undefined;
+}

--- a/packages/desktop/src/renderer/runtime/electronPiClient.ts
+++ b/packages/desktop/src/renderer/runtime/electronPiClient.ts
@@ -41,6 +41,7 @@ import { parseModelId } from "../lib/enabledModels";
 import { isMemoryUpdateCall } from "../lib/memory-tool";
 import { mentionsToPlainText } from "../lib/mentions";
 import { isOfficial } from "../lib/pluginRepo";
+import { skillReadName } from "../lib/skill-docs-tool";
 import { collapseSkillText, hoistSkillDirective } from "../lib/skillBlock";
 import { agentApi, authApi, pluginsApi, sessionsApi, settingsApi } from "../rpc/api";
 import type { AgentEvent, ModelInfo, SessionSummary } from "../rpc/types";
@@ -166,14 +167,12 @@ export function createElectronPiClient(): PiClient {
       trackAgentToolUsed(isMemoryUpdate ? "update_memory" : e.toolName, Boolean(e.isError));
       if (e.toolName === "add_transactions" && !e.isError) trackTransactionFirstAdded();
     }
-    if (e.type === "tool_execution_start" && e.toolName === "read") {
+    if (e.type === "tool_execution_start") {
       // The model activates a skill by reading its SKILL.md (pi's lazy-loading
       // contract) — that read IS the auto usage signal. The path is inspected
       // here only; it never leaves the machine.
-      const args = e.args as { path?: unknown; file_path?: unknown } | undefined;
-      const raw = args?.path ?? args?.file_path;
-      const segments = typeof raw === "string" ? raw.split(/[\\/]/) : [];
-      if (segments.at(-1) === "SKILL.md") trackSkillByName(segments.at(-2) ?? "", "auto");
+      const skill = skillReadName(e.toolName, e.args);
+      if (skill !== undefined) trackSkillByName(skill, "auto");
     }
     if (e.type === "agent_end") trackAgentMessageSent();
     if (e.type === "agent_start") running.add(e.sessionPath);


### PR DESCRIPTION
- Label a `SKILL.md` read as `Use Skill: <skill>` instead of `Read File`
- Label a read of a bundled docs page as `Read Docs: <page>`, via `Read File` or a `$ACCOUNTANT24_DOCS` command
- Add `skillReadName()` and `docsReadPages()` in `lib/skill-docs-tool.ts`
- Reuse `skillReadName()` for the skill usage analytics