### PR TITLE
feat: label docs reads in the chat as Read Documentation

### DIFF
--- a/packages/desktop/src/renderer/components/accountant24/__tests__/tool-fallback.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/tool-fallback.test.tsx
@@ -292,24 +292,14 @@ describe("toolCallLabel()", () => {
     expect(toolCallLabel("read", { path: "SKILL.md" })).toBe("Use Skill");
   });
 
-  it("should name the page for a read of a bundled documentation page", () => {
+  it("should return 'Read Documentation' for a read of a bundled documentation file", () => {
     expect(toolCallLabel("read", { path: "/Applications/Accountant24.app/Contents/Resources/docs/settings.md" })).toBe(
-      "Read Docs: settings",
+      "Read Documentation",
     );
   });
 
-  it("should name the page for a command reading it via $ACCOUNTANT24_DOCS", () => {
-    expect(toolCallLabel("bash", { command: 'cat "$ACCOUNTANT24_DOCS/settings.md"' })).toBe("Read Docs: settings");
-  });
-
-  it("should list every page for a command reading several", () => {
-    expect(toolCallLabel("bash", { command: "cat $ACCOUNTANT24_DOCS/contents.md $ACCOUNTANT24_DOCS/faq.md" })).toBe(
-      "Read Docs: contents, faq",
-    );
-  });
-
-  it("should return a bare 'Read Docs' for a command touching the docs dir without a page", () => {
-    expect(toolCallLabel("bash", { command: "echo $ACCOUNTANT24_DOCS" })).toBe("Read Docs");
+  it("should return 'Read Documentation' for a command reading the docs via $ACCOUNTANT24_DOCS", () => {
+    expect(toolCallLabel("bash", { command: 'cat "$ACCOUNTANT24_DOCS/settings.md"' })).toBe("Read Documentation");
   });
 
   it("should return the plain tool label for any other file read", () => {
@@ -349,13 +339,13 @@ describe("ToolFallback skill and documentation reads", () => {
     expect(screen.getByText("Use Skill")).toBeTruthy();
   });
 
-  it("should label a read call on a bundled documentation page with the page name", () => {
+  it("should label a read call on a bundled documentation file as 'Read Documentation'", () => {
     render(<ToolFallback {...partProps({ toolName: "read", args: { path: "/app/resources/docs/faq.md" } })} />);
-    expect(screen.getByText("Read Docs: faq")).toBeTruthy();
+    expect(screen.getByText("Read Documentation")).toBeTruthy();
     expect(screen.queryByText("Read File")).toBeNull();
   });
 
-  it("should label a command reading the bundled documentation with the page name", () => {
+  it("should label a command reading the bundled documentation as 'Read Documentation'", () => {
     render(
       <ToolFallback
         {...partProps({
@@ -364,14 +354,14 @@ describe("ToolFallback skill and documentation reads", () => {
         })}
       />,
     );
-    expect(screen.getByText("Read Docs: contents")).toBeTruthy();
+    expect(screen.getByText("Read Documentation")).toBeTruthy();
     expect(screen.queryByText("Run Command")).toBeNull();
   });
 
   it("should keep the plain command label for other commands", () => {
     render(<ToolFallback {...partProps({ toolName: "bash", args: { command: "hledger bal" } })} />);
     expect(screen.getByText("Run Command")).toBeTruthy();
-    expect(screen.queryByText(/Read Docs/)).toBeNull();
+    expect(screen.queryByText("Read Documentation")).toBeNull();
   });
 
   it("should show the standard input and output like any other tool", () => {

--- a/packages/desktop/src/renderer/components/accountant24/tool-fallback.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/tool-fallback.tsx
@@ -18,7 +18,7 @@ import {
 import { Spinner } from "@/components/shadcn/spinner";
 import { formatDuration } from "@/lib/duration";
 import { isMemoryReadCall, isMemoryUpdateCall } from "@/lib/memory-tool";
-import { docsReadPages, skillReadQualifiedName } from "@/lib/skill-docs-tool";
+import { isDocsReadCall, skillReadQualifiedName } from "@/lib/skill-docs-tool";
 import { TOOL_LABELS } from "@/lib/tool-labels";
 import { cn } from "@/lib/utils";
 
@@ -38,14 +38,13 @@ export const toolLabel = (toolName: string) => TOOL_LABELS[toolName] ?? toolName
 // Memory, skills and the bundled documentation ride on the generic file/shell
 // tools; only the step label is specialized so the user can see what is
 // touched, naming the skill (as `plugin:skill`, the name the composer uses for
-// a pick) or the page when the call says which.
+// a pick) when the call says which.
 export const toolCallLabel = (toolName: string, args: unknown) => {
   if (isMemoryUpdateCall(toolName, args)) return "Update Memory";
   if (isMemoryReadCall(toolName, args)) return "Read Memory";
   const skill = skillReadQualifiedName(toolName, args);
   if (skill !== undefined) return skill ? `Use Skill: ${skill}` : "Use Skill";
-  const pages = docsReadPages(toolName, args);
-  if (pages !== undefined) return pages.length ? `Read Docs: ${pages.join(", ")}` : "Read Docs";
+  if (isDocsReadCall(toolName, args)) return "Read Documentation";
   return toolLabel(toolName);
 };
 

--- a/packages/desktop/src/renderer/lib/__tests__/skill-docs-tool.test.ts
+++ b/packages/desktop/src/renderer/lib/__tests__/skill-docs-tool.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { docsReadPages, skillReadName, skillReadQualifiedName } from "../skill-docs-tool";
+import { isDocsReadCall, skillReadName, skillReadQualifiedName } from "../skill-docs-tool";
 
 describe("skillReadName()", () => {
   it("should return the skill folder name for a read of its SKILL.md", () => {
@@ -101,114 +101,83 @@ describe("skillReadQualifiedName()", () => {
   });
 });
 
-describe("docsReadPages()", () => {
+describe("isDocsReadCall()", () => {
   describe("read tool", () => {
-    it("should return the page name for a page under the packaged macOS docs dir", () => {
+    it("should return true for a file under the packaged macOS docs dir", () => {
       expect(
-        docsReadPages("read", { path: "/Applications/Accountant24.app/Contents/Resources/docs/settings.md" }),
-      ).toEqual(["settings"]);
+        isDocsReadCall("read", { path: "/Applications/Accountant24.app/Contents/Resources/docs/settings.md" }),
+      ).toBe(true);
     });
 
-    it("should return the page name for a page under the dev docs dir", () => {
-      expect(docsReadPages("read", { path: "/repo/packages/desktop/resources/docs/contents.md" })).toEqual([
-        "contents",
-      ]);
+    it("should return true for a file under the dev docs dir", () => {
+      expect(isDocsReadCall("read", { path: "/repo/packages/desktop/resources/docs/contents.md" })).toBe(true);
     });
 
-    it("should return the page name for a backslash path under the docs dir", () => {
-      expect(docsReadPages("read", { path: "C:\\Accountant24\\resources\\docs\\faq.md" })).toEqual(["faq"]);
-    });
-
-    it("should keep a multi-word page name intact", () => {
-      expect(docsReadPages("read", { path: "/app/resources/docs/create-a-plugin.md" })).toEqual(["create-a-plugin"]);
-    });
-
-    it("should keep a file name without the .md extension as is", () => {
-      expect(docsReadPages("read", { path: "/app/resources/docs/README" })).toEqual(["README"]);
+    it("should return true for a backslash path under the docs dir", () => {
+      expect(isDocsReadCall("read", { path: "C:\\Accountant24\\resources\\docs\\faq.md" })).toBe(true);
     });
 
     it("should accept the legacy file_path argument name", () => {
-      expect(docsReadPages("read", { file_path: "/app/resources/docs/faq.md" })).toEqual(["faq"]);
+      expect(isDocsReadCall("read", { file_path: "/app/resources/docs/faq.md" })).toBe(true);
     });
 
-    it("should return undefined for a skill inside the app resources", () => {
-      expect(
-        docsReadPages("read", { path: "/app/resources/plugins/accountant24/skills/docs/SKILL.md" }),
-      ).toBeUndefined();
+    it("should return false for a skill inside the app resources", () => {
+      expect(isDocsReadCall("read", { path: "/app/resources/plugins/accountant24/skills/docs/SKILL.md" })).toBe(false);
     });
 
-    it("should return undefined for a docs folder outside the app resources", () => {
-      expect(docsReadPages("read", { path: "/ws/docs/notes.md" })).toBeUndefined();
+    it("should return false for a docs folder outside the app resources", () => {
+      expect(isDocsReadCall("read", { path: "/ws/docs/notes.md" })).toBe(false);
     });
 
-    it("should return undefined for the docs dir itself with no page", () => {
-      expect(docsReadPages("read", { path: "/app/resources/docs" })).toBeUndefined();
-      expect(docsReadPages("read", { path: "/app/resources/docs/" })).toBeUndefined();
+    it("should return false for the docs dir itself with no file", () => {
+      expect(isDocsReadCall("read", { path: "/app/resources/docs" })).toBe(false);
+      expect(isDocsReadCall("read", { path: "/app/resources/docs/" })).toBe(false);
     });
 
-    it("should return undefined while args are missing or partial (streaming)", () => {
-      expect(docsReadPages("read", undefined)).toBeUndefined();
-      expect(docsReadPages("read", {})).toBeUndefined();
-      expect(docsReadPages("read", { path: 42 })).toBeUndefined();
+    it("should return false while args are missing or partial (streaming)", () => {
+      expect(isDocsReadCall("read", undefined)).toBe(false);
+      expect(isDocsReadCall("read", {})).toBe(false);
+      expect(isDocsReadCall("read", { path: 42 })).toBe(false);
     });
   });
 
   describe("bash tool", () => {
-    it("should return the page name for a cat of a quoted page via $ACCOUNTANT24_DOCS", () => {
-      expect(docsReadPages("bash", { command: 'cat "$ACCOUNTANT24_DOCS/settings.md"' })).toEqual(["settings"]);
+    it("should return true for a cat of a file via $ACCOUNTANT24_DOCS", () => {
+      expect(isDocsReadCall("bash", { command: 'cat "$ACCOUNTANT24_DOCS/settings.md"' })).toBe(true);
     });
 
-    it("should return the page name when the env var is referenced with braces", () => {
+    it("should return true when the env var is referenced with braces", () => {
       // Assembled so the shell's `${…}` is not read as a template placeholder.
       const command = ["cat $", "{ACCOUNTANT24_DOCS}/contents.md"].join("");
-      expect(docsReadPages("bash", { command })).toEqual(["contents"]);
+      expect(isDocsReadCall("bash", { command })).toBe(true);
     });
 
-    it("should return the page name for a compound command that also echoes the dir", () => {
-      expect(docsReadPages("bash", { command: "echo $ACCOUNTANT24_DOCS; cat $ACCOUNTANT24_DOCS/contents.md" })).toEqual(
-        ["contents"],
-      );
+    it("should return true for a command that only echoes or lists the docs dir", () => {
+      expect(isDocsReadCall("bash", { command: "echo $ACCOUNTANT24_DOCS; ls $ACCOUNTANT24_DOCS" })).toBe(true);
     });
 
-    it("should return every distinct page when a command reads several", () => {
-      expect(
-        docsReadPages("bash", {
-          command: "cat $ACCOUNTANT24_DOCS/contents.md $ACCOUNTANT24_DOCS/settings.md $ACCOUNTANT24_DOCS/contents.md",
-        }),
-      ).toEqual(["contents", "settings"]);
+    it("should return false when the env var is only mentioned by name", () => {
+      expect(isDocsReadCall("bash", { command: "env | grep ACCOUNTANT24_DOCS" })).toBe(false);
     });
 
-    it("should stop the page name at a pipe", () => {
-      expect(docsReadPages("bash", { command: "cat $ACCOUNTANT24_DOCS/faq.md|head -20" })).toEqual(["faq"]);
+    it("should return false for a different env var with the same prefix", () => {
+      expect(isDocsReadCall("bash", { command: "echo $ACCOUNTANT24_DOCS_EXTRA" })).toBe(false);
+      expect(isDocsReadCall("bash", { command: "echo $ACCOUNTANT24_WORKSPACE" })).toBe(false);
     });
 
-    it("should return an empty list when the docs dir is touched without a page", () => {
-      expect(docsReadPages("bash", { command: "echo $ACCOUNTANT24_DOCS" })).toEqual([]);
-      expect(docsReadPages("bash", { command: 'ls "$ACCOUNTANT24_DOCS"' })).toEqual([]);
+    it("should return false for unrelated commands", () => {
+      expect(isDocsReadCall("bash", { command: "hledger bal" })).toBe(false);
     });
 
-    it("should return undefined when the env var is only mentioned by name", () => {
-      expect(docsReadPages("bash", { command: "env | grep ACCOUNTANT24_DOCS" })).toBeUndefined();
-    });
-
-    it("should return undefined for a different env var with the same prefix", () => {
-      expect(docsReadPages("bash", { command: "echo $ACCOUNTANT24_DOCS_EXTRA" })).toBeUndefined();
-      expect(docsReadPages("bash", { command: "echo $ACCOUNTANT24_WORKSPACE" })).toBeUndefined();
-    });
-
-    it("should return undefined for unrelated commands", () => {
-      expect(docsReadPages("bash", { command: "hledger bal" })).toBeUndefined();
-    });
-
-    it("should return undefined while args are missing or partial (streaming)", () => {
-      expect(docsReadPages("bash", undefined)).toBeUndefined();
-      expect(docsReadPages("bash", {})).toBeUndefined();
-      expect(docsReadPages("bash", { command: 42 })).toBeUndefined();
+    it("should return false while args are missing or partial (streaming)", () => {
+      expect(isDocsReadCall("bash", undefined)).toBe(false);
+      expect(isDocsReadCall("bash", {})).toBe(false);
+      expect(isDocsReadCall("bash", { command: 42 })).toBe(false);
     });
   });
 
-  it("should return undefined for other tools even when the target matches", () => {
-    expect(docsReadPages("edit", { path: "/app/resources/docs/faq.md" })).toBeUndefined();
-    expect(docsReadPages("query", { command: "cat $ACCOUNTANT24_DOCS/faq.md" })).toBeUndefined();
+  it("should return false for other tools even when the target matches", () => {
+    expect(isDocsReadCall("edit", { path: "/app/resources/docs/faq.md" })).toBe(false);
+    expect(isDocsReadCall("query", { command: "cat $ACCOUNTANT24_DOCS/faq.md" })).toBe(false);
   });
 });

--- a/packages/desktop/src/renderer/lib/skill-docs-tool.ts
+++ b/packages/desktop/src/renderer/lib/skill-docs-tool.ts
@@ -38,28 +38,19 @@ export function skillReadQualifiedName(toolName: string, args: unknown): string 
 
 // Dev: packages/desktop/resources/docs; packaged: <app>/Contents/Resources/docs
 // on macOS, <app>/resources/docs elsewhere.
-const DOCS_DIR_SEGMENT = /\/resources\/docs\/([^/]+)$/i;
+const DOCS_DIR_SEGMENT = /\/resources\/docs\/[^/]+$/i;
 const DOCS_ENV_REFERENCE = /\$\{?ACCOUNTANT24_DOCS\b\}?/;
-// Every page path spelled after the env var in a shell command; a page name
-// ends at whitespace or shell punctuation.
-const DOCS_ENV_PAGE = /\$\{?ACCOUNTANT24_DOCS\}?\/([^\s"'`;|&)<>]+)/g;
 
-/** The documentation page name from a file name: `settings.md` → `settings`. */
-const pageName = (file: string) => file.replace(/\.md$/i, "");
-
-/** The documentation pages a call reads, as bare page names (`settings`), when
- *  the call targets the bundled docs; undefined when it does not. Empty when
- *  the docs are touched without a page (`echo $ACCOUNTANT24_DOCS`). */
-export function docsReadPages(toolName: string, args: unknown): string[] | undefined {
+/** Whether the call reads the bundled documentation: a file under the docs
+ *  folder with the read tool, or a command spelling `$ACCOUNTANT24_DOCS`. */
+export function isDocsReadCall(toolName: string, args: unknown): boolean {
   if (toolName === "read") {
-    const match = pathArg(args)?.replace(/\\/g, "/").match(DOCS_DIR_SEGMENT);
-    return match ? [pageName(match[1])] : undefined;
+    const path = pathArg(args);
+    return path !== undefined && DOCS_DIR_SEGMENT.test(path.replace(/\\/g, "/"));
   }
   if (toolName === "bash") {
     const { command } = (args ?? {}) as { command?: unknown };
-    if (typeof command !== "string" || !DOCS_ENV_REFERENCE.test(command)) return undefined;
-    const pages = [...command.matchAll(DOCS_ENV_PAGE)].map((m) => pageName(m[1].split("/").at(-1) ?? ""));
-    return [...new Set(pages)];
+    return typeof command === "string" && DOCS_ENV_REFERENCE.test(command);
   }
-  return undefined;
+  return false;
 }


### PR DESCRIPTION
- Rename the `Read Docs: <page>` step to `Read Documentation`, without the page name
- Replace `docsReadPages()` with `isDocsReadCall()` in `lib/skill-docs-tool.ts`