### PR TITLE
feat: suggest prompt ideas under the composer on the New Chat page

### DIFF
--- a/packages/desktop/e2e/prompt-ideas.e2e.ts
+++ b/packages/desktop/e2e/prompt-ideas.e2e.ts
@@ -1,0 +1,50 @@
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { type LaunchedApp, launchApp } from "./helpers";
+
+// E5 — the prompt ideas on the New Chat page over the real wiring: the
+// ledger_transaction_count IPC round trip (preload allowlist included) and a
+// suggestion click landing in the composer. A stored API key makes the app
+// boot into the chat layout; the workspace scaffolds the template journal,
+// which has no transactions, so the ideas deterministically come from the
+// Getting started group. Nothing is sent, so the pi agent never spawns.
+
+let launched: LaunchedApp;
+
+test.beforeEach(async () => {
+  launched = await launchApp({
+    seed: (home) => {
+      writeFileSync(path.join(home, "auth.json"), JSON.stringify({ anthropic: { type: "api_key", key: "sk-test" } }));
+    },
+  });
+});
+
+test.afterEach(async () => {
+  await launched?.close();
+});
+
+test("shows five prompt ideas under the composer, and a click fills the composer without sending", async () => {
+  const window = await launched.app.firstWindow();
+  await window.waitForLoadState("domcontentloaded");
+
+  const input = window.getByLabel("Message input");
+  await expect(input).toBeVisible();
+
+  const ideas = window.getByRole("list", { name: "Prompt ideas" }).getByRole("button");
+  await expect(ideas).toHaveCount(5);
+
+  const first = ideas.first();
+  const prompt = (await first.textContent()) ?? "";
+  expect(prompt).not.toBe("");
+  await first.click();
+
+  await expect(input).toHaveText(prompt);
+  // Focused with the caret after the idea: typing continues the prompt.
+  await expect(input.getByRole("textbox")).toBeFocused();
+  await window.keyboard.type(" please");
+  await expect(input).toHaveText(`${prompt} please`);
+  // Filled, not sent: no user message appears and the ideas stay.
+  await expect(window.locator('[data-role="user"]')).toHaveCount(0);
+  await expect(ideas).toHaveCount(5);
+});

--- a/packages/desktop/src/main/__tests__/ledger-json.test.ts
+++ b/packages/desktop/src/main/__tests__/ledger-json.test.ts
@@ -4,6 +4,7 @@ import {
   parseAssertions,
   parseBalanceSheetJson,
   parseLatestPriceTarget,
+  parseTransactionCount,
   parseTransactionsJson,
   type RawBalanceSheet,
 } from "../ledger-json";
@@ -576,5 +577,53 @@ describe("parseLatestPriceTarget()", () => {
     expect(parseLatestPriceTarget("P 2026-07-22 UAH")).toBeNull();
     expect(parseLatestPriceTarget("P 2026-07-22 UAH 0.01958")).toBeNull();
     expect(parseLatestPriceTarget("P not-a-date UAH 1 EUR")).toBeNull();
+  });
+});
+
+describe("parseTransactionCount()", () => {
+  // A real `hledger stats` report (hledger 1.52): the count line sits among
+  // other `Txns ...` lines that must not be read instead.
+  const STATS = [
+    "Main file           : /ws/ledger/main.journal",
+    "Included files      : 2",
+    "Txns span           : 2026-01-01 to 2026-01-04 (3 days)",
+    "Last txn            : 2026-01-03 (237 days ago)",
+    "Txns                : 3 (1.0 per day)",
+    "Txns last 30 days   : 0 (0.0 per day)",
+    "Txns last 7 days    : 0 (0.0 per day)",
+    "Payees/descriptions : 3",
+    "Accounts            : 2 (depth 1)",
+    "Commodities         : 1",
+    "Market prices       : 0",
+    "Runtime stats       : 0.04 s elapsed, 76 txns/s, 0 MB live, 6 MB alloc",
+  ].join("\n");
+
+  it("should return the Txns count from a stats report", () => {
+    expect(parseTransactionCount(STATS)).toBe(3);
+  });
+
+  it("should return 0 for a journal without transactions", () => {
+    expect(parseTransactionCount("Txns span           :  to  (0 days)\nTxns                : 0 (0.0 per day)\n")).toBe(
+      0,
+    );
+  });
+
+  it("should read a large count in full", () => {
+    expect(parseTransactionCount("Txns                : 1500 (1500.0 per day)")).toBe(1500);
+  });
+
+  it("should not read the span or recent-days lines when the count line is missing", () => {
+    const withoutCount = STATS.split("\n")
+      .filter((l) => !l.startsWith("Txns                :"))
+      .join("\n");
+    expect(parseTransactionCount(withoutCount)).toBe(0);
+  });
+
+  it("should return 0 for empty output", () => {
+    expect(parseTransactionCount("")).toBe(0);
+  });
+
+  it("should return 0 for unexpected output", () => {
+    expect(parseTransactionCount("hledger: Error: file not found")).toBe(0);
   });
 });

--- a/packages/desktop/src/main/__tests__/ledger.test.ts
+++ b/packages/desktop/src/main/__tests__/ledger.test.ts
@@ -70,6 +70,7 @@ async function invoke<T>(channel: string): Promise<T> {
 const mentions = () => invoke<{ accounts: string[]; payees: string[]; tags: string[] }>("ledger_mentions");
 const netWorth = () => invoke<NetWorth>("ledger_net_worth");
 const transactions = () => invoke<LedgerTransaction[]>("ledger_transactions");
+const transactionCount = () => invoke<number>("ledger_transaction_count");
 
 beforeEach(() => {
   h.handlers.clear();
@@ -498,6 +499,64 @@ describe("ledger_transactions", () => {
     h.existsSync.mockReturnValue(false);
     stubHledger({ print: PRINT });
     await transactions();
+    expect(h.execFile.mock.calls[0]?.[0]).toBe("hledger");
+  });
+});
+
+describe("ledger_transaction_count", () => {
+  const STATS = [
+    "Main file           : /ws/ledger/main.journal",
+    "Txns span           : 2026-01-01 to 2026-03-01 (60 days)",
+    "Txns                : 12 (0.2 per day)",
+    "Txns last 30 days   : 4 (0.1 per day)",
+  ];
+
+  it("should return the transaction count parsed from hledger stats", async () => {
+    stubHledger({ stats: STATS });
+    expect(await transactionCount()).toBe(12);
+  });
+
+  it("should run one stats query with assertions ignored, against the workspace journal, in the workspace cwd, with the agent env", async () => {
+    // -I: a failed balance assertion must not blank the count — the prompt
+    // ideas keep matching the ledger's real size while it is being fixed.
+    stubHledger({ stats: STATS });
+    await transactionCount();
+
+    expect(h.execFile.mock.calls).toHaveLength(1);
+    const call = h.execFile.mock.calls[0] as unknown[];
+    expect(call[1]).toEqual(["stats", "-I", "-f", "/ws/ledger/main.journal"]);
+    const opts = call[2] as { cwd: string; env: unknown };
+    expect(opts.cwd).toBe("/ws");
+    expect(opts.env).toEqual({ PATH: "/vendored/bin", ACCOUNTANT24_WORKSPACE: "/ws" });
+  });
+
+  it("should return 0 when hledger fails (no journal yet)", async () => {
+    stubHledger({ stats: new Error("hledger: no journal") });
+    expect(await transactionCount()).toBe(0);
+  });
+
+  it("should return 0 when hledger is missing entirely", async () => {
+    const enoent = Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" });
+    stubHledger({ stats: enoent });
+    expect(await transactionCount()).toBe(0);
+  });
+
+  it("should return 0 when the stats output has no count line", async () => {
+    stubHledger({ stats: ["Main file           : /ws/ledger/main.journal"] });
+    expect(await transactionCount()).toBe(0);
+  });
+
+  it("should run the vendored hledger binary when it exists in binDir", async () => {
+    h.existsSync.mockReturnValue(true);
+    stubHledger({ stats: STATS });
+    await transactionCount();
+    expect(h.execFile.mock.calls[0]?.[0]).toBe("/vendored/bin/hledger");
+  });
+
+  it("should fall back to a PATH lookup of `hledger` when the vendored binary is absent", async () => {
+    h.existsSync.mockReturnValue(false);
+    stubHledger({ stats: STATS });
+    await transactionCount();
     expect(h.execFile.mock.calls[0]?.[0]).toBe("hledger");
   });
 });

--- a/packages/desktop/src/main/ledger-json.ts
+++ b/packages/desktop/src/main/ledger-json.ts
@@ -296,3 +296,12 @@ export function mergeValuedBalanceSheet(
   });
   return { sections, net: { amounts: raw.net, value: orRaw(raw.net, valued?.net) } };
 }
