### PR TITLE
fix: web analytics for the website

### DIFF
--- a/docs/analytics.js
+++ b/docs/analytics.js
@@ -8,11 +8,12 @@
 
   var script = document.createElement("script");
   script.async = true;
-  script.src = "https://eu-assets.i.posthog.com/static/array.js";
+  script.src = "https://u.accountant24.ai/static/array.js";
   script.onload = function () {
     if (!window.posthog) return;
     window.posthog.init(KEY, {
-      api_host: "https://eu.i.posthog.com",
+      api_host: "https://u.accountant24.ai",
+      ui_host: "https://eu.posthog.com",
       cookieless_mode: "always",
       person_profiles: "never",
       autocapture: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7142,28 +7142,28 @@
       "license": "MIT"
     },
     "node_modules/@posthog/browser-common": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.5.2.tgz",
-      "integrity": "sha512-8GvfEshFdeKIccuy3kpp6mDBxawQtRamMYRCwzy1r1ixLKQVLAGs3afhOf6r75yp59ZQBi5mtXQgUJ2Jz8eHuw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.7.2.tgz",
+      "integrity": "sha512-ukDmETXy6fTBE4ZpaO8ccscrNz5SvTaUnhQ0Ze2JX/oYILa89rrNwqUH7lDAuhFKa+NY6EoJ9kZMuOvuu4WwLQ==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/core": "^1.48.11",
-        "@posthog/types": "^1.405.3"
+        "@posthog/core": "^1.50.4",
+        "@posthog/types": "^1.408.1"
       }
     },
     "node_modules/@posthog/core": {
-      "version": "1.49.2",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.49.2.tgz",
-      "integrity": "sha512-AXHDo/4nisUg7OPG1TQNgREK7n+chBQXLQyttp7bDTDsDg2k9lV06TmnpvuNbwJs53q9mP9hjezKEZu4fYadfg==",
+      "version": "1.50.5",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.50.5.tgz",
+      "integrity": "sha512-afEchuShDaVIoxAIj76kDZQ1DhfesDmgfVp+mtTzsA3wlc8DF5uoz8YjuTjnxOicWkpP5HCDqYidK/1kT125Cg==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/types": "^1.407.1"
+        "@posthog/types": "^1.409.0"
       }
     },
     "node_modules/@posthog/types": {
-      "version": "1.407.1",
-      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.407.1.tgz",
-      "integrity": "sha512-WhbkXPC2rgylXqmxHqv70ffI3k+KxyR6s7DBIfr5NvIqHkxp6v0pk31D/jbz0DNVbzwkLjyll2pxr4FNbJiYzg==",
+      "version": "1.409.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.409.0.tgz",
+      "integrity": "sha512-239umoaZVb2GBaXeEyJpwFvjhrrChJH8NHCwiao23EBSu3NA6EN0MTMoaHSmMEf4yjiXEFFoYJA6FjJAXF5HGA==",
       "license": "MIT"
     },
     "node_modules/@preact/signals-core": {
@@ -19756,21 +19756,33 @@
       }
     },
     "node_modules/posthog-js": {
-      "version": "1.418.10",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.418.10.tgz",
-      "integrity": "sha512-XMvmmnuFoesSPjFo+wvzXkvuzYqIho8CVqxugG1Wt768offFARYNZDd1/xWfm9vk/pJTJ4RhUEHRzLpggmGx9Q==",
+      "version": "1.427.2",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.427.2.tgz",
+      "integrity": "sha512-/jRg3ChHuxcHTTJ/xb+IbpXLYxiBKIWdjrsNNqY1tAwjnFoijmz58i4mIR4A2P5MWx+4R7LlpK9vQfBr8v292g==",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
-        "@posthog/browser-common": "^0.5.0",
-        "@posthog/core": "^1.48.8",
-        "@posthog/types": "^1.405.1",
+        "@posthog/browser-common": "^0.7.2",
+        "@posthog/core": "^1.50.5",
+        "@posthog/types": "^1.409.0",
         "core-js": "^3.49.0",
         "dompurify": "^3.4.13",
         "fflate": "^0.4.8",
         "preact": "^10.29.3",
         "query-selector-shadow-dom": "^1.0.1",
-        "web-vitals": "^5.3.0",
-        "web-vitals-soft-navs": "npm:web-vitals@6.0.0"
+        "web-vitals": "^6.2.1",
+        "web-vitals-soft-navs": "npm:web-vitals@6.2.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/powershell-utils": {
@@ -23339,16 +23351,16 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
-      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.2.1.tgz",
+      "integrity": "sha512-rLcLXA2sx6+9dE88NHFubwTtGxpK4yYBLj6qHPdFoCaLr0cXGb4efOqtKLlm4loGA4OEKHIQKMKzZkKyOh5ctw==",
       "license": "Apache-2.0"
     },
     "node_modules/web-vitals-soft-navs": {
       "name": "web-vitals",
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.0.0.tgz",
-      "integrity": "sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.2.1.tgz",
+      "integrity": "sha512-rLcLXA2sx6+9dE88NHFubwTtGxpK4yYBLj6qHPdFoCaLr0cXGb4efOqtKLlm4loGA4OEKHIQKMKzZkKyOh5ctw==",
       "license": "Apache-2.0"
     },
     "node_modules/webcrypto-core": {
@@ -23839,6 +23851,9 @@
     "packages/demo": {
       "name": "@accountant24/demo",
       "version": "0.0.0",
+      "dependencies": {
+        "@fontsource/ibm-plex-mono": "5.3.0"
+      },
       "devDependencies": {
         "@astrojs/check": "0.9.10",
         "astro": "7.2.4",
@@ -23918,8 +23933,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@accountant24/demo": "*",
-        "@fontsource/ibm-plex-mono": "5.3.0",
-        "posthog-js": "1.418.10"
+        "posthog-js": "1.427.2"
       },
       "devDependencies": {
         "@astrojs/check": "0.9.10",

--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -19,7 +19,7 @@ Copy and data live in `src/content/site.ts`. Pure logic (`src/lib/`, `src/worker
 
 ## Analytics
 
-PostHog (EU) in cookieless mode: no cookies or storage, no person profiles, no recordings, no heatmaps or web vitals, so no consent banner; the client loads no script beyond its own bundle. The project token goes into `site.posthogKey` (`src/content/site.ts`) and `docs/analytics.js`; an empty token disables analytics. CTAs carry `data-track` / `data-placement` attributes and emit `download_clicked`, `github_clicked`, `docs_clicked`.
+PostHog (EU) in cookieless mode: no cookies or storage, no person profiles, no recordings, no heatmaps or web vitals, so no consent banner; the client loads no script beyond its own bundle. Events and `array.js` go through `u.accountant24.ai`, PostHog's managed reverse proxy on our own domain, so the ad blockers that filter `posthog.com` cannot drop them; `ui_host` stays the real app, which the proxy does not serve. The project token goes into `site.posthogKey` (`src/content/site.ts`) and `docs/analytics.js`; an empty token disables analytics. CTAs carry `data-track` / `data-placement` attributes and emit `download_clicked`, `github_clicked`, `docs_clicked`.
 
 ## Production
 

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@accountant24/demo": "*",
-    "posthog-js": "1.418.10"
+    "posthog-js": "1.427.2"
   },
   "devDependencies": {
     "@astrojs/check": "0.9.10",

--- a/packages/website/src/lib/__tests__/analytics.test.ts
+++ b/packages/website/src/lib/__tests__/analytics.test.ts
@@ -19,9 +19,8 @@ describe("initAnalytics()", () => {
     expect(client.init).toHaveBeenCalledWith("phc_test", analyticsOptions);
   });
 
-  it("should use cookieless mode without person profiles, recordings or autocapture against the EU host", () => {
+  it("should use cookieless mode without person profiles, recordings or autocapture", () => {
     expect(analyticsOptions).toMatchObject({
-      api_host: "https://eu.i.posthog.com",
       cookieless_mode: "always",
       person_profiles: "never",
       autocapture: false,
@@ -39,6 +38,11 @@ describe("initAnalytics()", () => {
       capture_performance: false,
       disable_surveys: true,
     });
+  });
+
+  it("should send events to our own domain so ad blockers cannot drop them, and point links at the real app", () => {
+    expect(analyticsOptions.api_host).toBe("https://u.accountant24.ai");
+    expect(analyticsOptions.ui_host).toBe("https://eu.posthog.com");
   });
 
   it("should load no script beyond its own and never ask the server what to enable", () => {
@@ -65,6 +69,7 @@ describe("initAnalytics()", () => {
         "disable_surveys",
         "person_profiles",
         "respect_dnt",
+        "ui_host",
       ].sort(),
     );
   });

--- a/packages/website/src/lib/analytics.ts
+++ b/packages/website/src/lib/analytics.ts
@@ -7,7 +7,12 @@ import posthog from "posthog-js";
 type Client = Pick<typeof posthog, "init" | "capture">;
 
 export const analyticsOptions = {
-  api_host: "https://eu.i.posthog.com",
+  // Events go to a subdomain of our own site, which PostHog's managed reverse
+  // proxy answers, so the ad blockers that filter posthog.com cannot silently
+  // drop them. `ui_host` is the real app, which the proxy does not serve: it
+  // is what PostHog's own links have to point back to.
+  api_host: "https://u.accountant24.ai",
+  ui_host: "https://eu.posthog.com",
   cookieless_mode: "always",
   person_profiles: "never",
   autocapture: false,


### PR DESCRIPTION
- Point `api_host` at the `u.accountant24.ai` managed reverse proxy in `packages/website/src/lib/analytics.ts` and `docs/analytics.js`
- Load `array.js` from the proxy in `docs/analytics.js`
- Add `ui_host` so PostHog's own links keep pointing at the app the proxy does not serve
- Update `posthog-js` to `1.427.2`
- Sync the lockfile with `@fontsource/ibm-plex-mono` moving to `packages/demo`
- Assert both hosts in the analytics tests and document the proxy in the website README