### PR TITLE
docs: add Memory and Workspace pages

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -15,7 +15,7 @@
       },
       {
         "group": "Features",
-        "pages": ["docs/memory", "docs/skills", "docs/plugins", "docs/marketplace"]
+        "pages": ["docs/workspace", "docs/memory", "docs/skills", "docs/plugins", "docs/marketplace"]
       },
       {
         "group": "Guides",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -15,7 +15,7 @@
       },
       {
         "group": "Features",
-        "pages": ["docs/skills", "docs/plugins", "docs/marketplace"]
+        "pages": ["docs/memory", "docs/skills", "docs/plugins", "docs/marketplace"]
       },
       {
         "group": "Guides",

--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -10,7 +10,7 @@ Yes. Everything stays on your machine as plain-text files. Nothing is uploaded u
 
 ## Where is my data stored?
 
-In one folder on your machine, the workspace: `~/.accountant24` by default. It holds your ledger, documents, memory, skills, and settings, all as plain files in a git repository. **Settings → About** shows the path and opens the folder. You can also run the app on a different folder, see [Settings](/docs/settings#workspace).
+In one folder on your machine, the workspace, `~/.accountant24` by default. See [Workspace](/docs/workspace) for more details.
 
 ## Does it work offline?
 

--- a/docs/docs/memory.mdx
+++ b/docs/docs/memory.mdx
@@ -34,4 +34,4 @@ Tell the agent that a fact changed, or ask it to forget one. It fixes or removes
 
 ## Where memory lives
 
-Memory is stored in `memory.md` in your [workspace](/docs/settings#workspace), a plain markdown file you can open and edit by hand. Like your ledger, every change to it is versioned with git.
+Memory is stored in `memory.md` in your [workspace](/docs/workspace), a plain markdown file you can open and edit by hand. Like your ledger, every change to it is versioned with git.

--- a/docs/docs/memory.mdx
+++ b/docs/docs/memory.mdx
@@ -1,0 +1,37 @@
+---
+title: "Memory"
+sidebarTitle: "Memory"
+description: "The agent remembers your preferences, rules, and recurring arrangements across chats, and applies them when they matter."
+---
+
+## What the agent remembers
+
+Memory holds the facts that stay true from one chat to the next, like your default account and currency, or a budget to watch. The agent reads memory before answering every message, so a rule you gave weeks ago still applies today.
+
+Memory is a layer on top of your ledger, not a copy of it. The ledger holds the facts, every transaction with its date, amount, payee, and account. Memory holds what the ledger can't, your preferences, your rules, and what repeats every month. Anything the ledger already answers stays out of memory, so the two never disagree.
+
+The agent combines the two when it books a purchase. The account comes from your ledger history for that payee. The paying account and the currency come from memory when you leave them out. What you say in chat wins over both.
+
+## Teach the agent
+
+Tell the agent in chat, the same way you would tell a person:
+
+> My salary comes in on the 25th.
+
+> I'm visiting Italy from April 10th to 15th. Tag all transactions during this period with the 'trip_italy' tag.
+
+> Remember, I always pay for groceries in cash.
+
+The agent saves the fact on its own. Say “remember” to make sure it’s saved.
+
+## Correct or forget
+
+Tell the agent that a fact changed, or ask it to forget one. It fixes or removes the entry right away.
+
+> My salary now comes in on the 28th.
+
+> Forget the Italy trip.
+
+## Where memory lives
+
+Memory is stored in `memory.md` in your [workspace](/docs/settings#workspace), a plain markdown file you can open and edit by hand. Like your ledger, every change to it is versioned with git.

--- a/docs/docs/settings.mdx
+++ b/docs/docs/settings.mdx
@@ -6,7 +6,7 @@ description: "Where Accountant24 keeps your data, how to run it on a different w
 
 ## Workspace
 
-Everything Accountant24 knows about your money lives in one folder, the workspace: the ledger (`ledger/`), your stored documents (`files/`), the agent's memory (`memory.md`), installed plugins (`plugins/`), chat sessions, provider logins, and the app settings. The folder is a git repository, so every change to your books is recoverable.
+Everything Accountant24 knows about your money lives in one folder, the workspace: the ledger (`ledger/`), your stored documents (`files/`), the agent's [memory](/docs/memory) (`memory.md`), installed plugins (`plugins/`), chat sessions, provider logins, and the app settings. The folder is a git repository, so every change to your books is recoverable.
 
 By default the workspace is `~/.accountant24`, a hidden folder in your home directory. **Settings → About** shows the exact path; click the row to open the folder in the Finder.
 

--- a/docs/docs/settings.mdx
+++ b/docs/docs/settings.mdx
@@ -1,30 +1,10 @@
 ---
 title: "Settings"
 sidebarTitle: "Settings"
-description: "Where Accountant24 keeps your data, how to run it on a different workspace, and every option in its app-settings.json settings file."
+description: "Every option in the app-settings.json settings file."
 ---
 
-## Workspace
-
-Everything Accountant24 knows about your money lives in one folder, the workspace: the ledger (`ledger/`), your stored documents (`files/`), the agent's [memory](/docs/memory) (`memory.md`), installed plugins (`plugins/`), chat sessions, provider logins, and the app settings. The folder is a git repository, so every change to your books is recoverable.
-
-By default the workspace is `~/.accountant24`, a hidden folder in your home directory. **Settings → About** shows the exact path; click the row to open the folder in the Finder.
-
-### Use a different workspace
-
-You can point the app at another folder, for example a second set of books or a demo. Launch it with the `--workspace` flag from the terminal:
-
-```sh
-open -a Accountant24 --args --workspace ~/Demo
-```
-
-The path may be relative or start with `~`. A folder that does not exist yet is created and seeded with a fresh ledger, so a new workspace is just a new path. The flag applies to that launch only; without it the app opens `~/.accountant24` again.
-
-The app refuses to start, with an error message, when `--workspace` has no path or points to a file instead of a folder. It never falls back to another workspace silently.
-
-## App settings
-
-Accountant24 stores its settings in `app-settings.json` in the workspace. The app updates the file when you change options in **Settings**. You can also edit it by hand. Restart the app afterwards to apply the changes.
+Accountant24 stores its settings in `app-settings.json` in the [workspace](/docs/workspace). The app updates the file when you change options in **Settings**. You can also edit it by hand. Restart the app afterwards to apply the changes.
 
 ## `defaultModel`
 

--- a/docs/docs/use-cases.mdx
+++ b/docs/docs/use-cases.mdx
@@ -42,7 +42,7 @@ The agent checks your ledger and gives you a clear answer.
 
 > My food budget is \$600/month, please notify me when I get close.
 
-Tell the agent once, and it remembers and applies it when it matters.
+Tell the agent once, and it remembers and applies it when it matters. See [Memory](/docs/memory) for more details.
 
 ## Extend the agent with skills
 

--- a/docs/docs/workspace.mdx
+++ b/docs/docs/workspace.mdx
@@ -1,0 +1,34 @@
+---
+title: "Workspace"
+sidebarTitle: "Workspace"
+description: "Everything Accountant24 knows about your money lives in one folder on your machine, the workspace."
+---
+
+## Where the workspace is
+
+By default the workspace is `~/.accountant24`, a hidden folder in your home directory. **Settings → About** shows the exact path. Click the row to open the folder in the Finder.
+
+## What the workspace holds
+
+The workspace is a git repository, so every change to your books is recoverable.
+
+| Path                | What it holds                                                           | Versioned with git |
+| ------------------- | ----------------------------------------------------------------------- | ------------------ |
+| `ledger/`           | Your books as plain-text hledger journal files                          | Yes                |
+| `files/`            | The bank statements, receipts, and other documents you attached in chat | Yes                |
+| `memory.md`         | The agent's [memory](/docs/memory)                                      | Yes                |
+| `plugins/`          | Your installed [plugins](/docs/plugins)                                 | Yes                |
+| `app-settings.json` | The [app settings](/docs/settings)                                      | Yes                |
+| `models.json`       | Your local Ollama models, and any custom models you add by hand         | Yes                |
+| `sessions/`         | Your chats                                                              | No                 |
+| `auth.json`         | Your provider logins                                                    | No                 |
+
+## Use a different workspace
+
+You can point the app at another folder, for example a second set of books, or a scratch workspace to try things out. Launch it with the `--workspace` flag from the terminal:
+
+```sh
+open -a Accountant24 --args --workspace ~/Demo
+```
+
+The path may be relative or start with `~`. A folder that does not exist yet is created and seeded with a fresh ledger. The flag applies to that launch only. Without it the app opens `~/.accountant24` again.


### PR DESCRIPTION
- Add a Memory page under Features covering what the agent remembers, how to teach, correct, or forget a fact, and where memory is stored
- Add a Workspace page under Features covering where the workspace is, what it holds and which parts are versioned with git, and how to use a different workspace
- Move the workspace section out of the Settings page and reduce it to the `app-settings.json` reference
- Link the new pages from the Use cases, FAQ, Settings, and Memory pages