+
+/** The transaction count from `hledger stats` output. The report is a short
+ *  `Label : value` table; the line is `Txns                : 3 (1.0 per day)`.
+ *  Anchored to the line start so `Txns span` / `Txns last 30 days` never
+ *  match. 0 when the line is missing (empty or unexpected output). */
+export function parseTransactionCount(text: string): number {
+  const match = /^Txns\s*:\s*(\d+)/m.exec(text);
+  return match ? Number(match[1]) : 0;
+}

--- a/packages/desktop/src/main/ledger.ts
+++ b/packages/desktop/src/main/ledger.ts
@@ -1,6 +1,7 @@
 // Ledger data served straight from the main process: the @-mention picker's
-// entity lists, the Net Worth view's balance report, and the Transactions
-// view's journal register.
+// entity lists, the Net Worth view's balance report, the Transactions
+// view's journal register, and the transaction count behind the New Chat
+// page's prompt ideas.
 //
 // Runs the same `hledger` queries the pi-extension uses, but directly so the
 // renderer gets its data without round-tripping through the agent's RPC stream.
@@ -20,6 +21,7 @@ import {
   parseAssertions,
   parseBalanceSheetJson,
   parseLatestPriceTarget,
+  parseTransactionCount,
   parseTransactionsJson,
 } from "./ledger-json";
 
@@ -141,9 +143,19 @@ async function ledgerTransactions(): Promise<LedgerTransaction[]> {
   return parseTransactionsJson(stdout);
 }
 
