### PR TITLE
fix: serve the website sitemap at /sitemap.xml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -815,18 +815,6 @@
         "node": ">=22.12.0"
       }
     },
-    "node_modules/@astrojs/sitemap": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
-      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sitemap": "^9.0.0",
-        "stream-replace-string": "^2.0.0",
-        "zod": "^4.3.6"
-      }
-    },
     "node_modules/@astrojs/telemetry": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.3.tgz",
@@ -10431,16 +10419,6 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
     },
-    "node_modules/@types/sax": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
-      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -11099,13 +11077,6 @@
       "engines": {
         "node": ">= 4.0.0"
       }
-    },
-    "node_modules/arg": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -21461,43 +21432,6 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
-    "node_modules/sitemap": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
-      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^24.9.2",
-        "@types/sax": "^1.2.1",
-        "arg": "^5.0.0",
-        "sax": "^1.4.1"
-      },
-      "bin": {
-        "sitemap": "dist/esm/cli.js"
-      },
-      "engines": {
-        "node": ">=20.19.5",
-        "npm": ">=10.8.2"
-      }
-    },
-    "node_modules/sitemap/node_modules/@types/node": {
-      "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
-      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.18.0"
-      }
-    },
-    "node_modules/sitemap/node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/smol-toml": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
@@ -21602,13 +21536,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/stream-replace-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
-      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -23937,7 +23864,6 @@
       },
       "devDependencies": {
         "@astrojs/check": "0.9.10",
-        "@astrojs/sitemap": "3.7.3",
         "@tailwindcss/vite": "4.3.1",
         "astro": "7.2.4",
         "cookie": "2.0.1",

--- a/packages/website/astro.config.ts
+++ b/packages/website/astro.config.ts
@@ -1,4 +1,3 @@
-import sitemap from "@astrojs/sitemap";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 
@@ -33,7 +32,6 @@ export default defineConfig({
     // pages buys nothing on a site with two of them.
     inlineStylesheets: "always",
   },
-  integrations: [sitemap({ filter: (page) => !page.includes("/404") })],
   vite: {
     plugins: [tailwindcss()],
     server: { proxy: Object.fromEntries(docsPaths.map((path) => [path, docsProxy])) },

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -17,7 +17,6 @@
   },
   "devDependencies": {
     "@astrojs/check": "0.9.10",
-    "@astrojs/sitemap": "3.7.3",
     "@tailwindcss/vite": "4.3.1",
     "astro": "7.2.4",
     "cookie": "2.0.1",

--- a/packages/website/public/robots.txt
+++ b/packages/website/public/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://accountant24.ai/sitemap-index.xml
+Sitemap: https://accountant24.ai/sitemap.xml
 Sitemap: https://accountant24.ai/docs/sitemap.xml

--- a/packages/website/src/layouts/Base.astro
+++ b/packages/website/src/layouts/Base.astro
@@ -56,7 +56,7 @@ const ogImage = new URL("/og.png", site.url).href;
     <link rel="icon" href="/favicon.ico" sizes="16x16 32x32 48x48" />
     <link rel="icon" href="/favicon-dark.ico" sizes="16x16 32x32" media="(prefers-color-scheme: dark)" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="sitemap" href="/sitemap-index.xml" />
+    <link rel="sitemap" href="/sitemap.xml" />
     <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff" />
     <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0e1a1c" />
     <meta property="og:site_name" content={site.name} />

--- a/packages/website/src/lib/__tests__/sitemap.test.ts
+++ b/packages/website/src/lib/__tests__/sitemap.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { sitemapRoutes, sitemapXml } from "../sitemap";
+
+describe("sitemapRoutes()", () => {
+  it("should map the home page to the site root", () => {
+    expect(sitemapRoutes(["./index.astro"])).toEqual(["/"]);
+  });
+
+  it("should map a top-level page to an extensionless path", () => {
+    expect(sitemapRoutes(["./pricing.astro"])).toEqual(["/pricing"]);
+  });
+
+  it("should map a nested index to its directory without a trailing slash", () => {
+    expect(sitemapRoutes(["./blog/index.astro"])).toEqual(["/blog"]);
+  });
+
+  it("should map a nested page to its full path", () => {
+    expect(sitemapRoutes(["./blog/launch.astro"])).toEqual(["/blog/launch"]);
+  });
+
+  it("should leave out the 404 page", () => {
+    expect(sitemapRoutes(["./index.astro", "./404.astro"])).toEqual(["/"]);
+  });
+
+  it("should leave out the 500 page", () => {
+    expect(sitemapRoutes(["./500.astro"])).toEqual([]);
+  });
+
+  it("should leave out a status page nested in a directory", () => {
+    expect(sitemapRoutes(["./blog/404.astro"])).toEqual([]);
+  });
+
+  it("should leave out a dynamic route", () => {
+    expect(sitemapRoutes(["./blog/[slug].astro"])).toEqual([]);
+  });
+
+  it("should leave out a rest route", () => {
+    expect(sitemapRoutes(["./[...path].astro"])).toEqual([]);
+  });
+
+  it("should keep a page whose name merely contains the word index", () => {
+    expect(sitemapRoutes(["./indexing.astro"])).toEqual(["/indexing"]);
+  });
+
+  it("should sort routes so the output is stable across builds", () => {
+    expect(sitemapRoutes(["./pricing.astro", "./about.astro", "./index.astro"])).toEqual(["/", "/about", "/pricing"]);
+  });
+
+  it("should list a duplicated key once", () => {
+    expect(sitemapRoutes(["./about.astro", "./about.astro"])).toEqual(["/about"]);
+  });
+
+  it("should return no routes for no pages", () => {
+    expect(sitemapRoutes([])).toEqual([]);
+  });
+});
+
+describe("sitemapXml()", () => {
+  it("should render the home page as an absolute URL with a trailing slash", () => {
+    expect(sitemapXml(["/"], "https://accountant24.ai")).toBe(
+      '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
+        "  <url><loc>https://accountant24.ai/</loc></url>\n" +
+        "</urlset>\n",
+    );
+  });
+
+  it("should render a sub-page without a trailing slash", () => {
+    expect(sitemapXml(["/pricing"], "https://accountant24.ai")).toContain("<loc>https://accountant24.ai/pricing</loc>");
+  });
+
+  it("should render one url element per route, in the order given", () => {
+    const xml = sitemapXml(["/", "/about"], "https://accountant24.ai");
+    expect(xml.match(/<url>/g)).toHaveLength(2);
+    expect(xml.indexOf("accountant24.ai/</loc>")).toBeLessThan(xml.indexOf("/about</loc>"));
+  });
+
+  it("should escape XML metacharacters in a URL", () => {
+    expect(sitemapXml(["/a&b"], "https://accountant24.ai")).toContain("<loc>https://accountant24.ai/a&amp;b</loc>");
+  });
+
+  it("should render an empty urlset when there are no routes", () => {
+    expect(sitemapXml([], "https://accountant24.ai")).toBe(
+      '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
+        "</urlset>\n",
+    );
+  });
+
+  it("should end with a single trailing newline", () => {
+    expect(sitemapXml(["/"], "https://accountant24.ai").endsWith("</urlset>\n")).toBe(true);
+  });
+});

--- a/packages/website/src/lib/sitemap.ts
+++ b/packages/website/src/lib/sitemap.ts
@@ -1,0 +1,54 @@
+// The site's sitemap. @astrojs/sitemap only ever emits a sitemap index plus
+// numbered chunk files (it has no flat-file mode), which is ceremony for a
+// site of one page, so `/sitemap.xml` is built here: the path crawlers try
+// first. The docs are Mintlify's own sitemap under /docs, declared next to
+// this one in robots.txt.
+
+/** Pages that are served but never listed: search engines index neither. */
+const STATUS_PAGES = new Set(["404", "500"]);
+
+/**
+ * The routes to list, from `import.meta.glob` keys for src/pages ("./index.astro").
+ * Status pages are left out, and so are dynamic routes, whose params are not
+ * knowable from a file name. The rest match the canonical URLs Base.astro
+ * emits: "/" for the home page, and "/name" with no trailing slash for the
+ * others, which `build.format: "file"` serves without an extension.
+ */
+export function sitemapRoutes(globKeys: string[]): string[] {
+  const routes: string[] = [];
+  for (const key of globKeys) {
+    const name = key.replace(/^\.\//, "").replace(/\.astro$/, "");
+    if (name.includes("[")) continue;
+    const segments = name.split("/");
+    if (STATUS_PAGES.has(segments[segments.length - 1])) continue;
+    if (segments[segments.length - 1] === "index") segments.pop();
+    routes.push(`/${segments.join("/")}`);
+  }
+  return [...new Set(routes)].sort();
+}
+
+/** XML-escape a value for a text node. */
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/**
+ * `routes` as a sitemap under `siteUrl`. No changefreq or priority, which
+ * Google ignores, and no lastmod: it counts only while it stays accurate, and
+ * a date stamped on every deploy is worth less than none at all.
+ */
+export function sitemapXml(routes: string[], siteUrl: string): string {
+  const entries = routes.map((route) => `  <url><loc>${escapeXml(new URL(route, siteUrl).href)}</loc></url>`);
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...entries,
+    "</urlset>",
+    "",
+  ].join("\n");
+}

--- a/packages/website/src/pages/sitemap.xml.ts
+++ b/packages/website/src/pages/sitemap.xml.ts
@@ -1,0 +1,11 @@
+import type { APIRoute } from "astro";
+import { site } from "../content/site";
+import { sitemapRoutes, sitemapXml } from "../lib/sitemap";
+
+// Every page next to this one; only the keys are read, so no page is loaded.
+const pages = import.meta.glob("./**/*.astro");
+
+export const GET: APIRoute = () =>
+  new Response(sitemapXml(sitemapRoutes(Object.keys(pages)), site.url), {
+    headers: { "content-type": "application/xml" },
+  });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
         "packages/desktop/src/shared/**",
         "packages/desktop/src/main/template/**",
         "packages/website/src/worker/index.ts",
+        "packages/website/src/pages/sitemap.xml.ts",
       ],
       // Enforced floor — ratchets up toward 100 as gaps close; never lowered.
       // Kept just under the current effective baseline so the gate is honest


### PR DESCRIPTION
- Generate the sitemap in `src/pages/sitemap.xml.ts` from the pages in `src/pages`, replacing `@astrojs/sitemap` and its `sitemap-index.xml` plus `sitemap-0.xml` output.
- Add `src/lib/sitemap.ts` with `sitemapRoutes()` and `sitemapXml()`, covered by unit tests.
- Leave status pages and dynamic routes out of the sitemap.
- Emit `<loc>https://accountant24.ai/</loc>` for the home page, matching its canonical URL.
- Point `robots.txt` and the `<link rel="sitemap">` in `Base.astro` at `/sitemap.xml`.
- Drop the `@astrojs/sitemap` dependency and its `integrations` entry in `astro.config.ts`.
- Exclude `src/pages/sitemap.xml.ts` from coverage as an entry point.