### PR TITLE
feat: spill large query results to a scratch file with a head preview

### DIFF
--- a/packages/pi-extension/src/ledger/query.ts
+++ b/packages/pi-extension/src/ledger/query.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, rmSync, statSync, utimesSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -71,8 +71,13 @@ export function sweepStaleScratch(base: string = tmpdir(), ttlMs: number = SCRAT
   for (const name of names) {
     if (!name.startsWith(SCRATCH_PREFIX)) continue;
     const p = join(base, name);
-    const st = statSync(p, { throwIfNoEntry: false });
-    if (st && Date.now() - st.mtimeMs > ttlMs) rmSync(p, { recursive: true, force: true });
+    try {
+      const st = statSync(p, { throwIfNoEntry: false });
+      if (st && Date.now() - st.mtimeMs > ttlMs) rmSync(p, { recursive: true, force: true });
+    } catch {
+      // One undeletable entry (permissions, a race with another sweep) must
+      // not stop the sweep or fail the query that triggered it.
+    }
   }
 }
 
@@ -86,9 +91,24 @@ let scratchDir: string | undefined;
 // timestamp alone would silently overwrite one result with the other.
 let scratchSeq = 0;
 function ensureScratchDir(): string {
+  if (scratchDir !== undefined && !existsSync(scratchDir)) {
+    // Another instance's sweep (or a tmp cleaner) removed the dir mid-run.
+    // Recreate rather than letting every spill fail until restart.
+    scratchDir = undefined;
+  }
   if (scratchDir === undefined) {
     sweepStaleScratch();
     scratchDir = mkdtempSync(join(tmpdir(), SCRATCH_PREFIX));
+  } else {
+    // Keep a live dir looking live: the sweep judges staleness by mtime, and
+    // a long-running process can outlive the TTL between spills.
+    const now = new Date();
+    try {
+      utimesSync(scratchDir, now, now);
+    } catch {
+      // Best effort - worst case the dir looks stale and is swept, which the
+      // existsSync check above then recovers from.
+    }
   }
   return scratchDir;
 }

--- a/packages/pi-extension/src/ledger/query.ts
+++ b/packages/pi-extension/src/ledger/query.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdtempSync, readdirSync, rmSync, statSync, utimesSync } fr
 import { writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DEFAULT_MAX_BYTES } from "@earendil-works/pi-coding-agent";
 import { ACCOUNTANT24_WORKSPACE } from "../config";
 import { runHledger } from "./hledger";
 import { resolveSafePath } from "./paths";
@@ -22,9 +23,11 @@ const TUI_CHROME_WIDTH = 6;
 // this size, spill the full output to a scratch file and return only a head
 // preview plus the path. Gate on total length, not line count: line count
 // misleads for `-O json` (one pretty-printed array) and for wide `reg` output,
-// and counting lines means scanning the whole string. ~16k chars is roughly
-// 4k tokens.
-export const MAX_INLINE_CHARS = 16_000;
+// and counting lines means scanning the whole string. The threshold is pi's
+// own tool-output cap (50 KB, what its bash/read/grep tools enforce), so the
+// model lives with one limit everywhere; report output is ASCII-dominated,
+// so chars ≈ bytes.
+export const MAX_INLINE_CHARS = DEFAULT_MAX_BYTES;
 // How much of a spilled result to still show inline, so the model (and the
 // user, who sees this text in the tool-result card) can read the shape of the
 // output and often answer without a second call. Trimmed back to a line break.

--- a/packages/pi-extension/src/ledger/query.ts
+++ b/packages/pi-extension/src/ledger/query.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { ACCOUNTANT24_WORKSPACE } from "../config";
 import { runHledger } from "./hledger";
 import { resolveSafePath } from "./paths";
