### PR TITLE
feat: run plugin scripts with a bundled uv, no Python install needed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Untap untrusted Homebrew taps from the runner image
         run: brew untap aws/tap || true
 
-      - name: Vendor CLI tools (hledger, pdftotext, tesseract)
+      - name: Vendor CLI tools (hledger, pdftotext, tesseract, uv)
         run: npx tsx scripts/vendor-bin.ts
 
       - name: Build renderer + main + extension bundle

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ The Electron desktop app:
 
 `packages/desktop` follows the standard electron-vite layout (`src/main`, `src/preload`, `src/renderer`), plus one addition:
 
-- `src/main/` — Electron main process: window, IPC handlers, the workspace (location `cli.ts` + `env.ts`, `migrations/`, setup `workspace.ts`), the agent (`agent/`), LLM provider connections (`llm-providers/`), vendored binaries (hledger).
+- `src/main/` — Electron main process: window, IPC handlers, the workspace (location `cli.ts` + `env.ts`, `migrations/`, setup `workspace.ts`), the agent (`agent/`), LLM provider connections (`llm-providers/`), vendored binaries (hledger, uv).
 - `src/main/agent/plugins-defaults.ts` — the plugins a new workspace starts with, listed as repositories and installed from the marketplace on first launch. The app bundles no plugin of its own.
 - `src/main/agent/` — the chat runtime: the IPC router plus `host/`, which runs in a single agent-host utilityProcess hosting one pi SDK session per chat. Nothing in `host/` may import Electron APIs.
 - `src/main/llm-providers/` — LLM provider auth, OAuth login, models, Ollama. `llm-providers/` and `agent/` never import each other; their only interface is the workspace files (`auth.json`/`models.json`).

--- a/docs/docs/create-a-plugin.mdx
+++ b/docs/docs/create-a-plugin.mdx
@@ -122,7 +122,41 @@ Put reference material in the skill's `references/` folder. Point the agent at a
 
 ## Helper scripts
 
