### PR TITLE
feat: show the plugin name in the Use Skill step of the chat

### DIFF
--- a/packages/desktop/src/renderer/components/accountant24/__tests__/tool-fallback.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/tool-fallback.test.tsx
@@ -278,10 +278,14 @@ describe("toolCallLabel()", () => {
     expect(toolCallLabel("read", { path: "/ws/memory.md" })).toBe("Read Memory");
   });
 
-  it("should name the skill for a read of its SKILL.md", () => {
-    expect(toolCallLabel("read", { path: "/ws/plugins/accountant24-skills/skills/docs/SKILL.md" })).toBe(
-      "Use Skill: docs",
+  it("should name the skill as plugin:skill for a read of a plugin's SKILL.md", () => {
+    expect(toolCallLabel("read", { path: "/ws/plugins/accountant24-skills/skills/recurring-spending/SKILL.md" })).toBe(
+      "Use Skill: accountant24-skills:recurring-spending",
     );
+  });
+
+  it("should name the skill by its folder for a SKILL.md outside a plugin", () => {
+    expect(toolCallLabel("read", { path: "/ws/skills/pdf/SKILL.md" })).toBe("Use Skill: pdf");
   });
 
   it("should return a bare 'Use Skill' for a SKILL.md with no folder", () => {
@@ -327,10 +331,22 @@ describe("toolCallLabel()", () => {
 });
 
 describe("ToolFallback skill and documentation reads", () => {
-  it("should label a read call on a SKILL.md with the skill name", () => {
-    render(<ToolFallback {...partProps({ toolName: "read", args: { path: "/ws/skills/pdf/SKILL.md" } })} />);
-    expect(screen.getByText("Use Skill: pdf")).toBeTruthy();
+  it("should label a read of a plugin's SKILL.md with the plugin:skill name", () => {
+    render(
+      <ToolFallback
+        {...partProps({
+          toolName: "read",
+          args: { path: "/ws/plugins/accountant24-skills/skills/recurring-spending/SKILL.md" },
+        })}
+      />,
+    );
+    expect(screen.getByText("Use Skill: accountant24-skills:recurring-spending")).toBeTruthy();
     expect(screen.queryByText("Read File")).toBeNull();
+  });
+
+  it("should label a SKILL.md with no folder as a bare 'Use Skill'", () => {
+    render(<ToolFallback {...partProps({ toolName: "read", args: { path: "SKILL.md" } })} />);
+    expect(screen.getByText("Use Skill")).toBeTruthy();
   });
 
   it("should label a read call on a bundled documentation page with the page name", () => {
@@ -363,17 +379,17 @@ describe("ToolFallback skill and documentation reads", () => {
       <ToolFallback
         {...partProps({
           toolName: "read",
-          args: { path: "/ws/skills/pdf/SKILL.md" },
-          argsText: '{"path":"/ws/skills/pdf/SKILL.md"}',
+          args: { path: "/ws/plugins/tools/skills/pdf/SKILL.md" },
+          argsText: '{"path":"/ws/plugins/tools/skills/pdf/SKILL.md"}',
           result: "---\nname: pdf\n---",
         })}
       />,
     );
-    fireEvent.click(screen.getByText("Use Skill: pdf"));
+    fireEvent.click(screen.getByText("Use Skill: tools:pdf"));
     expect(screen.getByText("Input:")).toBeTruthy();
     expect(screen.getByText("Output:")).toBeTruthy();
     const args = document.querySelector("[data-slot=tool-fallback-args] pre");
-    expect(args?.textContent).toBe(`{\n  "path": "/ws/skills/pdf/SKILL.md"\n}`);
+    expect(args?.textContent).toBe(`{\n  "path": "/ws/plugins/tools/skills/pdf/SKILL.md"\n}`);
   });
 });
 

--- a/packages/desktop/src/renderer/components/accountant24/tool-fallback.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/tool-fallback.tsx
@@ -18,7 +18,7 @@ import {
 import { Spinner } from "@/components/shadcn/spinner";
 import { formatDuration } from "@/lib/duration";
 import { isMemoryReadCall, isMemoryUpdateCall } from "@/lib/memory-tool";
-import { docsReadPages, skillReadName } from "@/lib/skill-docs-tool";
+import { docsReadPages, skillReadQualifiedName } from "@/lib/skill-docs-tool";
 import { TOOL_LABELS } from "@/lib/tool-labels";
 import { cn } from "@/lib/utils";
 
@@ -37,11 +37,12 @@ export const toolLabel = (toolName: string) => TOOL_LABELS[toolName] ?? toolName
 
 // Memory, skills and the bundled documentation ride on the generic file/shell
 // tools; only the step label is specialized so the user can see what is
-// touched, naming the skill or page when the call says which.
+// touched, naming the skill (as `plugin:skill`, the name the composer uses for
+// a pick) or the page when the call says which.
 export const toolCallLabel = (toolName: string, args: unknown) => {
   if (isMemoryUpdateCall(toolName, args)) return "Update Memory";
   if (isMemoryReadCall(toolName, args)) return "Read Memory";
-  const skill = skillReadName(toolName, args);
+  const skill = skillReadQualifiedName(toolName, args);
   if (skill !== undefined) return skill ? `Use Skill: ${skill}` : "Use Skill";
   const pages = docsReadPages(toolName, args);
   if (pages !== undefined) return pages.length ? `Read Docs: ${pages.join(", ")}` : "Read Docs";

--- a/packages/desktop/src/renderer/lib/__tests__/skill-docs-tool.test.ts
+++ b/packages/desktop/src/renderer/lib/__tests__/skill-docs-tool.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { docsReadPages, skillReadName } from "../skill-docs-tool";
+import { docsReadPages, skillReadName, skillReadQualifiedName } from "../skill-docs-tool";
 
 describe("skillReadName()", () => {
   it("should return the skill folder name for a read of its SKILL.md", () => {
@@ -48,6 +48,56 @@ describe("skillReadName()", () => {
     expect(skillReadName("read", null)).toBeUndefined();
     expect(skillReadName("read", {})).toBeUndefined();
     expect(skillReadName("read", { path: 42 })).toBeUndefined();
+  });
+});
+
+describe("skillReadQualifiedName()", () => {
+  it("should return plugin:skill for a SKILL.md inside a plugin's skills folder", () => {
+    expect(
+      skillReadQualifiedName("read", { path: "/ws/plugins/accountant24-skills/skills/recurring-spending/SKILL.md" }),
+    ).toBe("accountant24-skills:recurring-spending");
+  });
+
+  it("should return plugin:skill for a relative plugin path", () => {
+    expect(skillReadQualifiedName("read", { path: "plugins/budget-pro/skills/subscription-audit/SKILL.md" })).toBe(
+      "budget-pro:subscription-audit",
+    );
+  });
+
+  it("should return plugin:skill for a backslash plugin path", () => {
+    expect(skillReadQualifiedName("read", { path: "C:\\ws\\plugins\\health\\skills\\nutrition\\SKILL.md" })).toBe(
+      "health:nutrition",
+    );
+  });
+
+  it("should return the bare folder name for a SKILL.md outside a plugin", () => {
+    expect(skillReadQualifiedName("read", { path: "/ws/skills/pdf/SKILL.md" })).toBe("pdf");
+    expect(skillReadQualifiedName("read", { path: "skills/pdf/SKILL.md" })).toBe("pdf");
+  });
+
+  it("should return the bare folder name when the layout only resembles a plugin", () => {
+    expect(skillReadQualifiedName("read", { path: "/ws/plugins/budget-pro/pdf/SKILL.md" })).toBe("pdf");
+    expect(skillReadQualifiedName("read", { path: "/ws/skills/pdf/SKILL.md" })).toBe("pdf");
+  });
+
+  it("should return an empty name for a bare SKILL.md with no folder", () => {
+    expect(skillReadQualifiedName("read", { path: "SKILL.md" })).toBe("");
+  });
+
+  it("should accept the legacy file_path argument name", () => {
+    expect(skillReadQualifiedName("read", { file_path: "/ws/plugins/health/skills/nutrition/SKILL.md" })).toBe(
+      "health:nutrition",
+    );
+  });
+
+  it("should return undefined for reads of other files and for non-read tools", () => {
+    expect(skillReadQualifiedName("read", { path: "plugins/health/skills/nutrition/README.md" })).toBeUndefined();
+    expect(skillReadQualifiedName("edit", { path: "plugins/health/skills/nutrition/SKILL.md" })).toBeUndefined();
+  });
+
+  it("should return undefined while args are missing or partial (streaming)", () => {
+    expect(skillReadQualifiedName("read", undefined)).toBeUndefined();
+    expect(skillReadQualifiedName("read", {})).toBeUndefined();
   });
 });
 

--- a/packages/desktop/src/renderer/lib/skill-docs-tool.ts
+++ b/packages/desktop/src/renderer/lib/skill-docs-tool.ts
@@ -11,11 +11,28 @@ function pathArg(args: unknown): string | undefined {
   return typeof raw === "string" ? raw : undefined;
 }
 
-/** The skill folder name when the call reads a skill's SKILL.md, else undefined. */
-export function skillReadName(toolName: string, args: unknown): string | undefined {
+/** The path segments of a SKILL.md the call reads, else undefined. */
+function skillReadSegments(toolName: string, args: unknown): string[] | undefined {
   if (toolName !== "read") return undefined;
   const segments = pathArg(args)?.split(/[\\/]/) ?? [];
-  if (segments.at(-1) !== "SKILL.md") return undefined;
+  return segments.at(-1) === "SKILL.md" ? segments : undefined;
+}
+
+/** The skill folder name when the call reads a skill's SKILL.md, else undefined. */
+export function skillReadName(toolName: string, args: unknown): string | undefined {
+  const segments = skillReadSegments(toolName, args);
+  return segments && (segments.at(-2) ?? "");
+}
+
+/** The skill's `<plugin>:<skill>` name when the call reads a SKILL.md inside a
+ *  plugin (`plugins/<plugin>/skills/<skill>/SKILL.md`, the plugin folder being
+ *  the plugin's name), the bare folder name for a SKILL.md anywhere else, and
+ *  undefined when the call is not a skill read. */
+export function skillReadQualifiedName(toolName: string, args: unknown): string | undefined {
+  const segments = skillReadSegments(toolName, args);
+  if (!segments) return undefined;
+  const [plugins, plugin, skills, skill] = segments.slice(-5, -1);
+  if (plugins === "plugins" && plugin && skills === "skills" && skill) return `${plugin}:${skill}`;
   return segments.at(-2) ?? "";
 }
 


### PR DESCRIPTION
- Label a plugin's `SKILL.md` read as `Use Skill: <plugin>:<skill>`
- Add `skillReadQualifiedName()` in `lib/skill-docs-tool.ts`