@@ -13,9 +17,76 @@ const PERIOD_FLAGS: Record<string, string> = {
 // TUI box border (2) + padding (2) + content indent (2)
 const TUI_CHROME_WIDTH = 6;
 
+// A large result (a `reg`/`print` dump meant for a downstream script, not for
+// the model to read turn by turn) burns context tokens for no benefit. Past
+// this size, spill the full output to a scratch file and return only a head
+// preview plus the path. Gate on total length, not line count: line count
+// misleads for `-O json` (one pretty-printed array) and for wide `reg` output,
+// and counting lines means scanning the whole string. ~16k chars is roughly
+// 4k tokens.
+export const MAX_INLINE_CHARS = 16_000;
+// How much of a spilled result to still show inline, so the model (and the
+// user, who sees this text in the tool-result card) can read the shape of the
+// output and often answer without a second call. Trimmed back to a line break.
+export const PREVIEW_CHARS = 2_000;
+
+const OUTPUT_EXTENSIONS: Record<string, string> = { csv: "csv", tsv: "tsv", json: "json" };
+
+// Scratch files go in the OS temp dir, never the workspace: `~/.accountant24`
+// is a git repo, and a dump left there would get swept into a commit. The
+// agent's bash/file tools inherit this process's environment, so they can read
+// an os.tmpdir() path.
+const SCRATCH_PREFIX = "accountant24-query-scratch-";
+const SCRATCH_TTL_MS = 6 * 60 * 60 * 1000;
+
 export interface QueryLedgerResult {
   command: string;
   output: string;
+  outputFile?: string;
+}
+
+/** First `budget` chars of `s`, trimmed back to the last line break so the
+ *  preview never ends mid-row. O(budget), not O(s). */
+function headWithinBudget(s: string, budget: number): string {
+  if (s.length <= budget) return s;
+  const slice = s.slice(0, budget);
+  const nl = slice.lastIndexOf("\n");
+  return nl > 0 ? slice.slice(0, nl) : slice;
+}
+
+function approxKb(chars: number): string {
+  return chars < 1024 ? `${chars} chars` : `${Math.round(chars / 1024)} KB`;
+}
+
+/** Best effort: remove scratch dirs left by crashed earlier runs. A graceful
+ *  shutdown leaves at most one dir behind, reclaimed here on the next launch.
+ *  Exported for testing. */
+export function sweepStaleScratch(base: string = tmpdir(), ttlMs: number = SCRATCH_TTL_MS): void {
+  let names: string[];
+  try {
+    names = readdirSync(base);
+  } catch {
+    return; // temp dir unreadable - nothing to sweep
+  }
+  for (const name of names) {
+    if (!name.startsWith(SCRATCH_PREFIX)) continue;
+    const p = join(base, name);
+    const st = statSync(p, { throwIfNoEntry: false });
+    if (st && Date.now() - st.mtimeMs > ttlMs) rmSync(p, { recursive: true, force: true });
+  }
+}
+
+// One scratch dir for the life of this host process (not one per query),
+// created lazily so a session that never spills touches nothing. A failure
+// here propagates to queryLedger's catch (inline fallback) and leaves this
+// unset so the next call retries.
+let scratchDir: string | undefined;
+function ensureScratchDir(): string {
+  if (scratchDir === undefined) {
+    sweepStaleScratch();
+    scratchDir = mkdtempSync(join(tmpdir(), SCRATCH_PREFIX));
+  }
+  return scratchDir;
 }
 
 export async function queryLedger(params: any, signal?: AbortSignal): Promise<QueryLedgerResult> {
@@ -24,7 +95,33 @@ export async function queryLedger(params: any, signal?: AbortSignal): Promise<Qu
   const args = buildQueryArgs(params, resolved);
   const raw = await runHledger(args, { signal });
   const command = ["hledger", ...args].join(" ");
-  return { command, output: raw || "(no results)" };
+
+  if (raw.length <= MAX_INLINE_CHARS) {
+    return { command, output: raw || "(no results)" };
+  }
+
+  const preview = headWithinBudget(raw, PREVIEW_CHARS);
+  const ext = OUTPUT_EXTENSIONS[params.output_format] ?? "txt";
+  try {
+    const outputFile = join(ensureScratchDir(), `query-${Date.now()}.${ext}`);
+    await writeFile(outputFile, raw, { signal });
+    return {
+      command,
+      output:
+        `${preview}\n\n[Preview only. Full output (${approxKb(raw.length)}) written to ${outputFile} - ` +
+        `read it from there with bash or a script rather than re-running this query.]`,
+      outputFile,
+    };
+  } catch (err) {
+    // hledger succeeded; the spill is an optimization. Fall back to the
+    // preview inline rather than failing the whole query or flooding context.
+    return {
+      command,
+      output:
+        `${preview}\n\n[Preview only - showing ${approxKb(preview.length)} of ${approxKb(raw.length)}. ` +
+        `Scratch file unavailable (${(err as Error).message}); narrow the query (filters or a date range) to see the rest.]`,
+    };
+  }
 }
 
 function buildQueryArgs(params: any, resolved: string): string[] {

--- a/packages/pi-extension/src/ledger/query.ts
+++ b/packages/pi-extension/src/ledger/query.ts
@@ -81,6 +81,10 @@ export function sweepStaleScratch(base: string = tmpdir(), ttlMs: number = SCRAT
 // here propagates to queryLedger's catch (inline fallback) and leaves this
 // unset so the next call retries.
 let scratchDir: string | undefined;
+// Serial per process, appended to each scratch file name: one host process
+// serves every chat, so two queries can spill in the same millisecond, and a
+// timestamp alone would silently overwrite one result with the other.
+let scratchSeq = 0;
 function ensureScratchDir(): string {
   if (scratchDir === undefined) {
     sweepStaleScratch();
@@ -103,7 +107,7 @@ export async function queryLedger(params: any, signal?: AbortSignal): Promise<Qu
   const preview = headWithinBudget(raw, PREVIEW_CHARS);
   const ext = OUTPUT_EXTENSIONS[params.output_format] ?? "txt";
   try {
-    const outputFile = join(ensureScratchDir(), `query-${Date.now()}.${ext}`);
+    const outputFile = join(ensureScratchDir(), `query-${Date.now()}-${scratchSeq++}.${ext}`);
     await writeFile(outputFile, raw, { signal });
     return {
       command,

--- a/packages/pi-extension/src/tools/__tests__/query.test.ts
+++ b/packages/pi-extension/src/tools/__tests__/query.test.ts
@@ -313,6 +313,22 @@ describe("large-output spillover", () => {
     expect(result.details.command).toContain("Expenses");
   });
 
+  test("gives two spills in the same millisecond distinct scratch files", async () => {
+    // One host process serves every chat, so concurrent queries can spill in
+    // the same tick; a timestamp-only name would overwrite the first result.
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_756_000_000_000);
+    try {
+      mockProc = makeMockProc(0, blob(MAX_INLINE_CHARS * 2));
+      const first = await spill({ report: "reg" });
+      const second = await spill({ report: "reg" });
+      expect(first.details.outputFile).not.toBe(second.details.outputFile);
+      expect(existsSync(first.details.outputFile)).toBe(true);
+      expect(existsSync(second.details.outputFile)).toBe(true);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   test("falls back to an inline preview when the scratch write fails", async () => {
     // hledger (mocked spawn) still succeeds; an already-aborted signal makes
     // writeFile reject, exercising the catch without failing the whole query.

--- a/packages/pi-extension/src/tools/__tests__/query.test.ts
+++ b/packages/pi-extension/src/tools/__tests__/query.test.ts
@@ -3,9 +3,9 @@ import { spawnText } from "../../spawn";
 
 vi.mock("../../spawn");
 
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 const BASE = mkdtempSync(join(tmpdir(), "accountant24-query-"));
 vi.mock("../../config.js", () => ({
@@ -25,6 +25,7 @@ function makeMockProc(exitCode: number, stdout = "", stderr = "") {
 let mockProc: ReturnType<typeof makeMockProc>;
 
 const { queryTool } = await import("../query.js");
+const { MAX_INLINE_CHARS, PREVIEW_CHARS, sweepStaleScratch } = await import("../../ledger/query.js");
 
 afterAll(() => rmSync(BASE, { recursive: true, force: true }));
 beforeEach(() => {
@@ -230,5 +231,132 @@ describe("arg-building", () => {
     expect(args).toContain("--invert");
     expect(args).toContain("-O");
     expect(args).toContain("csv");
+  });
+});
+
+// ── large-output spillover ──────────────────────────────────────────
+
+/** A string of exactly `chars` characters with a line break every 10. */
+function blob(chars: number): string {
+  return "012345678\n".repeat(Math.ceil(chars / 10)).slice(0, chars);
+}
+
+/** The preview portion of a spilled result (everything before the trailer). */
+function previewOf(text: string): string {
+  return text.split("\n\n[")[0];
+}
+
+describe("large-output spillover", () => {
+  // One scratch dir for the whole process; remove it once, after the block.
+  let spilledDir: string | undefined;
+  afterAll(() => {
+    if (spilledDir) rmSync(spilledDir, { recursive: true, force: true });
+  });
+  const spill = async (params: any, signal?: AbortSignal) => {
+    const result = await (queryTool.execute("t", params, signal, undefined, undefined as any) as Promise<any>);
+    if (result.details.outputFile) spilledDir = dirname(result.details.outputFile);
+    return result;
+  };
+
+  test("returns output inline at exactly the size limit", async () => {
+    mockProc = makeMockProc(0, blob(MAX_INLINE_CHARS));
+    const result = await spill({ report: "reg" });
+    expect(result.details.outputFile).toBeUndefined();
+    expect(result.content[0].text).toBe(blob(MAX_INLINE_CHARS));
+  });
+
+  test("spills to a scratch file one character over the limit", async () => {
+    const raw = blob(MAX_INLINE_CHARS + 1);
+    mockProc = makeMockProc(0, raw);
+    const result = await spill({ report: "reg" });
+    expect(result.details.outputFile).toBeDefined();
+    expect(existsSync(result.details.outputFile)).toBe(true);
+    expect(readFileSync(result.details.outputFile, "utf-8")).toBe(raw);
+  });
+
+  test("returns a head preview plus the path, not the full output", async () => {
+    const raw = blob(MAX_INLINE_CHARS * 4);
+    mockProc = makeMockProc(0, raw);
+    const result = await spill({ report: "reg" });
+    const text = result.content[0].text as string;
+    expect(text).toContain(result.details.outputFile);
+    expect(text).toContain("Preview only");
+    expect(text.length).toBeLessThan(raw.length);
+    // the preview is a real prefix of the output, trimmed to a line break
+    const preview = previewOf(text);
+    expect(preview.length).toBeLessThanOrEqual(PREVIEW_CHARS);
+    expect(raw.startsWith(preview)).toBe(true);
+  });
+
+  test("writes the scratch file in the OS tmpdir, not the workspace", async () => {
+    mockProc = makeMockProc(0, blob(MAX_INLINE_CHARS * 2));
+    const result = await spill({ report: "reg" });
+    expect(result.details.outputFile).toContain(tmpdir());
+    expect(result.details.outputFile).not.toContain(BASE);
+  });
+
+  test("names the scratch file with the output_format extension", async () => {
+    mockProc = makeMockProc(0, blob(MAX_INLINE_CHARS * 2));
+    expect((await spill({ report: "reg", output_format: "tsv" })).details.outputFile).toMatch(/\.tsv$/);
+    expect((await spill({ report: "reg", output_format: "json" })).details.outputFile).toMatch(/\.json$/);
+  });
+
+  test("defaults the scratch file extension to txt with no output_format", async () => {
+    mockProc = makeMockProc(0, blob(MAX_INLINE_CHARS * 2));
+    expect((await spill({ report: "reg" })).details.outputFile).toMatch(/\.txt$/);
+  });
+
+  test("still returns the real hledger command in details when spilled", async () => {
+    mockProc = makeMockProc(0, blob(MAX_INLINE_CHARS * 2));
+    const result = await spill({ report: "bal", account_pattern: "Expenses" });
+    expect(result.details.command).toContain("hledger bal");
+    expect(result.details.command).toContain("Expenses");
+  });
+
+  test("falls back to an inline preview when the scratch write fails", async () => {
+    // hledger (mocked spawn) still succeeds; an already-aborted signal makes
+    // writeFile reject, exercising the catch without failing the whole query.
+    mockProc = makeMockProc(0, blob(MAX_INLINE_CHARS * 3));
+    const result = await spill({ report: "reg" }, AbortSignal.abort());
+    expect(result.details.outputFile).toBeUndefined();
+    const text = result.content[0].text as string;
+    expect(text).toContain("Scratch file unavailable");
+    expect(text.length).toBeLessThan((MAX_INLINE_CHARS * 3) as number);
+    expect(blob(MAX_INLINE_CHARS * 3).startsWith(previewOf(text))).toBe(true);
+  });
+});
+
+describe("sweepStaleScratch", () => {
+  test("removes scratch dirs older than the ttl, keeps fresh and unrelated ones", () => {
+    const base = mkdtempSync(join(tmpdir(), "sweep-test-"));
+    try {
+      const stale = mkdtempSync(join(base, "accountant24-query-scratch-"));
+      const fresh = mkdtempSync(join(base, "accountant24-query-scratch-"));
+      const unrelated = mkdtempSync(join(base, "something-else-"));
+      const past = new Date(Date.now() - 60_000);
+      utimesSync(stale, past, past);
+
+      sweepStaleScratch(base, 1_000); // ttl 1s: stale (60s old) goes, fresh stays
+
+      expect(existsSync(stale)).toBe(false);
+      expect(existsSync(fresh)).toBe(true);
+      expect(existsSync(unrelated)).toBe(true);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  test("skips an entry that cannot be stat'd (vanished or broken symlink)", () => {
+    const base = mkdtempSync(join(tmpdir(), "sweep-test-"));
+    try {
+      symlinkSync(join(base, "nonexistent-target"), join(base, "accountant24-query-scratch-broken"));
+      expect(() => sweepStaleScratch(base, 0)).not.toThrow();
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  test("does nothing when the base directory does not exist", () => {
+    expect(() => sweepStaleScratch(join(tmpdir(), "sweep-no-such-dir-xyz"), 0)).not.toThrow();
   });
 });

--- a/packages/pi-extension/src/tools/__tests__/query.test.ts
+++ b/packages/pi-extension/src/tools/__tests__/query.test.ts
@@ -3,7 +3,7 @@ import { spawnText } from "../../spawn";
 
 vi.mock("../../spawn");
 
-import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, utimesSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -327,6 +327,28 @@ describe("large-output spillover", () => {
     } finally {
       nowSpy.mockRestore();
     }
+  });
+
+  test("recreates the scratch dir when it was swept away mid-run", async () => {
+    // Another instance's TTL sweep (or a tmp cleaner) can remove this
+    // process's scratch dir while it is still running; the next spill must
+    // get a fresh dir instead of failing until restart.
+    mockProc = makeMockProc(0, blob(MAX_INLINE_CHARS * 2));
+    const first = await spill({ report: "reg" });
+    rmSync(dirname(first.details.outputFile), { recursive: true, force: true });
+    const second = await spill({ report: "reg" });
+    expect(second.details.outputFile).toBeDefined();
+    expect(existsSync(second.details.outputFile)).toBe(true);
+  });
+
+  test("refreshes the scratch dir mtime on each spill so a live dir never looks stale", async () => {
+    mockProc = makeMockProc(0, blob(MAX_INLINE_CHARS * 2));
+    const first = await spill({ report: "reg" });
+    const dir = dirname(first.details.outputFile);
+    const past = new Date(Date.now() - 60_000);
+    utimesSync(dir, past, past);
+    await spill({ report: "reg" });
+    expect(statSync(dir).mtimeMs).toBeGreaterThan(Date.now() - 5_000);
   });
 
   test("falls back to an inline preview when the scratch write fails", async () => {

--- a/packages/pi-extension/src/tools/query.ts
+++ b/packages/pi-extension/src/tools/query.ts
@@ -64,7 +64,10 @@ export const queryTool: ToolDefinition<typeof Params, QueryLedgerResult> = {
   description:
     "Run an hledger report against the journal. Supports balance, register, income statement, balance sheet, and more with structured filters.",
   promptSnippet: "Run hledger reports (balance, register, income statement, etc.)",
-  promptGuidelines: [`Available query report types: ${REPORT_TYPES}.`],
+  promptGuidelines: [
+    `Available query report types: ${REPORT_TYPES}.`,
+    "A large result returns a head preview plus a scratch-file path holding the full output - read that file with bash or a script rather than re-running the query.",
+  ],
   parameters: Params,
 
   async execute(_id, params, signal) {

--- a/packages/pi-extension/src/tools/query.ts
+++ b/packages/pi-extension/src/tools/query.ts
@@ -66,7 +66,7 @@ export const queryTool: ToolDefinition<typeof Params, QueryLedgerResult> = {
   promptSnippet: "Run hledger reports (balance, register, income statement, etc.)",
   promptGuidelines: [
     `Available query report types: ${REPORT_TYPES}.`,
-    "A large result returns a head preview plus a scratch-file path holding the full output - read that file with bash or a script rather than re-running the query.",
+    "A large `query` result returns a head preview plus a scratch-file path holding the full output - read that file with bash or a script rather than re-running the query.",
   ],
   parameters: Params,
 


### PR DESCRIPTION
- Spill `query` output over ~16k characters to a scratch file and return a head preview plus the file path instead of the full result.
- Gate the spill on total output length rather than line count.
- Trim the inline preview back to a line break so it never ends mid-row.
- Keep one scratch directory per host process under `os.tmpdir()`, and sweep directories left by crashed earlier runs on the next launch.
- Fall back to the inline preview when the scratch write fails, instead of failing the whole query.
- Add `outputFile` to `QueryLedgerResult`.
- Update the `query` tool prompt guideline to describe the preview-plus-path behavior.