-Put helper code in the skill's `scripts/` folder, and tell the agent in the instructions when to run it.
+Put helper code in the skill's `scripts/` folder, and tell the agent in the instructions when to run it. Most skills need no script. The agent already has `hledger`, `pdftotext`, `tesseract` and `bash`, plus its own tools to query and change the ledger. Write a script only for a step those cannot do.
+
+Scripts are Python, and the agent runs them with `uv run scripts/<name>.py`. The app ships [uv](https://docs.astral.sh/uv/), a Python runner, so there is nothing to install. The first run downloads Python once, over the network, and keeps it in the workspace. After that, everything runs locally.
+
+Every script opens with an inline metadata header, as [PEP 723](https://peps.python.org/pep-0723/) defines it, that names the Python version and pins the packages the script imports.
+
+Here is an example that reads a spreadsheet the user attached, a format none of the built-in tools open:
+
+```python
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["openpyxl==3.1.5"]
+# ///
+import json
+import sys
+from openpyxl import load_workbook
+
+if len(sys.argv) != 2:
+    print("usage: budget.py budget.xlsx", file=sys.stderr)
+    sys.exit(2)
+
+sheet = load_workbook(sys.argv[1], read_only=True).active
+rows = [[cell.value for cell in row] for row in sheet.iter_rows()]
+print(json.dumps({"rows": rows}))
+```
+
+uv installs the pinned packages into an environment of its own on the first run. Pin every package to an exact version. The script can pull anything from PyPI, and a reader of your repository should see exactly what runs.
+
+Write scripts for the agent, not for a person:
+
+- Take everything as command-line arguments, and never prompt for input.
+- Print the result as JSON on stdout.
+- On failure, print what went wrong on stderr and exit with a non-zero code.
+
+Then name the command in the skill's steps. For this script, tell the agent to run `uv run scripts/budget.py` with the path of the spreadsheet from the skill's folder, and to read the rows it prints.
 
 ## Several skills in one plugin
 
@@ -191,6 +225,7 @@ curl -fsSL https://raw.githubusercontent.com/accountant24/marketplace/main/scrip
 - `plugin.json` at the root, with a `name` that matches the folder and follows the naming rules, and a `description` of what the plugin does.
 - At least one `skills/<name>/SKILL.md`, its frontmatter `name` matching its folder, with a description written for matching.
 - No unknown fields in the manifest.
+- Scripts, if any, are Python files with an inline metadata header and every package pinned to a version.
 - Tested in the app, both from the `/` picker and by asking in your own words.
 - Public repository with the `accountant24-plugin` topic, previewed with the command above.
 

--- a/docs/docs/marketplace.mdx
+++ b/docs/docs/marketplace.mdx
@@ -18,7 +18,7 @@ To report a plugin, open an issue or a pull request against [`blocklist.json`](h
 
 <Warning>
   Accountant24 does not review plugins, and a listing is not a recommendation. A
-  plugin can read and change your financial data, and can run commands on your
+  plugin can read and change your financial data, and can run commands or scripts on your
   computer.
 </Warning>
 

--- a/docs/docs/workspace.mdx
+++ b/docs/docs/workspace.mdx
@@ -22,6 +22,7 @@ The workspace is a git repository, so every change to your books is recoverable.
 | `models.json`       | Your local Ollama models, and any custom models you add by hand         | Yes                |
 | `sessions/`         | Your chats                                                              | No                 |
 | `auth.json`         | Your provider logins                                                    | No                 |
+| `uv/`              | Python and packages for [plugin scripts](/docs/create-a-plugin#helper-scripts), downloaded on first use and safe to delete | No                 |
 
 ## Use a different workspace
 

--- a/packages/desktop/build/entitlements.mac.plist
+++ b/packages/desktop/build/entitlements.mac.plist
@@ -5,7 +5,7 @@
   <!--
     Hardened-runtime entitlements required because the app bundles and spawns
     executables (Electron runs pi under Node with V8 JIT, and we run
-    hledger / pdftotext / tesseract). Without these, notarized launches crash.
+    hledger / pdftotext / tesseract / uv). Without these, notarized launches crash.
   -->
   <key>com.apple.security.cs.allow-jit</key>
   <true/>

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -38,7 +38,8 @@ files:
   - package.json
   - "!**/*.{map,md}"
 
-# Vendored, on-disk resources the agent child reads via env (PATH / TESSDATA_PREFIX)
+# Vendored, on-disk resources (hledger, pdftotext, tesseract, uv, OCR data) the
+# agent child reads via env (PATH / TESSDATA_PREFIX)
 # and `pi -e`. Land under Contents/Resources/ → matches env.ts resourceDir().
 extraResources:
   - from: resources/bin

--- a/packages/desktop/resources/THIRD-PARTY-LICENSES.txt
+++ b/packages/desktop/resources/THIRD-PARTY-LICENSES.txt
@@ -1572,6 +1572,35 @@ Apache License
    limitations under the License.
 
 ================================================================
+uv (uv) 0.12.7 — MIT OR Apache-2.0
+Project: https://github.com/astral-sh/uv
+Corresponding source: https://github.com/astral-sh/uv/releases/tag/0.12.7
+----------------------------------------------------------------
+MIT License
+
+Copyright (c) 2025 Astral Software Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+(Also available under Apache-2.0: https://github.com/astral-sh/uv/blob/0.12.7/LICENSE-APACHE)
+
+================================================================
 Bundled shared libraries
 ----------------------------------------------------------------
 These dynamic libraries are dependencies of the tools above and are

--- a/packages/desktop/resources/bin/README.md
+++ b/packages/desktop/resources/bin/README.md
@@ -1,3 +1,4 @@
 # Vendored native tools (bundled into the .app at build time).
-# Place macOS builds of: hledger, pdftotext (poppler), tesseract here.
-# They are resolved by absolute path via injected PATH (see src/env.rs).
+# hledger, pdftotext (poppler), tesseract and uv are written here by
+# scripts/vendor-bin.ts. They reach the agent's subprocesses through the
+# injected PATH (see src/main/env.ts agentEnv()).

--- a/packages/desktop/src/main/__tests__/env.test.ts
+++ b/packages/desktop/src/main/__tests__/env.test.ts
@@ -46,6 +46,20 @@ describe("workspace paths", () => {
   });
 });
 
+describe("uvDir()", () => {
+  it("should resolve <workspace>/uv", async () => {
+    const prev = process.env.ACCOUNTANT24_WORKSPACE;
+    process.env.ACCOUNTANT24_WORKSPACE = "/ws";
+    try {
+      const mod = await import("../env");
+      expect(mod.uvDir()).toBe(path.join("/ws", "uv"));
+    } finally {
+      if (prev === undefined) delete process.env.ACCOUNTANT24_WORKSPACE;
+      else process.env.ACCOUNTANT24_WORKSPACE = prev;
+    }
+  });
+});
+
 describe("workspaceDir()", () => {
   it("should use ACCOUNTANT24_WORKSPACE verbatim when it is a non-empty path", async () => {
     const prev = process.env.ACCOUNTANT24_WORKSPACE;
@@ -221,6 +235,63 @@ describe("agentEnv()", () => {
       expect(mod.agentEnv().ACCOUNTANT24_DOCS).toBeUndefined();
     } finally {
       Object.defineProperty(process, "resourcesPath", { value: origRes, configurable: true });
+    }
+  });
+
+  it("should keep uv's managed Python under <workspace>/uv/python", async () => {
+    h.app.isPackaged = false;
+    h.app.getAppPath = () => "/app";
+    const prev = process.env.ACCOUNTANT24_WORKSPACE;
+    process.env.ACCOUNTANT24_WORKSPACE = "/ws";
+    h.existsSync.mockReturnValue(false);
+    try {
+      const mod = await import("../env");
+      expect(mod.agentEnv().UV_PYTHON_INSTALL_DIR).toBe(path.join("/ws", "uv", "python"));
+    } finally {
+      if (prev === undefined) delete process.env.ACCOUNTANT24_WORKSPACE;
+      else process.env.ACCOUNTANT24_WORKSPACE = prev;
+    }
+  });
+
+  it("should keep uv's package cache under <workspace>/uv/cache", async () => {
+    h.app.isPackaged = false;
+    h.app.getAppPath = () => "/app";
+    const prev = process.env.ACCOUNTANT24_WORKSPACE;
+    process.env.ACCOUNTANT24_WORKSPACE = "/ws";
+    h.existsSync.mockReturnValue(false);
+    try {
+      const mod = await import("../env");
+      expect(mod.agentEnv().UV_CACHE_DIR).toBe(path.join("/ws", "uv", "cache"));
+    } finally {
+      if (prev === undefined) delete process.env.ACCOUNTANT24_WORKSPACE;
+      else process.env.ACCOUNTANT24_WORKSPACE = prev;
+    }
+  });
+
+  it("should tell uv to use only the Python it manages, never one from the machine", async () => {
+    h.app.isPackaged = false;
+    h.app.getAppPath = () => "/app";
+    h.existsSync.mockReturnValue(false);
+    const mod = await import("../env");
+    expect(mod.agentEnv().UV_PYTHON_PREFERENCE).toBe("only-managed");
+  });
+
+  it("should point the uv variables at the workspace even when nothing is vendored", async () => {
+    h.app.isPackaged = false;
+    h.app.getAppPath = () => "/app";
+    const prev = process.env.ACCOUNTANT24_WORKSPACE;
+    process.env.ACCOUNTANT24_WORKSPACE = "/ws";
+    // Neither bin/ nor uv/ exists: the variables are paths uv creates itself.
+    h.existsSync.mockReturnValue(false);
+    try {
+      const mod = await import("../env");
+      const env = mod.agentEnv();
+      expect(env.UV_PYTHON_INSTALL_DIR).toBe(path.join("/ws", "uv", "python"));
+      expect(env.UV_CACHE_DIR).toBe(path.join("/ws", "uv", "cache"));
+      expect(env.UV_PYTHON_PREFERENCE).toBe("only-managed");
+    } finally {
+      if (prev === undefined) delete process.env.ACCOUNTANT24_WORKSPACE;
+      else process.env.ACCOUNTANT24_WORKSPACE = prev;
     }
   });
 

--- a/packages/desktop/src/main/__tests__/workspace.test.ts
+++ b/packages/desktop/src/main/__tests__/workspace.test.ts
@@ -134,6 +134,12 @@ describe("ensureWorkspace()", () => {
     expect(content).toContain("auth.json");
   });
 
+  test("should keep uv's Python and package cache (uv/) out of the workspace repo", async () => {
+    await ensureWorkspace();
+    const lines = readFileSync(join(BASE, ".gitignore"), "utf-8").split("\n");
+    expect(lines).toContain("uv/");
+  });
+
   test("should produce an output file for every template file", async () => {
     await ensureWorkspace();
     for (const relPath of EXPECTED_TEMPLATE_FILES) {

--- a/packages/desktop/src/main/env.ts
+++ b/packages/desktop/src/main/env.ts
@@ -2,8 +2,9 @@
 //
 // The workspace (~/.accountant24 by default) holds the ledger + auth.json +
 // models.json; PATH exposes the vendored native tools (hledger/pdftotext/
-// tesseract) to the agent's bash/tool subprocesses; TESSDATA_PREFIX points at
-// the OCR data.
+// tesseract/uv) to the agent's bash/tool subprocesses; TESSDATA_PREFIX points
+// at the OCR data; the UV_* variables keep the Python that uv downloads for
+// plugin scripts inside the workspace.
 //
 // ACCOUNTANT24_WORKSPACE is the single channel that names the workspace: set
 // by the `--workspace` launch flag (cli.ts) or by the caller's environment, read
@@ -43,6 +44,13 @@ export function sessionsDir(): string {
   return path.join(workspaceDir(), "sessions");
 }
 
+/** <workspace>/uv — what the vendored uv downloads when a plugin script runs:
+ *  the managed Python (python/) and the package cache (cache/). A cache, safe
+ *  to delete, and git-ignored in the workspace. */
+export function uvDir(): string {
+  return path.join(workspaceDir(), "uv");
+}
+
 /** <workspace>/ledger/main.journal — the ledger's entry point (includes the
  *  other journal files). */
 export function mainJournalPath(): string {
@@ -70,7 +78,7 @@ export function docsDir(): string {
   return path.join(resourceDir(), "docs");
 }
 
-/** Dir holding the vendored native tools (hledger/pdftotext/tesseract). Prepended
+/** Dir holding the vendored native tools (hledger/pdftotext/tesseract/uv). Prepended
  *  to the agent child's PATH; also used to resolve a tool's absolute path when we
  *  run one directly from the main process (which does NOT inherit that PATH). */
 export function binDir(): string {
@@ -116,13 +124,22 @@ export function agentHostConfig(skills: AgentHostSkill[]): AgentHostConfig {
 
 /** Env overrides for the agent host + in-process SDK: workspace + vendored
  *  tools. PI_CODING_AGENT_DIR is redundant for the host itself (agentDir is
- *  passed explicitly) but kept for env parity in the agent's subprocesses. */
+ *  passed explicitly) but kept for env parity in the agent's subprocesses.
+ *
+ *  Plugin scripts run through the vendored uv (`uv run scripts/foo.py`). The
+ *  UV_* variables pin everything it downloads to the workspace and make it
+ *  ignore any Python on the machine: a system Python varies per user, and on
+ *  macOS the /usr/bin/python3 stub pops the developer-tools installer. */
 export function agentEnv(): NodeJS.ProcessEnv {
   const workspace = workspaceDir();
+  const uv = uvDir();
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     ACCOUNTANT24_WORKSPACE: workspace,
     PI_CODING_AGENT_DIR: workspace,
+    UV_PYTHON_INSTALL_DIR: path.join(uv, "python"),
+    UV_CACHE_DIR: path.join(uv, "cache"),
+    UV_PYTHON_PREFERENCE: "only-managed",
   };
   const res = resourceDir();
   const bin = binDir();

--- a/packages/desktop/src/main/migrations/0003-ignore-uv-dir.ts
+++ b/packages/desktop/src/main/migrations/0003-ignore-uv-dir.ts
@@ -1,0 +1,25 @@
+// Plugin scripts run through the vendored uv, which downloads a managed Python
+// and its package cache into <workspace>/uv (see env.ts agentEnv()). The
+// workspace is a git repository and that folder is a cache worth tens of
+// megabytes, so the scaffold's .gitignore lists it from now on; this adds the
+// line to workspaces scaffolded before then.
+
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import type { Migration } from "./runner";
+
+const IGNORE_LINE = "uv/";
+
+export const ignoreUvDir: Migration = {
+  id: "0003-ignore-uv-dir",
+  run({ workspaceDir }) {
+    const file = path.join(workspaceDir, ".gitignore");
+    // No file yet: the workspace scaffold (workspace.ts) writes the template,
+    // which already carries the line.
+    if (!existsSync(file)) return;
+    const text = readFileSync(file, "utf8");
+    if (text.split(/\r?\n/).some((line) => line.trim() === IGNORE_LINE)) return;
+    const separator = text.length === 0 || text.endsWith("\n") ? "" : "\n";
+    appendFileSync(file, `${separator}${IGNORE_LINE}\n`);
+  },
+};

--- a/packages/desktop/src/main/migrations/__tests__/0003-ignore-uv-dir.test.ts
+++ b/packages/desktop/src/main/migrations/__tests__/0003-ignore-uv-dir.test.ts
@@ -1,0 +1,101 @@
+// 0003 over a REAL temp workspace: `uv/` joins the workspace's .gitignore
+// exactly once, whatever the file looked like before, and a workspace that has
+// no .gitignore yet is left to the scaffold.
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ignoreUvDir } from "../0003-ignore-uv-dir";
+import { MIGRATIONS_STATE_FILE, runMigrations } from "../runner";
+
+let home: string;
+const workspace = () => path.join(home, ".accountant24");
+const gitignore = () => path.join(workspace(), ".gitignore");
+const ctx = () => ({ workspaceDir: workspace(), homeDir: home });
+const run = () => ignoreUvDir.run(ctx());
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(tmpdir(), "a24-home-"));
+});
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+function seed(content: string): void {
+  writeFileSync(gitignore(), content);
+}
+
+describe("0003-ignore-uv-dir", () => {
+  beforeEach(() => {
+    mkdirSync(workspace(), { recursive: true });
+  });
+
+  it("should carry the id the runner records", () => {
+    expect(ignoreUvDir.id).toBe("0003-ignore-uv-dir");
+  });
+
+  it("should append uv/ to a .gitignore from the 0.3 scaffold", async () => {
+    seed("auth.json\nsessions/\n");
+    await run();
+    expect(readFileSync(gitignore(), "utf8")).toBe("auth.json\nsessions/\nuv/\n");
+  });
+
+  it("should start a new line first when the file does not end with one", async () => {
+    seed("auth.json\nsessions/");
+    await run();
+    expect(readFileSync(gitignore(), "utf8")).toBe("auth.json\nsessions/\nuv/\n");
+  });
+
+  it("should add the line to an empty .gitignore", async () => {
+    seed("");
+    await run();
+    expect(readFileSync(gitignore(), "utf8")).toBe("uv/\n");
+  });
+
+  it("should leave a .gitignore that already lists uv/ byte-identical", async () => {
+    seed("auth.json\nuv/\nsessions/\n");
+    await run();
+    expect(readFileSync(gitignore(), "utf8")).toBe("auth.json\nuv/\nsessions/\n");
+  });
+
+  it("should recognise the line with surrounding spaces or Windows line endings", async () => {
+    seed("auth.json\r\n  uv/  \r\nsessions/\r\n");
+    await run();
+    expect(readFileSync(gitignore(), "utf8")).toBe("auth.json\r\n  uv/  \r\nsessions/\r\n");
+  });
+
+  it("should not mistake a longer path for the line", async () => {
+    seed("auth.json\nuv/python/\n");
+    await run();
+    expect(readFileSync(gitignore(), "utf8")).toBe("auth.json\nuv/python/\nuv/\n");
+  });
+
+  it("should add the line only once when run twice", async () => {
+    seed("auth.json\n");
+    await run();
+    await run();
+    expect(readFileSync(gitignore(), "utf8")).toBe("auth.json\nuv/\n");
+  });
+
+  it("should create nothing when the workspace has no .gitignore", async () => {
+    await run();
+    expect(existsSync(gitignore())).toBe(false);
+  });
+
+  it("should do nothing when the workspace folder does not exist yet", async () => {
+    rmSync(workspace(), { recursive: true, force: true });
+    await run();
+    expect(existsSync(workspace())).toBe(false);
+  });
+
+  it("should be recorded by the runner after it ran", async () => {
+    seed("auth.json\n");
+    const applied = await runMigrations([ignoreUvDir], ctx());
+    expect(applied).toEqual(["0003-ignore-uv-dir"]);
+    expect(JSON.parse(readFileSync(path.join(workspace(), MIGRATIONS_STATE_FILE), "utf8"))).toEqual({
+      applied: ["0003-ignore-uv-dir"],
+    });
+    expect(readFileSync(gitignore(), "utf8")).toBe("auth.json\nuv/\n");
+  });
+});

--- a/packages/desktop/src/main/migrations/__tests__/index.test.ts
+++ b/packages/desktop/src/main/migrations/__tests__/index.test.ts
@@ -7,8 +7,12 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("electron", () => ({ app: { isPackaged: false, getAppPath: () => "/app" } }));
 
 describe("MIGRATIONS", () => {
-  it("should list the shipped migrations in order, 0001 then 0002", async () => {
+  it("should list the shipped migrations in order, 0001, 0002, then 0003", async () => {
     const { MIGRATIONS } = await import("../index");
-    expect(MIGRATIONS.map((m) => m.id)).toEqual(["0001-relocate-legacy-home", "0002-relocate-legacy-home-over-unused"]);
+    expect(MIGRATIONS.map((m) => m.id)).toEqual([
+      "0001-relocate-legacy-home",
+      "0002-relocate-legacy-home-over-unused",
+      "0003-ignore-uv-dir",
+    ]);
   });
 });

--- a/packages/desktop/src/main/migrations/index.ts
+++ b/packages/desktop/src/main/migrations/index.ts
@@ -5,9 +5,10 @@ import { homedir } from "node:os";
 import { workspaceDir } from "../env";
 import { relocateLegacyHome } from "./0001-relocate-legacy-home";
 import { relocateLegacyHomeOverUnused } from "./0002-relocate-legacy-home-over-unused";
+import { ignoreUvDir } from "./0003-ignore-uv-dir";
 import { type Migration, runMigrations } from "./runner";
 
-export const MIGRATIONS: readonly Migration[] = [relocateLegacyHome, relocateLegacyHomeOverUnused];
+export const MIGRATIONS: readonly Migration[] = [relocateLegacyHome, relocateLegacyHomeOverUnused, ignoreUvDir];
 
 /** Run the migrations the active workspace has not seen yet. */
 export function runPendingMigrations(): Promise<string[]> {

--- a/packages/desktop/src/main/template/.gitignore
+++ b/packages/desktop/src/main/template/.gitignore
@@ -1,2 +1,3 @@
 auth.json
 sessions/
+uv/

--- a/packages/desktop/src/renderer/components/accountant24/settings/plugin-dialogs.tsx
+++ b/packages/desktop/src/renderer/components/accountant24/settings/plugin-dialogs.tsx
@@ -249,8 +249,8 @@ function InstallPluginForm({
             ours, so "not reviewed" would be false for them. */}
         {!entry.official && (
           <WarningBanner title="Not reviewed by Accountant24">
-            The plugin can read and change your financial data, and run commands on your computer. Look through the
-            plugin repository before you install it.{" "}
+            The plugin can read and change your financial data, and run commands or scripts on your computer. Look
+            through the plugin repository before you install it.{" "}
             <ExternalLink href="https://accountant24.ai/docs/marketplace#install-only-plugins-you-trust">
               Learn more
             </ExternalLink>

--- a/scripts/vendor-bin.ts
+++ b/scripts/vendor-bin.ts
@@ -1,17 +1,31 @@
 // Vendors the external CLI tools the app shells out to (hledger, pdftotext,
-// tesseract) into packages/desktop/resources so electron-builder bundles them
-// into Contents/Resources. Run on the matching-arch macOS runner BEFORE the
-// build — it installs the tools via Homebrew, relocates their non-system dylibs
-// next to the binaries (so they run on a user Mac without Homebrew), copies the
-// English OCR data, ad-hoc signs everything (required for arm64 to launch while
-// the app is unsigned), and writes THIRD-PARTY-LICENSES.txt so the bundled GPL
-// tools (hledger, poppler) ship with their license + corresponding-source offer.
-// Developer-ID re-signing happens later in the electron-builder signing pass.
+// tesseract, uv) into packages/desktop/resources so electron-builder bundles
+// them into Contents/Resources. Run on the matching-arch macOS runner BEFORE
+// the build — it installs the brew tools via Homebrew, relocates their
+// non-system dylibs next to the binaries (so they run on a user Mac without
+// Homebrew), downloads the pinned uv release and verifies its checksum, copies
+// the English OCR data, ad-hoc signs everything (required for arm64 to launch
+// while the app is unsigned), and writes THIRD-PARTY-LICENSES.txt so the
+// bundled GPL tools (hledger, poppler) ship with their license +
+// corresponding-source offer. Developer-ID re-signing happens later in the
+// electron-builder signing pass.
 //
 // Usage: tsx scripts/vendor-bin.ts
 
 import { spawnSync } from "node:child_process";
-import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -45,6 +59,76 @@ const TOOLS = [
   { formula: "tesseract", exe: "tesseract" },
 ];
 
+// uv runs plugin helper scripts (`uv run scripts/foo.py`, with a PEP 723
+// header naming the Python version and packages) and downloads a managed
+// Python into the workspace on first use — the app bundles uv, not Python.
+// Not a brew formula: Astral publishes one self-contained binary per target
+// (system libraries only, so no dylib relocation), pinned here by version and
+// by the sha256 of the release asset. Only the Apple Silicon build is pinned,
+// since that is the only target the app ships (see electron-builder.yml);
+// bumping uv means editing the version and the hash together.
+const UV_VERSION = "0.12.7";
+const UV_TARGET = "aarch64-apple-darwin";
+const UV_SHA256 = "127ebdda7ad953cdf198e964b570ea5771b85467ea93eb7cb6d6f8e6f55408f3";
+
+/** GET a URL into memory (release assets redirect to a CDN; fetch follows).
+ *  GitHub answers with a 5xx now and then; three tries before giving up. */
+async function download(url: string, attempts = 3): Promise<Buffer> {
+  for (let attempt = 1; ; attempt++) {
+    const res = await fetch(url).catch((err: unknown) => err as Error);
+    if (!(res instanceof Error) && res.ok) return Buffer.from(await res.arrayBuffer());
+    const reason = res instanceof Error ? res.message : `${res.status} ${res.statusText}`;
+    if (attempt >= attempts || (!(res instanceof Error) && res.status < 500)) {
+      throw new Error(`Failed to download ${url}: ${reason}`);
+    }
+    console.log(`[vendor-bin] ${reason} for ${url}, retrying (${attempt}/${attempts})`);
+    await new Promise((r) => setTimeout(r, 2000 * attempt));
+  }
+}
+
+/** Download the pinned uv release, verify its sha256, and put the `uv`
+ *  binary (not `uvx`, which the app never calls) into BIN. Returns the
+ *  vendored path so it gets signed with the other binaries. */
+async function vendorUv(): Promise<string> {
+  if (process.platform !== "darwin" || process.arch !== "arm64") {
+    throw new Error(`uv ${UV_VERSION} is pinned for ${UV_TARGET} only, got ${process.platform}-${process.arch}`);
+  }
+  const asset = `uv-${UV_TARGET}.tar.gz`;
+  const url = `https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${asset}`;
+  console.log(`[vendor-bin] uv ${UV_VERSION} (${asset})`);
+
+  const buf = await download(url);
+  const actual = createHash("sha256").update(buf).digest("hex");
+  if (actual !== UV_SHA256) {
+    throw new Error(`SHA256 mismatch for ${asset}: expected ${UV_SHA256}, got ${actual}`);
+  }
+
+  // The archive holds one folder, uv-<target>/, with uv and uvx inside.
+  const tmp = mkdtempSync(join(tmpdir(), "a24-uv-"));
+  try {
+    const archive = join(tmp, asset);
+    writeFileSync(archive, buf);
+    run("tar", ["xzf", archive, "-C", tmp]);
+    const src = join(tmp, `uv-${UV_TARGET}`, "uv");
+    if (!existsSync(src)) throw new Error(`Expected uv inside ${asset}`);
+    const dest = join(BIN, "uv");
+    copyFileSync(src, dest);
+    chmodSync(dest, 0o755);
+    const version = capture(dest, ["--version"]);
+    if (!version.startsWith(`uv ${UV_VERSION}`)) throw new Error(`Vendored uv reports "${version}"`);
+    return dest;
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+/** uv's license text (dual MIT / Apache-2.0; the MIT text is embedded, the
+ *  Apache one is a link away at the same tag) for THIRD-PARTY-LICENSES.txt. */
+async function uvLicenseText(): Promise<string> {
+  const buf = await download(`https://raw.githubusercontent.com/astral-sh/uv/${UV_VERSION}/LICENSE-MIT`);
+  return buf.toString("utf8").trim();
+}
+
 type BrewMeta = { version: string; license: string; source: string; homepage: string };
 
 /** Read metadata (version, SPDX license, source URL) for formulae in one call. */
@@ -75,7 +159,7 @@ function licenseText(formula: string): string {
 
 /** Write THIRD-PARTY-LICENSES.txt: per-tool version + SPDX + corresponding-source
  *  URL + license text, plus an appendix of the bundled shared libraries. */
-function writeLicenses(): void {
+function writeLicenses(uvLicense: string): void {
   const meta = brewInfo(TOOLS.map((t) => t.formula));
   const lines: string[] = [
     "Accountant24 — Third-Party Licenses",
@@ -98,6 +182,18 @@ function writeLicenses(): void {
       "",
     );
   }
+  // Not a brew formula, so its metadata is pinned here with the binary.
+  lines.push(
+    "================================================================",
+    `uv (uv) ${UV_VERSION} — MIT OR Apache-2.0`,
+    "Project: https://github.com/astral-sh/uv",
+    `Corresponding source: https://github.com/astral-sh/uv/releases/tag/${UV_VERSION}`,
+    "----------------------------------------------------------------",
+    uvLicense,
+    "",
+    `(Also available under Apache-2.0: https://github.com/astral-sh/uv/blob/${UV_VERSION}/LICENSE-APACHE)`,
+    "",
+  );
   const libs = existsSync(LIB) ? readdirSync(LIB).filter((f) => f.endsWith(".dylib")) : [];
   lines.push(
     "================================================================",
@@ -114,7 +210,7 @@ function writeLicenses(): void {
   console.log(`[vendor-bin] wrote ${LICENSES} (${libs.length} bundled libs listed)`);
 }
 
-function main() {
+async function main() {
   console.log(`[vendor-bin] arch=${process.arch}`);
 
   // Start from a clean bin/ (keep the tracked README.md) and lib/.
@@ -149,21 +245,27 @@ function main() {
     ]);
   }
 
-  // 3. English OCR data (the app points TESSDATA_PREFIX at resources/tessdata).
+  // 3. uv: a pinned GitHub release, checksum-verified, no relocation needed.
+  bins.push(await vendorUv());
+
+  // 4. English OCR data (the app points TESSDATA_PREFIX at resources/tessdata).
   const tessShare = join(capture("brew", ["--prefix", "tesseract"]), "share", "tessdata");
   const eng = join(tessShare, "eng.traineddata");
   if (!existsSync(eng)) throw new Error(`eng.traineddata not found at ${eng}`);
   copyFileSync(eng, join(TESSDATA, "eng.traineddata"));
 
-  // 4. Ad-hoc sign the relocated dylibs first, then the binaries, so they launch
+  // 5. Ad-hoc sign the relocated dylibs first, then the binaries, so they launch
   //    on arm64 (Developer-ID re-signing happens later, with notarization).
   const dylibs = readdirSync(LIB).filter((f) => f.endsWith(".dylib")).map((f) => join(LIB, f));
   for (const f of [...dylibs, ...bins]) run("codesign", ["--force", "--sign", "-", f]);
 
-  // 5. Emit the third-party license notice for the bundled GPL/permissive tools.
-  writeLicenses();
+  // 6. Emit the third-party license notice for the bundled GPL/permissive tools.
+  writeLicenses(await uvLicenseText());
 
-  console.log(`[vendor-bin] ✓ vendored ${TOOLS.map((t) => t.exe).join(", ")} + eng.traineddata + licenses`);
+  console.log(`[vendor-bin] ✓ vendored ${TOOLS.map((t) => t.exe).join(", ")}, uv + eng.traineddata + licenses`);
 }
 
-main();
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
- Vendor `uv` 0.12.7 (Apple Silicon build, pinned by version and sha256) in `scripts/vendor-bin.ts`, next to hledger, pdftotext and tesseract, and add its license to `THIRD-PARTY-LICENSES.txt`
- Set `UV_PYTHON_INSTALL_DIR`, `UV_CACHE_DIR` and `UV_PYTHON_PREFERENCE=only-managed` in `agentEnv()` so uv keeps the managed Python and its cache under `<workspace>/uv`
- Add `uv/` to the workspace `.gitignore` template, and migration `0003-ignore-uv-dir` for existing workspaces
- Say "run commands or scripts on your computer" in the install dialog warning and in the Marketplace docs
- Rewrite the Helper scripts section of Create a plugin: Python only, `uv run scripts/<name>.py`, PEP 723 header with pinned packages, one example script, rules for arguments, output and errors
- Add the `uv/` row to the Workspace docs page