+/** How many transactions the journal holds, from `hledger stats`: a few
+ *  hundred bytes for any journal size, where the register runs ~2.6 KB per
+ *  transaction. `-I` keeps the count when a balance assertion fails. 0 when
+ *  there is no journal or hledger yet: the count only picks the prompt
+ *  ideas, and a fresh ledger's set is the right fallback. */
+async function ledgerTransactionCount(): Promise<number> {
+  return parseTransactionCount((await hledgerResult(["stats", "-I", "-f", mainJournalPath()])) ?? "");
+}
+
 /** Register the ledger IPC handlers. */
 export function registerLedgerIpc(): void {
   ipcMain.handle("ledger_mentions", () => ledgerMentions());
   ipcMain.handle("ledger_net_worth", () => ledgerNetWorth());
   ipcMain.handle("ledger_transactions", () => ledgerTransactions());
+  ipcMain.handle("ledger_transaction_count", () => ledgerTransactionCount());
 }

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -34,6 +34,7 @@ const INVOKE_CHANNELS = new Set([
   "ledger_mentions",
   "ledger_net_worth",
   "ledger_transactions",
+  "ledger_transaction_count",
   "analytics_track",
   "update_pending",
   "update_install",

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/prompt-idea-decks.test.ts
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/prompt-idea-decks.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+// Spec for the prompt idea decks' persistence: a lenient load (fresh decks on
+// anything unreadable, unknown groups and non-ids dropped) and a save that
+// never throws.
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { installJsdomPolyfills } from "@/test/jsdomPolyfills";
+import { loadPromptIdeaDecks, savePromptIdeaDecks } from "../prompt-idea-decks";
+
+const KEY = "accountant24.prompt-idea-decks";
+
+beforeAll(() => installJsdomPolyfills());
+afterEach(() => {
+  window.localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("loadPromptIdeaDecks()", () => {
+  it("should return fresh decks when nothing is stored", () => {
+    expect(loadPromptIdeaDecks()).toEqual({});
+  });
+
+  it("should return the stored decks", () => {
+    window.localStorage.setItem(KEY, JSON.stringify({ "getting-started": ["what-can-you-do"], history: [] }));
+    expect(loadPromptIdeaDecks()).toEqual({ "getting-started": ["what-can-you-do"], history: [] });
+  });
+
+  it("should return fresh decks when the stored value is not JSON", () => {
+    window.localStorage.setItem(KEY, "{oops");
+    expect(loadPromptIdeaDecks()).toEqual({});
+  });
+
+  it("should return fresh decks when the stored value is not an object", () => {
+    window.localStorage.setItem(KEY, JSON.stringify(["ask"]));
+    expect(loadPromptIdeaDecks()).toEqual({});
+    window.localStorage.setItem(KEY, "null");
+    expect(loadPromptIdeaDecks()).toEqual({});
+  });
+
+  it("should drop unknown groups, non-array decks, and non-string entries", () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({ bogus: ["x"], ask: "not-a-deck", skills: ["list-skills", 3, null] }),
+    );
+    expect(loadPromptIdeaDecks()).toEqual({ skills: ["list-skills"] });
+  });
+
+  it("should return fresh decks when localStorage is unavailable", () => {
+    vi.spyOn(window.localStorage, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(loadPromptIdeaDecks()).toEqual({});
+  });
+});
+
+describe("savePromptIdeaDecks()", () => {
+  it("should store the decks for the next load", () => {
+    savePromptIdeaDecks({ rules: ["recurring-bills"], history: [] });
+    expect(loadPromptIdeaDecks()).toEqual({ rules: ["recurring-bills"], history: [] });
+  });
+
+  it("should not throw when localStorage rejects the write", () => {
+    vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+    expect(() => savePromptIdeaDecks({ history: [] })).not.toThrow();
+  });
+});

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/prompt-ideas.integration.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/prompt-ideas.integration.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+
+// The prompt ideas flow across the renderer: the New Chat page asks main for
+// the ledger's size over IPC, shows the matching set, and a click reports
+// the idea's id over IPC while the text lands in the composer and nothing
+// is sent. The preload bridge is the faked boundary; the thread, the
+// composer, and the assistant-ui runtime run for real.
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// rpc/api.ts captures `window.api` at module load — install the fake bridge
+// before any import pulls it in (async vi.hoisted runs before the imports).
+const bridge = await vi.hoisted(async () => (await import("@/test/fakeApi")).installFakeApi());
+
+import {
+  AssistantRuntimeProvider,
+  type ExternalStoreAdapter,
+  useAui,
+  useExternalStoreRuntime,
+} from "@assistant-ui/react";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { installJsdomPolyfills } from "@/test/jsdomPolyfills";
+import { Thread } from "../thread";
+
+beforeAll(() => {
+  installJsdomPolyfills();
+  // The thread viewport calls scrollTo on mount; jsdom omits it.
+  Element.prototype.scrollTo ??= () => {};
+  Element.prototype.hasPointerCapture ??= () => false;
+  Element.prototype.setPointerCapture ??= () => {};
+  Element.prototype.releasePointerCapture ??= () => {};
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+  bridge.reset();
+  bridge.setHandler("ledger_transaction_count", () => 0);
+  // The composer's @-mentions, `/` skills, and model picker.
+  bridge.setHandler("ledger_mentions", () => ({ accounts: [], payees: [], tags: [] }));
+  bridge.setHandler("plugins_list", () => ({ plugins: [] }));
+  bridge.setHandler("settings_get", () => ({ enabledModels: [] }));
+  bridge.setHandler("analytics_track", () => undefined);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/** The aui handle of the rendered runtime, to read composer and thread state. */
+let aui: ReturnType<typeof useAui> | undefined;
+const CaptureAui = () => {
+  aui = useAui();
+  return null;
+};
+
+/** A real external-store runtime on the New Chat page: no messages, and the
+ *  thread list still loading (the startup branch of isNewChatView). */
+function Chrome({ children }: { children: ReactNode }) {
+  const store = {
+    messages: [],
+    isRunning: false,
+    onNew: async () => {},
+    convertMessage: (m: unknown) => m,
+    adapters: { threadList: { isLoading: true } },
+  } as unknown as ExternalStoreAdapter;
+  const runtime = useExternalStoreRuntime(store);
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <CaptureAui />
+      {children}
+    </AssistantRuntimeProvider>
+  );
+}
+
+const trackedEvents = () => bridge.callsFor("analytics_track");
+const ideaNames = (list: HTMLElement) =>
+  within(list)
+    .getAllByRole("button")
+    .map((b) => b.textContent);
+
+describe("prompt ideas on the New Chat page", () => {
+  it("should ask main for the transaction count once and show the Getting started ideas for an empty ledger", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    render(
+      <Chrome>
+        <Thread />
+      </Chrome>,
+    );
+
+    const list = await screen.findByRole("list", { name: "Prompt ideas" });
+    expect(ideaNames(list)).toEqual([
+      "Import my bank statement",
+      "Record spending",
+      "Add transactions from a receipt",
+      "Set up my accounts",
+      "Add a bank account",
+    ]);
+    expect(bridge.callsFor("ledger_transaction_count")).toEqual([undefined]);
+  });
+
+  it("should deal the next visit from the deck the previous visit left", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const { unmount } = render(
+      <Chrome>
+        <Thread />
+      </Chrome>,
+    );
+    await screen.findByRole("list", { name: "Prompt ideas" });
+    unmount();
+
+    render(
+      <Chrome>
+        <Thread />
+      </Chrome>,
+    );
+    const list = await screen.findByRole("list", { name: "Prompt ideas" });
+    expect(ideaNames(list)).toEqual([
+      "Set my main currency",
+      "What can you do?",
+      "Remember my name",
+      "Ask me a few questions to get to know me",
+      "What should I do first?",
+    ]);
+  });
+
+  it("should show one idea per other group once main reports more than 10 transactions", async () => {
+    bridge.setHandler("ledger_transaction_count", () => 11);
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    render(
+      <Chrome>
+        <Thread />
+      </Chrome>,
+    );
+
+    const list = await screen.findByRole("list", { name: "Prompt ideas" });
+    expect(ideaNames(list)).toEqual([
+      "Show my last transactions",
+      "Record a refund",
+      "Set a monthly budget and warn me when I get close",
+      "What did you change today?",
+      "What am I paying every month?",
+    ]);
+  });
+
+  it("should put a clicked idea in the composer, focus it, report the id over IPC, and send nothing", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    render(
+      <Chrome>
+        <Thread />
+      </Chrome>,
+    );
+    const list = await screen.findByRole("list", { name: "Prompt ideas" });
+
+    await userEvent.click(within(list).getByRole("button", { name: "Record spending" }));
+
+    expect(aui?.composer().getState().text).toBe("Record spending");
+    await waitFor(() => expect(document.activeElement).toHaveClass("aui-lexical-input"));
+    await waitFor(() =>
+      expect(trackedEvents()).toEqual([{ event: "prompt_idea_used", props: { idea: "record-spending" } }]),
+    );
+    expect(aui?.thread().getState().messages).toHaveLength(0);
+    expect(screen.getByRole("list", { name: "Prompt ideas" })).toBeInTheDocument();
+  });
+});

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/prompt-ideas.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/prompt-ideas.test.tsx
@@ -1,0 +1,270 @@
+// @vitest-environment jsdom
+
+// Spec for the prompt ideas under the New Chat composer: which set shows for
+// which ledger size, that a set holds for a visit and the next visit continues
+// the stored deck, and that a click only fills and focuses the composer
+// (never sends).
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+// IPC boundary: the composer (rendered alongside, so the focus target exists)
+// reads its model picker, @-mentions, and `/` skills over the bridge, and a
+// click reports one analytics event over it.
+vi.mock("@/rpc/api", () => ({
+  ledgerApi: { mentions: vi.fn().mockResolvedValue({ accounts: [], payees: [], tags: [] }) },
+  pluginsApi: { list: vi.fn().mockResolvedValue({ plugins: [] }), onEvent: vi.fn(async () => () => {}) },
+  settingsApi: {
+    get: vi.fn().mockResolvedValue({ enabledModels: [], defaultModel: undefined }),
+    onChange: () => () => {},
+  },
+  agentApi: { onModelsChanged: () => () => {} },
+  analyticsApi: { track: vi.fn() },
+}));
+
+import {
+  AssistantRuntimeProvider,
+  type ExternalStoreAdapter,
+  useAui,
+  useExternalStoreRuntime,
+} from "@assistant-ui/react";
+import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { PROMPT_IDEA_GROUPS } from "@/lib/promptIdeas";
+import { analyticsApi } from "@/rpc/api";
+import { installJsdomPolyfills } from "@/test/jsdomPolyfills";
+import { Composer } from "../composer";
+import { PromptIdeas } from "../prompt-ideas";
+
+beforeAll(() => {
+  installJsdomPolyfills();
+  Element.prototype.hasPointerCapture ??= () => false;
+  Element.prototype.setPointerCapture ??= () => {};
+  Element.prototype.releasePointerCapture ??= () => {};
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+});
+
+/** The aui handle of the rendered runtime, to read and seed composer state
+ *  the way the Lexical input would (jsdom cannot type into Lexical). */
+let aui: ReturnType<typeof useAui> | undefined;
+const CaptureAui = () => {
+  aui = useAui();
+  return null;
+};
+
+/** A real external-store assistant-ui runtime with an empty, idle thread. */
+function Chrome({ children }: { children: ReactNode }) {
+  const store = {
+    messages: [],
+    isRunning: false,
+    onNew: async () => {},
+    convertMessage: (m: unknown) => m,
+  } as unknown as ExternalStoreAdapter;
+  const runtime = useExternalStoreRuntime(store);
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <CaptureAui />
+      {children}
+    </AssistantRuntimeProvider>
+  );
+}
+
+const ideaList = () => screen.getByRole("list", { name: "Prompt ideas" });
+const ideaButtons = () => within(ideaList()).getAllByRole("button");
+const ideaNames = () => ideaButtons().map((b) => b.textContent);
+const groupOf = (prompt: string | null) =>
+  PROMPT_IDEA_GROUPS.find((group) => group.ideas.some((idea) => idea.prompt === prompt))?.id;
+const idOf = (prompt: string | null) =>
+  PROMPT_IDEA_GROUPS.flatMap((group) => group.ideas).find((idea) => idea.prompt === prompt)?.id;
+
+describe("<PromptIdeas />", () => {
+  describe("which ideas show", () => {
+    it("should render nothing while the transaction count is not known yet", () => {
+      render(
+        <Chrome>
+          <PromptIdeas transactionCount={null} />
+        </Chrome>,
+      );
+      expect(screen.queryByRole("list", { name: "Prompt ideas" })).toBeNull();
+    });
+
+    it("should show five Getting started ideas for an empty ledger", () => {
+      render(
+        <Chrome>
+          <PromptIdeas transactionCount={0} />
+        </Chrome>,
+      );
+      const names = ideaNames();
+      expect(names).toHaveLength(5);
+      expect(new Set(names).size).toBe(5);
+      for (const name of names) expect(groupOf(name)).toBe("getting-started");
+    });
+
+    it("should still show Getting started ideas at exactly 10 transactions", () => {
+      render(
+        <Chrome>
+          <PromptIdeas transactionCount={10} />
+        </Chrome>,
+      );
+      for (const name of ideaNames()) expect(groupOf(name)).toBe("getting-started");
+    });
+
+    it("should show one idea from each other group, in group order, once the ledger has 11 transactions", () => {
+      render(
+        <Chrome>
+          <PromptIdeas transactionCount={11} />
+        </Chrome>,
+      );
+      expect(ideaNames().map(groupOf)).toEqual(["ask", "log-and-edit", "rules", "history", "skills"]);
+    });
+
+    it("should continue the stored deck on the next visit and persist what is left", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const { unmount } = render(
+        <Chrome>
+          <PromptIdeas transactionCount={0} />
+        </Chrome>,
+      );
+      expect(ideaNames()[0]).toBe("Import my bank statement");
+      expect(JSON.parse(window.localStorage.getItem("accountant24.prompt-idea-decks") ?? "")).toEqual({
+        "getting-started": [
+          "set-main-currency",
+          "what-can-you-do",
+          "remember-my-name",
+          "get-to-know-me",
+          "what-first",
+          "starting-balances",
+          "record-income",
+          "add-credit-card",
+          "show-net-worth",
+        ],
+      });
+
+      unmount();
+      render(
+        <Chrome>
+          <PromptIdeas transactionCount={0} />
+        </Chrome>,
+      );
+      expect(ideaNames()).toEqual([
+        "Set my main currency",
+        "What can you do?",
+        "Remember my name",
+        "Ask me a few questions to get to know me",
+        "What should I do first?",
+      ]);
+    });
+
+    it("should keep the same set while the page stays open, even as the count changes below the threshold", () => {
+      const random = vi.spyOn(Math, "random").mockReturnValue(0);
+      const { rerender } = render(
+        <Chrome>
+          <PromptIdeas transactionCount={0} />
+        </Chrome>,
+      );
+      const initial = ideaNames();
+      expect(initial).toEqual([
+        "Import my bank statement",
+        "Record spending",
+        "Add transactions from a receipt",
+        "Set up my accounts",
+        "Add a bank account",
+      ]);
+
+      random.mockReturnValue(0.999);
+      rerender(
+        <Chrome>
+          <PromptIdeas transactionCount={7} />
+        </Chrome>,
+      );
+      expect(ideaNames()).toEqual(initial);
+    });
+
+    it("should pick a fresh set when the count crosses the threshold", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0.999);
+      const { rerender } = render(
+        <Chrome>
+          <PromptIdeas transactionCount={10} />
+        </Chrome>,
+      );
+      expect(ideaNames()[0]).toBe("Show my net worth");
+
+      rerender(
+        <Chrome>
+          <PromptIdeas transactionCount={11} />
+        </Chrome>,
+      );
+      expect(ideaNames()).toEqual([
+        "How much do I have in each currency?",
+        "Add another account",
+        "Ask me a few questions to know me better",
+        "What changed this week?",
+        "What else can you do?",
+      ]);
+    });
+  });
+
+  describe("clicking an idea", () => {
+    const renderWithComposer = () =>
+      render(
+        <Chrome>
+          <Composer />
+          <PromptIdeas transactionCount={0} />
+        </Chrome>,
+      );
+
+    it("should put the idea's text in the composer without sending a message", async () => {
+      renderWithComposer();
+      const [button] = ideaButtons();
+      await userEvent.click(button as HTMLElement);
+
+      expect(aui?.composer().getState().text).toBe(button?.textContent);
+      expect(aui?.thread().getState().messages).toHaveLength(0);
+    });
+
+    it("should replace a draft already in the composer", async () => {
+      renderWithComposer();
+      act(() => aui?.composer().setText("half-typed draft"));
+      const [button] = ideaButtons();
+      await userEvent.click(button as HTMLElement);
+
+      expect(aui?.composer().getState().text).toBe(button?.textContent);
+    });
+
+    it("should move focus to the composer input", async () => {
+      renderWithComposer();
+      const [button] = ideaButtons();
+      await userEvent.click(button as HTMLElement);
+
+      await waitFor(() => expect(document.activeElement).toHaveClass("aui-lexical-input"));
+    });
+
+    it("should report the idea's id (never its text) as used", async () => {
+      renderWithComposer();
+      const [button] = ideaButtons();
+      await userEvent.click(button as HTMLElement);
+
+      expect(analyticsApi.track).toHaveBeenCalledExactlyOnceWith("prompt_idea_used", {
+        idea: idOf(button?.textContent ?? null),
+      });
+    });
+
+    it("should fill the composer state and leave focus alone when no composer input is on screen", async () => {
+      render(
+        <Chrome>
+          <PromptIdeas transactionCount={0} />
+        </Chrome>,
+      );
+      const [button] = ideaButtons();
+      await userEvent.click(button as HTMLElement);
+
+      expect(aui?.composer().getState().text).toBe(button?.textContent);
+      await act(() => new Promise((resolve) => requestAnimationFrame(() => resolve(undefined))));
+      expect(document.activeElement).toBe(button);
+    });
+  });
+});

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/thread.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/thread.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { installJsdomPolyfills } from "@/test/jsdomPolyfills";
@@ -9,7 +9,11 @@ import { installJsdomPolyfills } from "@/test/jsdomPolyfills";
 // Electron bridge. Stub them so the thread (which always renders the composer)
 // mounts without a real main process.
 vi.mock("@/rpc/api", () => ({
-  ledgerApi: { mentions: vi.fn().mockResolvedValue({ accounts: [], payees: [], tags: [] }) },
+  ledgerApi: {
+    mentions: vi.fn().mockResolvedValue({ accounts: [], payees: [], tags: [] }),
+    // The prompt ideas under the composer read the ledger's size.
+    transactionCount: vi.fn().mockResolvedValue(0),
+  },
   // The composer's `/` skills picker lists skills over IPC.
   pluginsApi: { list: vi.fn().mockResolvedValue({ plugins: [] }), onEvent: vi.fn(async () => () => {}) },
   settingsApi: {
@@ -129,6 +133,26 @@ describe("Thread welcome vs. messages", () => {
     );
     expect(await screen.findByText("what is my balance?")).toBeInTheDocument();
     expect(screen.queryByText("How can I help you today?")).toBeNull();
+  });
+
+  it("should list five prompt ideas under the composer on the welcome screen", async () => {
+    render(
+      <Chrome threadListLoading>
+        <Thread />
+      </Chrome>,
+    );
+    const ideas = await screen.findByRole("list", { name: "Prompt ideas" });
+    expect(within(ideas).getAllByRole("button")).toHaveLength(5);
+  });
+
+  it("should not list prompt ideas once the thread has content", async () => {
+    render(
+      <Chrome messages={[userMsg("what is my balance?")]}>
+        <Thread />
+      </Chrome>,
+    );
+    expect(await screen.findByText("what is my balance?")).toBeInTheDocument();
+    expect(screen.queryByRole("list", { name: "Prompt ideas" })).toBeNull();
   });
 
   it("should render the assistant's answer text", async () => {

--- a/packages/desktop/src/renderer/components/accountant24/__tests__/use-transaction-count.test.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/__tests__/use-transaction-count.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+// Spec for the transaction count feed behind the prompt ideas: unknown until
+// the first answer, 0 on failure, refetched when a turn finishes.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// IPC boundary: the count comes over the Electron bridge.
+vi.mock("@/rpc/api", () => ({ ledgerApi: { transactionCount: vi.fn() } }));
+
+import { AssistantRuntimeProvider, type ExternalStoreAdapter, useExternalStoreRuntime } from "@assistant-ui/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { ledgerApi } from "@/rpc/api";
+import { useTransactionCount } from "../use-transaction-count";
+
+afterEach(() => cleanup());
+
+/** A real external-store runtime; `isRunning` drives the idle-edge refresh. */
+function Chrome({ children, isRunning = false }: { children: ReactNode; isRunning?: boolean }) {
+  const store = {
+    messages: [],
+    isRunning,
+    onNew: async () => {},
+    convertMessage: (m: unknown) => m,
+  } as unknown as ExternalStoreAdapter;
+  const runtime = useExternalStoreRuntime(store);
+  return <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>;
+}
+
+const Probe = () => {
+  const count = useTransactionCount();
+  return <output>{count === null ? "unknown" : String(count)}</output>;
+};
+
+const renderProbe = (isRunning = false) =>
+  render(
+    <Chrome isRunning={isRunning}>
+      <Probe />
+    </Chrome>,
+  );
+
+describe("useTransactionCount()", () => {
+  it("should fetch the count once on mount and expose it", async () => {
+    vi.mocked(ledgerApi.transactionCount).mockResolvedValue(12);
+    renderProbe();
+    expect(await screen.findByText("12")).toBeInTheDocument();
+    expect(ledgerApi.transactionCount).toHaveBeenCalledTimes(1);
+  });
+
+  it("should be unknown (null) until the fetch answers", async () => {
+    let resolve: (n: number) => void = () => {};
+    vi.mocked(ledgerApi.transactionCount).mockReturnValue(new Promise<number>((r) => (resolve = r)));
+    renderProbe();
+    expect(screen.getByText("unknown")).toBeInTheDocument();
+
+    await act(async () => resolve(3));
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("should count a failed fetch as 0", async () => {
+    vi.mocked(ledgerApi.transactionCount).mockRejectedValue(new Error("bridge down"));
+    renderProbe();
+    expect(await screen.findByText("0")).toBeInTheDocument();
+  });
+
+  it("should ignore an answer that arrives after unmount", async () => {
+    let resolve: (n: number) => void = () => {};
+    vi.mocked(ledgerApi.transactionCount).mockReturnValue(new Promise<number>((r) => (resolve = r)));
+    const { unmount } = renderProbe();
+    unmount();
+    await act(async () => resolve(3));
+    expect(screen.queryByText("3")).toBeNull();
+  });
+
+  it("should refetch when a turn finishes", async () => {
+    vi.mocked(ledgerApi.transactionCount).mockResolvedValueOnce(1).mockResolvedValueOnce(20);
+    const { rerender } = renderProbe();
+    expect(await screen.findByText("1")).toBeInTheDocument();
+
+    rerender(
+      <Chrome isRunning>
+        <Probe />
+      </Chrome>,
+    );
+    rerender(
+      <Chrome isRunning={false}>
+        <Probe />
+      </Chrome>,
+    );
+    expect(await screen.findByText("20")).toBeInTheDocument();
+    expect(ledgerApi.transactionCount).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/desktop/src/renderer/components/accountant24/prompt-idea-decks.ts
+++ b/packages/desktop/src/renderer/components/accountant24/prompt-idea-decks.ts
@@ -1,0 +1,35 @@
+// The prompt ideas' decks between New Chat visits — the same best-effort
+// localStorage idiom as the sidebar width and the table configs: load
+// validates the stored value and falls back to fresh decks, save never
+// throws. Which ideas come next is a convenience, not data, so it lives with
+// the other UI preferences rather than in the workspace.
+
+import { PROMPT_IDEA_GROUPS, type PromptIdeaDecks } from "@/lib/promptIdeas";
+
+const STORAGE_KEY = "accountant24.prompt-idea-decks";
+
+/** The stored decks; unknown groups and non-string entries are dropped, and
+ *  anything unreadable means fresh decks. */
+export function loadPromptIdeaDecks(): PromptIdeaDecks {
+  let stored: unknown;
+  try {
+    stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "");
+  } catch {
+    return {};
+  }
+  if (typeof stored !== "object" || stored === null || Array.isArray(stored)) return {};
+  const decks: PromptIdeaDecks = {};
+  for (const group of PROMPT_IDEA_GROUPS) {
+    const deck = (stored as Record<string, unknown>)[group.id];
+    if (Array.isArray(deck)) decks[group.id] = deck.filter((id): id is string => typeof id === "string");
+  }
+  return decks;
+}
+
+export function savePromptIdeaDecks(decks: PromptIdeaDecks): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(decks));
+  } catch {
+    // Persistence is best-effort; the next visit simply reshuffles.
+  }
+}

--- a/packages/desktop/src/renderer/components/accountant24/prompt-ideas.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/prompt-ideas.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+// Prompt ideas under the composer on the New Chat page: five things to try,
+// dealt fresh each time the page opens from decks that persist between
+// visits, so every idea comes around before any repeats. A click puts the
+// idea in the composer and focuses it; sending stays with the user.
+
+import { ThreadPrimitive } from "@assistant-ui/react";
+import { type FC, useEffect, useState } from "react";
+import { loadPromptIdeaDecks, savePromptIdeaDecks } from "@/components/accountant24/prompt-idea-decks";
+import { Button } from "@/components/shadcn/button";
+import { trackPromptIdeaUsed } from "@/lib/analyticsEvents";
+import { dealPromptIdeas, GETTING_STARTED_MAX_TRANSACTIONS } from "@/lib/promptIdeas";
+
+/** Focus the composer once the clicked idea has landed in it. The
+ *  suggestion's own handler (the composer setText) runs after ours, and the
+ *  Lexical sync commits that text with the caret at its end in a microtask;
+ *  a frame later a native focus keeps the caret there, so typing continues
+ *  after the idea. Same idiom as the New Chat action on the report pages. */
+function focusComposerInput(): void {
+  requestAnimationFrame(() => document.querySelector<HTMLElement>(".aui-lexical-input")?.focus());
+}
+
+/** `transactionCount` null = not known yet: nothing renders, so the wrong
+ *  set never flashes before the right one. */
+export const PromptIdeas: FC<{ transactionCount: number | null }> = ({ transactionCount }) => {
+  if (transactionCount === null) return null;
+  const phase = transactionCount > GETTING_STARTED_MAX_TRANSACTIONS ? "explore" : "getting-started";
+  // Keyed by phase: crossing the threshold deals a fresh hand; nothing else
+  // re-deals while the page stays open.
+  return <PromptIdeaList key={phase} transactionCount={transactionCount} />;
+};
+
+const PromptIdeaList: FC<{ transactionCount: number }> = ({ transactionCount }) => {
+  // Dealt once per mount (the thread mounts this anew with every New Chat
+  // visit) as a pure read of the stored decks; StrictMode may run the
+  // initializer twice and keeps one hand. The decks are written back in the
+  // effect, which is harmless when replayed.
+  const [{ ideas, decks }] = useState(() => dealPromptIdeas(transactionCount, loadPromptIdeaDecks()));
+  useEffect(() => {
+    savePromptIdeaDecks(decks);
+  }, [decks]);
+
+  return (
+    // A centered wrapping row of pills (the stock button is already pill
+    // shaped) on the composer's axis; the entrance matches the welcome heading.
+    <ul
+      aria-label="Prompt ideas"
+      className="fade-in slide-in-from-bottom-1 animate-in fill-mode-both flex flex-wrap justify-center gap-2 duration-200"
+    >
+      {ideas.map((idea) => (
+        <li key={idea.id}>
+          {/* No `send`: the suggestion only sets the composer text. */}
+          <ThreadPrimitive.Suggestion
+            prompt={idea.prompt}
+            asChild
+            onClick={() => {
+              trackPromptIdeaUsed(idea.id);
+              focusComposerInput();
+            }}
+          >
+            <Button variant="outline" size="sm">
+              {idea.prompt}
+            </Button>
+          </ThreadPrimitive.Suggestion>
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/packages/desktop/src/renderer/components/accountant24/thread.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/thread.tsx
@@ -21,8 +21,10 @@ import { CompactionIndicator, CompactionSummary } from "@/components/accountant2
 import { Composer, EditComposer, isNewChatView } from "@/components/accountant24/composer";
 import { MarkdownText } from "@/components/accountant24/markdown-text";
 import { MessageError } from "@/components/accountant24/message-error";
+import { PromptIdeas } from "@/components/accountant24/prompt-ideas";
 import { ToolFallback } from "@/components/accountant24/tool-fallback";
 import { TooltipIconButton } from "@/components/accountant24/tooltip-icon-button";
+import { useTransactionCount } from "@/components/accountant24/use-transaction-count";
 import { Bubble, BubbleContent } from "@/components/shadcn/bubble";
 import { Message, MessageContent, MessageGroup } from "@/components/shadcn/message";
 import { cn } from "@/lib/utils";
@@ -58,15 +60,18 @@ const ThreadComponentsContext = createContext<ThreadComponents>(EMPTY_COMPONENTS
 
 export const Thread: FC<ThreadProps> = ({ components = EMPTY_COMPONENTS }) => {
   const isEmpty = useAuiState(isNewChatView);
+  // Read here, where the thread stays mounted across chats, so a New Chat
+  // visit shows its prompt ideas at once instead of after a fetch.
+  const transactionCount = useTransactionCount();
 
   return (
     <ThreadComponentsContext.Provider value={components}>
-      <ThreadRoot isEmpty={isEmpty} />
+      <ThreadRoot isEmpty={isEmpty} transactionCount={transactionCount} />
     </ThreadComponentsContext.Provider>
   );
 };
 
-const ThreadRoot: FC<{ isEmpty: boolean }> = ({ isEmpty }) => {
+const ThreadRoot: FC<{ isEmpty: boolean; transactionCount: number | null }> = ({ isEmpty, transactionCount }) => {
   const { Welcome = ThreadWelcome } = useContext(ThreadComponentsContext);
 
   return (
@@ -113,6 +118,12 @@ const ThreadRoot: FC<{ isEmpty: boolean }> = ({ isEmpty }) => {
           >
             <ThreadScrollToBottom />
             <Composer />
+            {/* Mounted per New Chat visit (AuiIf drops it with the first
+                message or an existing chat), which is what makes each visit
+                pick a fresh set. */}
+            <AuiIf condition={isNewChatView}>
+              <PromptIdeas transactionCount={transactionCount} />
+            </AuiIf>
           </ThreadPrimitive.ViewportFooter>
         </div>
       </ThreadPrimitive.Viewport>

--- a/packages/desktop/src/renderer/components/accountant24/use-transaction-count.ts
+++ b/packages/desktop/src/renderer/components/accountant24/use-transaction-count.ts
@@ -1,0 +1,35 @@
+"use client";
+
+// The journal's transaction count, which picks the New Chat page's prompt ideas.
+
+import { useCallback, useEffect, useState } from "react";
+import { useAgentIdleRefresh } from "@/hooks/use-agent-idle-refresh";
+import { ledgerApi } from "@/rpc/api";
+
+/** null = not known yet (the ideas wait rather than show the wrong set). A
+ *  failed fetch counts as 0: the count only picks the ideas, and a fresh
+ *  ledger's set beats none. Refetched when a turn finishes (it may have
+ *  posted transactions), so the next New Chat sees the ledger's real size. */
+export function useTransactionCount(): number | null {
+  const [count, setCount] = useState<number | null>(null);
+
+  const refresh = useCallback(() => {
+    let cancelled = false;
+    ledgerApi
+      .transactionCount()
+      .then((n) => {
+        if (!cancelled) setCount(n);
+      })
+      .catch(() => {
+        if (!cancelled) setCount(0);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => refresh(), [refresh]);
+  useAgentIdleRefresh(refresh);
+
+  return count;
+}

--- a/packages/desktop/src/renderer/lib/__tests__/analyticsEvents.test.ts
+++ b/packages/desktop/src/renderer/lib/__tests__/analyticsEvents.test.ts
@@ -16,6 +16,7 @@ import {
   trackAgentToolUsed,
   trackAttachmentAdded,
   trackChatCreated,
+  trackPromptIdeaUsed,
   trackTransactionFirstAdded,
   trackUserFirstMessageSent,
   trackUserMessageSent,
@@ -119,6 +120,16 @@ describe("trackAttachmentAdded()", () => {
     expect(h.invoke).toHaveBeenCalledExactlyOnceWith("analytics_track", {
       event: "attachment_added",
       props: { kind: "pdf" },
+    });
+  });
+});
+
+describe("trackPromptIdeaUsed()", () => {
+  it("should send prompt_idea_used with the idea's id", () => {
+    trackPromptIdeaUsed("net-worth-trend");
+    expect(h.invoke).toHaveBeenCalledExactlyOnceWith("analytics_track", {
+      event: "prompt_idea_used",
+      props: { idea: "net-worth-trend" },
     });
   });
 });

--- a/packages/desktop/src/renderer/lib/__tests__/promptIdeas.test.ts
+++ b/packages/desktop/src/renderer/lib/__tests__/promptIdeas.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from "vitest";
+import {
+  dealPromptIdeas,
+  GETTING_STARTED_MAX_TRANSACTIONS,
+  PROMPT_IDEA_GROUPS,
+  PROMPT_IDEAS_SHOWN,
+  type PromptIdeaDecks,
+} from "../promptIdeas";
+
+// dealPromptIdeas deals one New Chat visit's ideas from the stored decks.
+// `random` is injected so the expected ids can be hardcoded: a constant 0
+// shuffles into declaration order, a value just under 1 into reverse.
+
+const ids = (ideas: { id: string }[]) => ideas.map((idea) => idea.id);
+const first = () => 0;
+const last = () => 0.999;
+const groupOf = (id: string) => PROMPT_IDEA_GROUPS.find((g) => g.ideas.some((i) => i.id === id))?.id;
+const groupIds = (id: string) => ids(PROMPT_IDEA_GROUPS.filter((g) => g.id === id).flatMap((g) => g.ideas));
+const gettingStartedIds = groupIds("getting-started");
+
+/** `visits` consecutive deals, threading the decks through like the page does. */
+function visitTimes(visits: number, transactionCount: number, random: () => number, decks: PromptIdeaDecks = {}) {
+  const hands: string[][] = [];
+  let current = decks;
+  for (let i = 0; i < visits; i++) {
+    const deal = dealPromptIdeas(transactionCount, current, random);
+    hands.push(ids(deal.ideas));
+    current = deal.decks;
+  }
+  return { hands, decks: current };
+}
+
+describe("dealPromptIdeas()", () => {
+  describe("while the ledger has up to 10 transactions", () => {
+    it("should deal the first five Getting started ideas from fresh decks when random is 0 and the ledger is empty", () => {
+      const { ideas, decks } = dealPromptIdeas(0, {}, first);
+      expect(ids(ideas)).toEqual([
+        "import-bank-statement",
+        "record-spending",
+        "add-from-receipt",
+        "set-up-accounts",
+        "add-bank-account",
+      ]);
+      expect(decks).toEqual({
+        "getting-started": [
+          "set-main-currency",
+          "what-can-you-do",
+          "remember-my-name",
+          "get-to-know-me",
+          "what-first",
+          "starting-balances",
+          "record-income",
+          "add-credit-card",
+          "show-net-worth",
+        ],
+      });
+    });
+
+    it("should still deal Getting started ideas at exactly 10 transactions", () => {
+      expect(ids(dealPromptIdeas(10, {}, first).ideas)).toEqual([
+        "import-bank-statement",
+        "record-spending",
+        "add-from-receipt",
+        "set-up-accounts",
+        "add-bank-account",
+      ]);
+    });
+
+    it("should shuffle into reverse order when random is close to 1", () => {
+      expect(ids(dealPromptIdeas(0, {}, last).ideas)).toEqual([
+        "show-net-worth",
+        "add-credit-card",
+        "record-income",
+        "starting-balances",
+        "what-first",
+      ]);
+    });
+
+    it("should deal the rest of the deck first, then reshuffle for the remainder of the hand", () => {
+      const { ideas, decks } = dealPromptIdeas(
+        0,
+        { "getting-started": ["set-main-currency", "what-can-you-do"] },
+        first,
+      );
+      expect(ids(ideas)).toEqual([
+        "set-main-currency",
+        "what-can-you-do",
+        "import-bank-statement",
+        "record-spending",
+        "add-from-receipt",
+      ]);
+      expect(decks["getting-started"]).toEqual([
+        "set-up-accounts",
+        "add-bank-account",
+        "set-main-currency",
+        "what-can-you-do",
+        "remember-my-name",
+        "get-to-know-me",
+        "what-first",
+        "starting-balances",
+        "record-income",
+        "add-credit-card",
+        "show-net-worth",
+      ]);
+    });
+
+    it("should move an id the reshuffle repeats from this hand to the deck's end instead of dealing it twice", () => {
+      // The reversed reshuffle starts with show-net-worth, just dealt from
+      // the old deck.
+      const { ideas, decks } = dealPromptIdeas(0, { "getting-started": ["show-net-worth"] }, last);
+      expect(ids(ideas)).toEqual([
+        "show-net-worth",
+        "add-credit-card",
+        "record-income",
+        "starting-balances",
+        "what-first",
+      ]);
+      expect(decks["getting-started"]).toEqual([
+        "get-to-know-me",
+        "remember-my-name",
+        "what-can-you-do",
+        "set-main-currency",
+        "add-bank-account",
+        "set-up-accounts",
+        "add-from-receipt",
+        "record-spending",
+        "import-bank-statement",
+        "show-net-worth",
+      ]);
+    });
+
+    it("should skip stored ids that are no longer in the list and duplicates", () => {
+      const { ideas, decks } = dealPromptIdeas(
+        0,
+        { "getting-started": ["gone-idea", "record-spending", "record-spending"] },
+        first,
+      );
+      expect(ids(ideas)).toEqual([
+        "record-spending",
+        "import-bank-statement",
+        "add-from-receipt",
+        "set-up-accounts",
+        "add-bank-account",
+      ]);
+      expect(decks["getting-started"]).toEqual([
+        "set-main-currency",
+        "what-can-you-do",
+        "remember-my-name",
+        "get-to-know-me",
+        "what-first",
+        "starting-balances",
+        "record-income",
+        "add-credit-card",
+        "show-net-worth",
+        "record-spending",
+      ]);
+    });
+
+    it("should show every Getting started idea within three visits with the default random source", () => {
+      const { hands } = visitTimes(3, 0, Math.random);
+      expect(hands[0]).toHaveLength(PROMPT_IDEAS_SHOWN);
+      expect(new Set(hands.flat())).toEqual(new Set(gettingStartedIds));
+    });
+
+    it("should leave the other groups' decks untouched", () => {
+      const { decks } = dealPromptIdeas(0, { ask: ["top-payees"], history: [] }, first);
+      expect(decks.ask).toEqual(["top-payees"]);
+      expect(decks.history).toEqual([]);
+    });
+  });
+
+  describe("once the ledger has more than 10 transactions", () => {
+    it("should deal the first idea of each other group, in group order, from fresh decks when random is 0", () => {
+      const { ideas, decks } = dealPromptIdeas(GETTING_STARTED_MAX_TRANSACTIONS + 1, {}, first);
+      expect(ids(ideas)).toEqual([
+        "last-transactions",
+        "record-refund",
+        "monthly-budget",
+        "changes-today",
+        "monthly-payments",
+      ]);
+      expect(decks.history).toEqual([
+        "undo-last-change",
+        "transaction-history",
+        "undo-last-import",
+        "restore-deleted",
+        "changes-this-week",
+      ]);
+      expect(decks.skills).toEqual([
+        "cancel-subscriptions",
+        "create-review-skill",
+        "list-skills",
+        "skills-to-add",
+        "subscription-increases",
+        "what-else-can-you-do",
+      ]);
+      expect(decks.ask).toHaveLength(18);
+      expect(decks["getting-started"]).toBeUndefined();
+    });
+
+    it("should deal the last idea of each other group when random is close to 1", () => {
+      expect(ids(dealPromptIdeas(5000, {}, last).ideas)).toEqual([
+        "balances-by-currency",
+        "add-another-account",
+        "know-me-better",
+        "changes-this-week",
+        "what-else-can-you-do",
+      ]);
+    });
+
+    it("should continue each group's deck on the next visit", () => {
+      const { hands } = visitTimes(2, 11, first);
+      expect(hands[1]).toEqual([
+        "spent-this-month",
+        "record-transfer",
+        "recurring-bills",
+        "undo-last-change",
+        "cancel-subscriptions",
+      ]);
+    });
+
+    it("should show every idea of a group once per deck, reshuffling when the deck runs out", () => {
+      const visits = groupIds("ask").length;
+      const { hands } = visitTimes(visits, 11, Math.random);
+      const shown = hands.flat();
+      // Ask is the largest group: exactly one full deck over these visits.
+      for (const id of groupIds("ask")) expect(shown.filter((s) => s === id)).toHaveLength(1);
+      // Every other group cycles its deck several times; no idea is ever
+      // more than one showing ahead of another.
+      for (const group of PROMPT_IDEA_GROUPS.slice(2)) {
+        const size = group.ideas.length;
+        for (const idea of group.ideas) {
+          const times = shown.filter((s) => s === idea.id).length;
+          expect(times).toBeGreaterThanOrEqual(Math.floor(visits / size));
+          expect(times).toBeLessThanOrEqual(Math.ceil(visits / size));
+        }
+      }
+    });
+
+    it("should never include a Getting started idea", () => {
+      for (const id of ids(dealPromptIdeas(11, {}).ideas)) expect(gettingStartedIds).not.toContain(id);
+    });
+
+    it("should deal one idea per other group, in group order, with the default random source", () => {
+      const picked = ids(dealPromptIdeas(11, {}).ideas);
+      expect(picked).toHaveLength(PROMPT_IDEAS_SHOWN);
+      expect(picked.map(groupOf)).toEqual(["ask", "log-and-edit", "rules", "history", "skills"]);
+    });
+  });
+});
+
+describe("PROMPT_IDEA_GROUPS", () => {
+  const all = PROMPT_IDEA_GROUPS.flatMap((g) => g.ideas);
+
+  it("should hold the six groups in display order", () => {
+    expect(PROMPT_IDEA_GROUPS.map((g) => g.id)).toEqual([
+      "getting-started",
+      "ask",
+      "log-and-edit",
+      "rules",
+      "history",
+      "skills",
+    ]);
+  });
+
+  it("should hold more Getting started ideas than a visit shows, so visits differ", () => {
+    expect(gettingStartedIds.length).toBeGreaterThan(PROMPT_IDEAS_SHOWN);
+  });
+
+  it("should hold exactly as many other groups as a visit shows ideas, one each", () => {
+    expect(PROMPT_IDEA_GROUPS.length - 1).toBe(PROMPT_IDEAS_SHOWN);
+  });
+
+  it("should hold at least one idea in every group", () => {
+    for (const group of PROMPT_IDEA_GROUPS) expect(group.ideas.length).toBeGreaterThan(0);
+  });
+
+  it("should use ids that are unique across all groups", () => {
+    expect(new Set(ids(all)).size).toBe(all.length);
+  });
+
+  it("should use kebab-case ids", () => {
+    for (const idea of all) expect(idea.id).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+  });
+
+  it("should keep every prompt a single non-empty line", () => {
+    for (const idea of all) {
+      expect(idea.prompt.trim()).not.toBe("");
+      expect(idea.prompt).not.toMatch(/\n/);
+    }
+  });
+
+  it("should keep the copy rules: no em dashes, no ellipsis, accounts never categories", () => {
+    for (const idea of all) {
+      expect(idea.prompt).not.toMatch(/—/);
+      expect(idea.prompt).not.toMatch(/…|\.\.\./);
+      expect(idea.prompt).not.toMatch(/categor/i);
+    }
+  });
+});

--- a/packages/desktop/src/renderer/lib/analyticsEvents.ts
+++ b/packages/desktop/src/renderer/lib/analyticsEvents.ts
@@ -69,3 +69,10 @@ export function trackMarketplaceViewed(pluginCount: number): void {
 export function trackPluginInstallStarted(official: boolean): void {
   analyticsApi.track("plugin_install_started", { official });
 }
+
+/** Record a prompt idea on the New Chat page being clicked into the composer.
+ *  `idea` is the idea's stable id from the hardcoded list, never its text, so
+ *  the list can be reworded without breaking the series. */
+export function trackPromptIdeaUsed(idea: string): void {
+  analyticsApi.track("prompt_idea_used", { idea });
+}

--- a/packages/desktop/src/renderer/lib/promptIdeas.ts
+++ b/packages/desktop/src/renderer/lib/promptIdeas.ts
@@ -1,0 +1,200 @@
+// The prompt ideas shown under the composer on the New Chat page: one
+// hardcoded list in groups, five dealt per visit from shuffled decks so every
+// idea comes around once before any repeats. Written as the user would type
+// them: one line, short, generic (no amounts, no real payee or account
+// names, "account" never "category"), no ellipsis, no em dashes. The ids are
+// what analytics carries, never the text, so wording can change freely while
+// an id stays put.
+
+export interface PromptIdea {
+  id: string;
+  prompt: string;
+}
+
+export interface PromptIdeaGroup {
+  id: "getting-started" | "ask" | "log-and-edit" | "rules" | "history" | "skills";
+  ideas: PromptIdea[];
+}
+
+/** Ledgers with at most this many transactions get the Getting started ideas. */
+export const GETTING_STARTED_MAX_TRANSACTIONS = 10;
+
+/** How many ideas a visit shows: also the number of groups the explore set
+ *  draws from, one idea each. */
+export const PROMPT_IDEAS_SHOWN = 5;
+
+export const PROMPT_IDEA_GROUPS: readonly PromptIdeaGroup[] = [
+  {
+    id: "getting-started",
+    ideas: [
+      { id: "import-bank-statement", prompt: "Import my bank statement" },
+      { id: "record-spending", prompt: "Record spending" },
+      { id: "add-from-receipt", prompt: "Add transactions from a receipt" },
+      { id: "set-up-accounts", prompt: "Set up my accounts" },
+      { id: "add-bank-account", prompt: "Add a bank account" },
+      { id: "set-main-currency", prompt: "Set my main currency" },
+      { id: "what-can-you-do", prompt: "What can you do?" },
+      { id: "remember-my-name", prompt: "Remember my name" },
+      { id: "get-to-know-me", prompt: "Ask me a few questions to get to know me" },
+      { id: "what-first", prompt: "What should I do first?" },
+      { id: "starting-balances", prompt: "Set my starting balances" },
+      { id: "record-income", prompt: "Record my income" },
+      { id: "add-credit-card", prompt: "Add a credit card" },
+      { id: "show-net-worth", prompt: "Show my net worth" },
+    ],
+  },
+  {
+    id: "ask",
+    ideas: [
+      { id: "last-transactions", prompt: "Show my last transactions" },
+      { id: "spent-this-month", prompt: "How much did I spend this month?" },
+      { id: "where-money-went", prompt: "Where did most of my money go last month?" },
+      { id: "compare-months", prompt: "Compare this month's spending to last month" },
+      { id: "spending-by-month", prompt: "Show my spending for the year by month" },
+      { id: "net-worth-trend", prompt: "Show my net worth over the last months" },
+      { id: "total-across-accounts", prompt: "How much do I have across all my accounts?" },
+      { id: "earned-vs-spent", prompt: "How much did I earn vs spend this year?" },
+      { id: "income-this-year", prompt: "Show my income for this year" },
+      { id: "monthly-savings", prompt: "How much am I saving each month?" },
+      { id: "top-payees", prompt: "Which payees do I spend the most with?" },
+      { id: "biggest-purchase", prompt: "What was my biggest purchase this year?" },
+      { id: "last-trip-cost", prompt: "How much did my last trip cost?" },
+      { id: "hobby-spending", prompt: "Show everything I spent on a hobby" },
+      { id: "upcoming-30-days", prompt: "What is coming up in the next 30 days?" },
+      { id: "within-budget", prompt: "Am I within my budget this month?" },
+      { id: "credit-card-balance", prompt: "How much do I owe on my credit card?" },
+      { id: "find-receipt", prompt: "Show me the receipt for a purchase" },
+      { id: "balances-by-currency", prompt: "How much do I have in each currency?" },
+    ],
+  },
+  {
+    id: "log-and-edit",
+    ideas: [
+      { id: "record-refund", prompt: "Record a refund" },
+      { id: "record-transfer", prompt: "Record a transfer between my accounts" },
+      { id: "split-transaction", prompt: "Split my last transaction between two accounts" },
+      { id: "add-note", prompt: "Add a note to a transaction" },
+      { id: "tag-last-trip", prompt: "Tag transactions from my last trip" },
+      { id: "merge-payees", prompt: "Merge two payees that are the same business" },
+      { id: "rename-account", prompt: "Rename an account" },
+      { id: "check-duplicates", prompt: "Check my ledger for duplicates and mistakes" },
+      { id: "find-unusual", prompt: "Find transactions that look unusual" },
+      { id: "reconcile-balance", prompt: "Reconcile my current balance" },
+      { id: "import-latest-statement", prompt: "Import my latest bank statement" },
+      { id: "record-todays-spending", prompt: "Record today's spending" },
+      { id: "correct-last-transaction", prompt: "Correct my last transaction" },
+      { id: "delete-transaction", prompt: "Delete a transaction I added by mistake" },
+      { id: "move-transaction", prompt: "Move a transaction to a different account" },
+      { id: "attach-receipt", prompt: "Attach a receipt to a transaction" },
+      { id: "update-investment-values", prompt: "Update the value of my investments" },
+      { id: "purchase-from-receipt", prompt: "Add a purchase from a receipt" },
+      { id: "record-received-income", prompt: "Record income I received" },
+      { id: "add-another-account", prompt: "Add another account" },
+    ],
+  },
+  {
+    id: "rules",
+    ideas: [
+      { id: "monthly-budget", prompt: "Set a monthly budget and warn me when I get close" },
+      { id: "recurring-bills", prompt: "Set up my recurring bills" },
+      { id: "monthly-salary", prompt: "Set up my monthly salary" },
+      { id: "household-split", prompt: "Set up my household and who pays for what" },
+      { id: "tag-upcoming-trip", prompt: "Tag everything from my upcoming trip" },
+      { id: "import-reminder", prompt: "Remind me to import my bank statement every month" },
+      { id: "what-you-remember", prompt: "What do you remember about me?" },
+      { id: "answer-language", prompt: "Talk to me in my language" },
+      { id: "flag-unusual-on-import", prompt: "Warn me about unusual transactions when I import" },
+      { id: "know-me-better", prompt: "Ask me a few questions to know me better" },
+    ],
+  },
+  {
+    id: "history",
+    ideas: [
+      { id: "changes-today", prompt: "What did you change today?" },
+      { id: "undo-last-change", prompt: "Undo the last change" },
+      { id: "transaction-history", prompt: "Show the history of one transaction" },
+      { id: "undo-last-import", prompt: "Undo everything from my last import" },
+      { id: "restore-deleted", prompt: "Restore a transaction I deleted" },
+      { id: "changes-this-week", prompt: "What changed this week?" },
+    ],
+  },
+  {
+    id: "skills",
+    ideas: [
+      { id: "monthly-payments", prompt: "What am I paying every month?" },
+      { id: "cancel-subscriptions", prompt: "Which subscriptions can I cancel?" },
+      { id: "create-review-skill", prompt: "Create a skill" },
+      { id: "list-skills", prompt: "What skills do I have and what can I do with them?" },
+      { id: "skills-to-add", prompt: "How can I get more skills?" },
+      { id: "subscription-increases", prompt: "Check my subscriptions for price increases" },
+      { id: "what-else-can-you-do", prompt: "What else can you do?" },
+    ],
+  },
+];
+
+/** What is left to deal per group, as idea ids in deal order. A missing or
+ *  empty deck reshuffles the group; ids no longer in the list are skipped, so
+ *  a stored deck survives copy changes. */
+export type PromptIdeaDecks = Partial<Record<PromptIdeaGroup["id"], string[]>>;
+
+/** One visit's hand and the decks to store for the next one. */
+export interface PromptIdeaDeal {
+  ideas: PromptIdea[];
+  decks: PromptIdeaDecks;
+}
+
+/** The ideas in a fresh random order, each position by one `random()` draw
+ *  over what is left, so a constant `random` yields the list's own order. */
+function shuffle(ideas: readonly PromptIdea[], random: () => number): string[] {
+  const pool = [...ideas];
+  return Array.from({ length: pool.length })
+    .flatMap(() => pool.splice(Math.floor(random() * pool.length), 1))
+    .map((idea) => idea.id);
+}
+
+/** Deal `count` ideas from the top of the group's deck, reshuffling the group
+ *  when the deck runs out. An id the new deck repeats from this very hand
+ *  moves to the deck's end, so each idea still shows once per deck. */
+function deal(
+  ideas: readonly PromptIdea[],
+  count: number,
+  deck: readonly string[] | undefined,
+  random: () => number,
+): { ideas: PromptIdea[]; deck: string[] } {
+  const known = new Set(ideas.map((idea) => idea.id));
+  let remaining = [...new Set(deck)].filter((id) => known.has(id));
+  const dealt: string[] = [];
+  while (dealt.length < Math.min(count, ideas.length)) {
+    if (remaining.length === 0) remaining = shuffle(ideas, random);
+    // Non-empty here: a reshuffle has more ids than this hand still needs.
+    const next = remaining.shift() as string;
+    if (dealt.includes(next)) remaining.push(next);
+    else dealt.push(next);
+  }
+  return { ideas: dealt.flatMap((id) => ideas.filter((idea) => idea.id === id)), deck: remaining };
+}
+
+/** The ideas for one New Chat visit, dealt from `decks` (the stored state
+ *  from the last visit; `{}` on the first). A ledger with up to
+ *  GETTING_STARTED_MAX_TRANSACTIONS transactions gets PROMPT_IDEAS_SHOWN
+ *  Getting started ideas; a bigger one gets one idea from each other group,
+ *  in group order, so the set stays diverse. Decks of groups not dealt from
+ *  are carried over untouched. `random` is injectable for deterministic tests. */
+export function dealPromptIdeas(
+  transactionCount: number,
+  decks: PromptIdeaDecks,
+  random: () => number = Math.random,
+): PromptIdeaDeal {
+  const groups =
+    transactionCount <= GETTING_STARTED_MAX_TRANSACTIONS
+      ? PROMPT_IDEA_GROUPS.filter((group) => group.id === "getting-started")
+      : PROMPT_IDEA_GROUPS.filter((group) => group.id !== "getting-started");
+  const count = groups.length === 1 ? PROMPT_IDEAS_SHOWN : 1;
+  const next: PromptIdeaDecks = { ...decks };
+  const ideas = groups.flatMap((group) => {
+    const hand = deal(group.ideas, count, decks[group.id], random);
+    next[group.id] = hand.deck;
+    return hand.ideas;
+  });
+  return { ideas, decks: next };
+}

--- a/packages/desktop/src/renderer/rpc/__tests__/api.test.ts
+++ b/packages/desktop/src/renderer/rpc/__tests__/api.test.ts
@@ -371,6 +371,17 @@ describe("ledgerApi", () => {
       expect(bridge.callsFor("ledger_transactions")).toEqual([undefined]);
     });
   });
+
+  describe("transactionCount()", () => {
+    it("should invoke 'ledger_transaction_count' and resolve the count", async () => {
+      bridge.setHandler("ledger_transaction_count", () => 42);
+
+      const result = await ledgerApi.transactionCount();
+
+      expect(result).toBe(42);
+      expect(bridge.callsFor("ledger_transaction_count")).toEqual([undefined]);
+    });
+  });
 });
 
 describe("pluginsApi", () => {

--- a/packages/desktop/src/renderer/rpc/api.ts
+++ b/packages/desktop/src/renderer/rpc/api.ts
@@ -142,6 +142,8 @@ export const ledgerApi = {
   netWorth: () => api.invoke<NetWorth>("ledger_net_worth"),
   /** Fetch the `hledger print` register (journal order) for the Transactions view. */
   transactions: () => api.invoke<LedgerTransaction[]>("ledger_transactions"),
+  /** Fetch the journal's transaction count (from `hledger stats`) for the prompt ideas. */
+  transactionCount: () => api.invoke<number>("ledger_transaction_count"),
 };
 
 export const pluginsApi = {


### PR DESCRIPTION
- Show five prompt ideas as pills under the composer on the New Chat page, hidden once the chat has messages
- Add the hardcoded idea list in six groups in `promptIdeas.ts`; show the Getting started group while the ledger has up to 10 transactions, otherwise one idea from each other group
- Deal ideas from per-group decks persisted in `localStorage` (`prompt-idea-decks.ts`), reshuffled when a deck runs out, so every idea shows once before any repeats
- Put a clicked idea's text in the composer and focus it, without sending
- Add the `ledger_transaction_count` IPC channel backed by `hledger stats -I`, with `useTransactionCount` in `Thread`
- Add the `prompt_idea_used` analytics event carrying the idea id
- Add unit, component, integration, and e2e tests for the feature